### PR TITLE
accept custom marker symbols for plotly create_bus_trace even when colormap is given

### DIFF
--- a/pandapower/plotting/plotly/traces.py
+++ b/pandapower/plotting/plotly/traces.py
@@ -191,6 +191,7 @@ def create_bus_trace(net, buses=None, size=5, patch_type="circle", color="blue",
                                      colorbar=ColorBar(thickness=10,
                                                        x=1.0,
                                                        titleside='right'),
+                                     symbol=patch_type
                                      )
 
         if cbar_title:


### PR DESCRIPTION
Affects #140 

Currently, a custom marker for buses in plotly is only accepted if no cmap argument is given.