### PR TITLE
JSON encoding / decoding

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
          conda uninstall numba --yes;
     fi
   - conda install matplotlib --yes
+  - pip install future
   - pip install pytest pytest-cov
   - pip install codecov
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ install:
          conda uninstall numba --yes;
     fi
   - conda install matplotlib --yes
-  - pip install future
   - pip install pytest pytest-cov
   - pip install codecov
   - python setup.py install

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   # We don't actually use the Travis Python, but this keeps it organized.
   - "2.7"
   - "3.4"
-#  - "3.3"
   - "3.5"
   - "3.6"
  

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -206,15 +206,12 @@ class PPJSONDecoder(json.JSONDecoder):
     def __init__(self, *args, **kwargs):
         super(PPJSONDecoder, self).__init__(object_hook=pp_hook, *args, **kwargs)
 
-import jsonpickle
 
 def pp_hook(d):
     if '_module' in d.keys() and '_class' in d.keys():
         class_name = d.pop('_class')
         module_name = d.pop('_module')
         obj = d.pop('_object')
-        if module_name == "jsonpickle":
-            return jsonpickle.decode(obj)
 
         keys = copy.deepcopy(list(d.keys()))
         for key in keys:

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -185,13 +185,8 @@ class PPJSONEncoder(json.JSONEncoder):
         _iterencode = _make_iterencode(
                 markers, self.default, _encoder, self.indent, floatstr,
                 self.key_separator, self.item_separator, self.sort_keys,
-                self.skipkeys, _one_shot, isinstance=self.isinstance)
+                self.skipkeys, _one_shot, isinstance=isinstance_partial)
         return _iterencode(o, 0)
-
-    def isinstance(self, obj, cls):
-        if isinstance(obj, (pandapowerNet, tuple)):
-            return False
-        return isinstance(obj, cls)
 
     def default(self, o):
         try:
@@ -201,7 +196,12 @@ class PPJSONEncoder(json.JSONEncoder):
             return json.JSONEncoder.default(self, o)
         else:
             return s
-
+            
+def isinstance_partial(obj, cls):
+    if isinstance(obj, (pandapowerNet, tuple)):
+        return False
+    return isinstance(obj, cls)
+            
 class PPJSONDecoder(json.JSONDecoder):
     def __init__(self, *args, **kwargs):
         super(PPJSONDecoder, self).__init__(object_hook=pp_hook, *args, **kwargs)

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
                       "networkx",
                       "numpy",
                       "scipy"],
+    extras_require = {":python_version<'3.0'": ["future"]}
     packages=find_packages(),
     include_package_data=True,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
                       "networkx",
                       "numpy",
                       "scipy"],
-    extras_require = {":python_version<'3.0'": ["future"]}
+    extras_require = {":python_version<'3.0'": ["future"]},
     packages=find_packages(),
     include_package_data=True,
     classifiers=[


### PR DESCRIPTION
With the new to_json method, it is possible to encode pandapower nets to json using the builtin to_json methods of pandas. I have been working on not only having a function that allows to convert a single pandapower net, but to register the pandapowerNet object with the JSON handler, so that it can convert any data structure that contains a pandapower net like this:

```
d = {"a": net, "b": [1,2,3]}
json_string = json.dumps(d, cls=PPJSONEncoder)
d = json.loads(json_string, cls=PPJSONDecoder)
````

In addition, I have registered sets, tuples and frozensets with the PPJSONEncoder/PPJSONDecoder so that they can be safely encoded and decoded. I have implemented a [workaround](https://github.com/lthurner/pandapower/blob/1c2df09a5a533fb8e8f9463e6dffaf02f5d4d5e3/pandapower/io_utils.py#L191-L194) for this in PPJSONEncoder, where tuples are not recognized as tuples by the encoder and therefore passed on to the to_serialiazable function. This works when a tuple is passed directly to the PPJSONEncoder. However, the to_json function of Series/DatFrame does use the standard encoder, which does not have this workaround. Therefore, a tuple inside of a DataFrame is not properly encoded so that it can be restored as tuple, and gets converted to a list. This is relevant for line_geodata, which is saved in net.line_geodata.coords as:

```
[(x1, y1), (x2, y2), ..]
```
and after going through encoding/decoding in JSON comes out as:
```
[[x1, y1], [x2, y2], ..]
```
I have added an [xfailing test](https://github.com/lthurner/pandapower/blob/1c2df09a5a533fb8e8f9463e6dffaf02f5d4d5e3/pandapower/test/api/test_file_io.py#L146-L152) that reproduces this problem. 

I currently don't see how we can resolve this besides not using the standard pandas to_json method. The question is if this really relevant, because I don't see why the (x1, y1) has to be a tuple and not a list, but its still not ideal.