### PR TITLE
Iwamoto 11-bus testcase

### DIFF
--- a/pandapower/networks/power_system_test_case_jsons/case11_iwamoto.json
+++ b/pandapower/networks/power_system_test_case_jsons/case11_iwamoto.json
@@ -1,0 +1,1260 @@
+{"bus":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"vn_kv\",\"type\",\"zone\",\"in_service\"],\"index\":[0,1,2,3,4,5,6,7,8,9,10],\"data\":[[1,1.0,\"b\",null,true],[2,1.0,\"b\",null,true],[3,1.0,\"b\",null,true],[4,1.0,\"b\",null,true],[5,1.0,\"b\",null,true],[6,1.0,\"b\",null,true],[7,1.0,\"b\",null,true],[8,1.0,\"b\",null,true],[9,1.0,\"b\",null,true],[10,1.0,\"b\",null,true],[11,1.0,\"b\",null,true]]}",
+    "dtype": {
+        "name": "object",
+        "vn_kv": "float64",
+        "type": "object",
+        "zone": "object",
+        "in_service": "bool"
+    },
+    "orient": "split"
+},"bus_geodata":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"x\",\"y\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "x": "float64",
+        "y": "float64"
+    },
+    "orient": "split"
+},"converged":false,"dcline":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"from_bus\",\"to_bus\",\"p_kw\",\"loss_percent\",\"loss_kw\",\"vm_from_pu\",\"vm_to_pu\",\"max_p_kw\",\"min_q_from_kvar\",\"min_q_to_kvar\",\"max_q_from_kvar\",\"max_q_to_kvar\",\"in_service\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "name": "object",
+        "from_bus": "uint32",
+        "to_bus": "uint32",
+        "p_kw": "float64",
+        "loss_percent": "float64",
+        "loss_kw": "float64",
+        "vm_from_pu": "float64",
+        "vm_to_pu": "float64",
+        "max_p_kw": "float64",
+        "min_q_from_kvar": "float64",
+        "min_q_to_kvar": "float64",
+        "max_q_from_kvar": "float64",
+        "max_q_to_kvar": "float64",
+        "in_service": "bool"
+    },
+    "orient": "split"
+},"ext_grid":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"bus\",\"vm_pu\",\"va_degree\",\"in_service\"],\"index\":[0],\"data\":[[1,0,1.024,0.0,true]]}",
+    "dtype": {
+        "name": "object",
+        "bus": "uint32",
+        "vm_pu": "float64",
+        "va_degree": "float64",
+        "in_service": "bool"
+    },
+    "orient": "split"
+},"f_hz":50.0,"gen":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"bus\",\"p_kw\",\"vm_pu\",\"sn_kva\",\"min_q_kvar\",\"max_q_kvar\",\"scaling\",\"in_service\",\"type\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "name": "object",
+        "bus": "uint32",
+        "p_kw": "float64",
+        "vm_pu": "float64",
+        "sn_kva": "float64",
+        "min_q_kvar": "float64",
+        "max_q_kvar": "float64",
+        "scaling": "float64",
+        "in_service": "bool",
+        "type": "object"
+    },
+    "orient": "split"
+},"impedance":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"from_bus\",\"to_bus\",\"rft_pu\",\"xft_pu\",\"rtf_pu\",\"xtf_pu\",\"sn_kva\",\"in_service\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "name": "object",
+        "from_bus": "uint32",
+        "to_bus": "uint32",
+        "rft_pu": "float64",
+        "xft_pu": "float64",
+        "rtf_pu": "float64",
+        "xtf_pu": "float64",
+        "sn_kva": "float64",
+        "in_service": "bool"
+    },
+    "orient": "split"
+},"line":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"std_type\",\"from_bus\",\"to_bus\",\"length_km\",\"r_ohm_per_km\",\"x_ohm_per_km\",\"c_nf_per_km\",\"g_us_per_km\",\"max_i_ka\",\"df\",\"parallel\",\"type\",\"in_service\"],\"index\":[0,1,2,3,4,5,6,7,8,9,10],\"data\":[[\"1-2\",null,0,1,1.0,0.0,0.0706814,0.0,0.0,null,1.0,1,null,true],[\"2-3\",null,1,2,1.0,0.0,0.153988,0.0,0.0,null,1.0,1,null,true],[\"2-4\",null,1,3,1.0,0.0377316,0.0413197,0.0,0.0,null,1.0,1,null,true],[\"3-5\",null,2,4,1.0,0.122799,0.180273,0.0,0.0,null,1.0,1,null,true],[\"4-5\",null,3,4,1.0,0.0,0.459348,0.0,0.0,null,1.0,1,null,true],[\"4-6\",null,3,5,1.0,0.0,0.0176401,0.0,0.0,null,1.0,1,null,true],[\"4-7\",null,3,6,1.0,0.611406,0.811765,0.0,0.0,null,1.0,1,null,true],[\"7-8\",null,6,7,1.0,0.162088,0.216728,0.0,0.0,null,1.0,1,null,true],[\"8-9\",null,7,8,1.0,0.0718494,0.717973,0.0,0.0,null,1.0,1,null,true],[\"8-10\",null,7,9,1.0,0.409771,0.560004,0.0,0.0,null,1.0,1,null,true],[\"10-11\",null,9,10,1.0,0.0264452,0.264594,0.0,0.0,null,1.0,1,null,true]]}",
+    "dtype": {
+        "name": "object",
+        "std_type": "object",
+        "from_bus": "uint32",
+        "to_bus": "uint32",
+        "length_km": "float64",
+        "r_ohm_per_km": "float64",
+        "x_ohm_per_km": "float64",
+        "c_nf_per_km": "float64",
+        "g_us_per_km": "float64",
+        "max_i_ka": "float64",
+        "df": "float64",
+        "parallel": "uint32",
+        "type": "object",
+        "in_service": "bool"
+    },
+    "orient": "split"
+},"line_geodata":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"coords\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "coords": "object"
+    },
+    "orient": "split"
+},"load":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"bus\",\"p_kw\",\"q_kvar\",\"const_z_percent\",\"const_i_percent\",\"sn_kva\",\"scaling\",\"in_service\",\"type\"],\"index\":[0,1,2,3,4],\"data\":[[3,2,128.0,62.0,0.0,0.0,null,1.0,true,null],[5,4,165.0,80.0,0.0,0.0,null,1.0,true,null],[6,5,90.0,68.0,0.0,0.0,null,1.0,true,null],[9,8,26.0,9.0,0.0,0.0,null,1.0,true,null],[11,10,158.0,57.0,0.0,0.0,null,1.0,true,null]]}",
+    "dtype": {
+        "name": "object",
+        "bus": "uint32",
+        "p_kw": "float64",
+        "q_kvar": "float64",
+        "const_z_percent": "float64",
+        "const_i_percent": "float64",
+        "sn_kva": "float64",
+        "scaling": "float64",
+        "in_service": "bool",
+        "type": "object"
+    },
+    "orient": "split"
+},"measurement":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"type\",\"element_type\",\"value\",\"std_dev\",\"bus\",\"element\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "name": "object",
+        "type": "object",
+        "element_type": "object",
+        "value": "float64",
+        "std_dev": "float64",
+        "bus": "uint32",
+        "element": "object"
+    },
+    "orient": "split"
+},"name":"case11_iwamoto","piecewise_linear_cost":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"type\",\"element\",\"element_type\",\"p\",\"f\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "type": "object",
+        "element": "object",
+        "element_type": "object",
+        "p": "object",
+        "f": "object"
+    },
+    "orient": "split"
+},"polynomial_cost":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"type\",\"element\",\"element_type\",\"c\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "type": "object",
+        "element": "object",
+        "element_type": "object",
+        "c": "object"
+    },
+    "orient": "split"
+},"res_bus":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"vm_pu\",\"va_degree\",\"p_kw\",\"q_kvar\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "vm_pu": "float64",
+        "va_degree": "float64",
+        "p_kw": "float64",
+        "q_kvar": "float64"
+    },
+    "orient": "split"
+},"res_dcline":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"p_from_kw\",\"q_from_kvar\",\"p_to_kw\",\"q_to_kvar\",\"pl_kw\",\"vm_from_pu\",\"va_from_degree\",\"vm_to_pu\",\"va_to_degree\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "p_from_kw": "float64",
+        "q_from_kvar": "float64",
+        "p_to_kw": "float64",
+        "q_to_kvar": "float64",
+        "pl_kw": "float64",
+        "vm_from_pu": "float64",
+        "va_from_degree": "float64",
+        "vm_to_pu": "float64",
+        "va_to_degree": "float64"
+    },
+    "orient": "split"
+},"res_ext_grid":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"p_kw\",\"q_kvar\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "p_kw": "float64",
+        "q_kvar": "float64"
+    },
+    "orient": "split"
+},"res_gen":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"p_kw\",\"q_kvar\",\"va_degree\",\"vm_pu\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "p_kw": "float64",
+        "q_kvar": "float64",
+        "va_degree": "float64",
+        "vm_pu": "float64"
+    },
+    "orient": "split"
+},"res_impedance":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"p_from_kw\",\"q_from_kvar\",\"p_to_kw\",\"q_to_kvar\",\"pl_kw\",\"ql_kvar\",\"i_from_ka\",\"i_to_ka\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "p_from_kw": "float64",
+        "q_from_kvar": "float64",
+        "p_to_kw": "float64",
+        "q_to_kvar": "float64",
+        "pl_kw": "float64",
+        "ql_kvar": "float64",
+        "i_from_ka": "float64",
+        "i_to_ka": "float64"
+    },
+    "orient": "split"
+},"res_line":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"p_from_kw\",\"q_from_kvar\",\"p_to_kw\",\"q_to_kvar\",\"pl_kw\",\"ql_kvar\",\"i_from_ka\",\"i_to_ka\",\"i_ka\",\"loading_percent\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "p_from_kw": "float64",
+        "q_from_kvar": "float64",
+        "p_to_kw": "float64",
+        "q_to_kvar": "float64",
+        "pl_kw": "float64",
+        "ql_kvar": "float64",
+        "i_from_ka": "float64",
+        "i_to_ka": "float64",
+        "i_ka": "float64",
+        "loading_percent": "float64"
+    },
+    "orient": "split"
+},"res_load":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"p_kw\",\"q_kvar\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "p_kw": "float64",
+        "q_kvar": "float64"
+    },
+    "orient": "split"
+},"res_sgen":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"p_kw\",\"q_kvar\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "p_kw": "float64",
+        "q_kvar": "float64"
+    },
+    "orient": "split"
+},"res_shunt":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"p_kw\",\"q_kvar\",\"vm_pu\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "p_kw": "float64",
+        "q_kvar": "float64",
+        "vm_pu": "float64"
+    },
+    "orient": "split"
+},"res_storage":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"p_kw\",\"q_kvar\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "p_kw": "float64",
+        "q_kvar": "float64"
+    },
+    "orient": "split"
+},"res_trafo":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"p_hv_kw\",\"q_hv_kvar\",\"p_lv_kw\",\"q_lv_kvar\",\"pl_kw\",\"ql_kvar\",\"i_hv_ka\",\"i_lv_ka\",\"loading_percent\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "p_hv_kw": "float64",
+        "q_hv_kvar": "float64",
+        "p_lv_kw": "float64",
+        "q_lv_kvar": "float64",
+        "pl_kw": "float64",
+        "ql_kvar": "float64",
+        "i_hv_ka": "float64",
+        "i_lv_ka": "float64",
+        "loading_percent": "float64"
+    },
+    "orient": "split"
+},"res_trafo3w":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"p_hv_kw\",\"q_hv_kvar\",\"p_mv_kw\",\"q_mv_kvar\",\"p_lv_kw\",\"q_lv_kvar\",\"pl_kw\",\"ql_kvar\",\"i_hv_ka\",\"i_mv_ka\",\"i_lv_ka\",\"loading_percent\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "p_hv_kw": "float64",
+        "q_hv_kvar": "float64",
+        "p_mv_kw": "float64",
+        "q_mv_kvar": "float64",
+        "p_lv_kw": "float64",
+        "q_lv_kvar": "float64",
+        "pl_kw": "float64",
+        "ql_kvar": "float64",
+        "i_hv_ka": "float64",
+        "i_mv_ka": "float64",
+        "i_lv_ka": "float64",
+        "loading_percent": "float64"
+    },
+    "orient": "split"
+},"res_ward":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"p_kw\",\"q_kvar\",\"vm_pu\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "p_kw": "float64",
+        "q_kvar": "float64",
+        "vm_pu": "float64"
+    },
+    "orient": "split"
+},"res_xward":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"p_kw\",\"q_kvar\",\"vm_pu\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "p_kw": "float64",
+        "q_kvar": "float64",
+        "vm_pu": "float64"
+    },
+    "orient": "split"
+},"sgen":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"bus\",\"p_kw\",\"q_kvar\",\"sn_kva\",\"scaling\",\"in_service\",\"type\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "name": "object",
+        "bus": "int64",
+        "p_kw": "float64",
+        "q_kvar": "float64",
+        "sn_kva": "float64",
+        "scaling": "float64",
+        "in_service": "bool",
+        "type": "object"
+    },
+    "orient": "split"
+},"shunt":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"bus\",\"name\",\"q_kvar\",\"p_kw\",\"vn_kv\",\"step\",\"max_step\",\"in_service\"],\"index\":[0,1,2,3,4,5,6,7,8,9,10],\"data\":[[0,1,791.0,0.0,1.0,1,1,true],[1,2,-750.0,0.0,1.0,1,1,true],[2,3,-1.0,0.0,1.0,1,1,true],[3,4,1232.0,-1.0,1.0,1,1,true],[4,5,-77.0,0.0,1.0,1,1,true],[5,6,-1133.0,0.0,1.0,1,1,true],[6,7,559.0,421.0,1.0,1,1,true],[7,8,-33.0,-309.0,1.0,1,1,true],[8,9,-337.0,-34.0,1.0,1,1,true],[9,10,1205.0,121.0,1.0,1,1,true],[10,11,-957.0,-91.0,1.0,1,1,true]]}",
+    "dtype": {
+        "bus": "uint32",
+        "name": "object",
+        "q_kvar": "float64",
+        "p_kw": "float64",
+        "vn_kv": "float64",
+        "step": "uint32",
+        "max_step": "uint32",
+        "in_service": "bool"
+    },
+    "orient": "split"
+},"sn_kva":1000.0,"std_types":{
+    "line": {
+        "NAYY 4x50 SE": {
+            "c_nf_per_km": 210,
+            "r_ohm_per_km": 0.642,
+            "x_ohm_per_km": 0.083,
+            "max_i_ka": 0.142,
+            "type": "cs",
+            "q_mm2": 50
+        },
+        "NAYY 4x120 SE": {
+            "c_nf_per_km": 264,
+            "r_ohm_per_km": 0.225,
+            "x_ohm_per_km": 0.08,
+            "max_i_ka": 0.242,
+            "type": "cs",
+            "q_mm2": 120
+        },
+        "NAYY 4x150 SE": {
+            "c_nf_per_km": 261,
+            "r_ohm_per_km": 0.208,
+            "x_ohm_per_km": 0.08,
+            "max_i_ka": 0.27,
+            "type": "cs",
+            "q_mm2": 150
+        },
+        "NA2XS2Y 1x95 RM/25 12/20 kV": {
+            "c_nf_per_km": 216,
+            "r_ohm_per_km": 0.313,
+            "x_ohm_per_km": 0.132,
+            "max_i_ka": 0.252,
+            "type": "cs",
+            "q_mm2": 95
+        },
+        "NA2XS2Y 1x185 RM/25 12/20 kV": {
+            "c_nf_per_km": 273,
+            "r_ohm_per_km": 0.161,
+            "x_ohm_per_km": 0.117,
+            "max_i_ka": 0.362,
+            "type": "cs",
+            "q_mm2": 185
+        },
+        "NA2XS2Y 1x240 RM/25 12/20 kV": {
+            "c_nf_per_km": 304,
+            "r_ohm_per_km": 0.122,
+            "x_ohm_per_km": 0.112,
+            "max_i_ka": 0.421,
+            "type": "cs",
+            "q_mm2": 240
+        },
+        "NA2XS2Y 1x95 RM/25 6/10 kV": {
+            "c_nf_per_km": 315,
+            "r_ohm_per_km": 0.313,
+            "x_ohm_per_km": 0.123,
+            "max_i_ka": 0.249,
+            "type": "cs",
+            "q_mm2": 95
+        },
+        "NA2XS2Y 1x185 RM/25 6/10 kV": {
+            "c_nf_per_km": 406,
+            "r_ohm_per_km": 0.161,
+            "x_ohm_per_km": 0.11,
+            "max_i_ka": 0.358,
+            "type": "cs",
+            "q_mm2": 185
+        },
+        "NA2XS2Y 1x240 RM/25 6/10 kV": {
+            "c_nf_per_km": 456,
+            "r_ohm_per_km": 0.122,
+            "x_ohm_per_km": 0.105,
+            "max_i_ka": 0.416,
+            "type": "cs",
+            "q_mm2": 240
+        },
+        "NA2XS2Y 1x150 RM/25 12/20 kV": {
+            "c_nf_per_km": 250,
+            "r_ohm_per_km": 0.206,
+            "x_ohm_per_km": 0.116,
+            "max_i_ka": 0.319,
+            "type": "cs",
+            "q_mm2": 150
+        },
+        "NA2XS2Y 1x120 RM/25 12/20 kV": {
+            "c_nf_per_km": 230,
+            "r_ohm_per_km": 0.253,
+            "x_ohm_per_km": 0.119,
+            "max_i_ka": 0.283,
+            "type": "cs",
+            "q_mm2": 120
+        },
+        "NA2XS2Y 1x70 RM/25 12/20 kV": {
+            "c_nf_per_km": 190,
+            "r_ohm_per_km": 0.443,
+            "x_ohm_per_km": 0.132,
+            "max_i_ka": 0.22,
+            "type": "cs",
+            "q_mm2": 70
+        },
+        "NA2XS2Y 1x150 RM/25 6/10 kV": {
+            "c_nf_per_km": 360,
+            "r_ohm_per_km": 0.206,
+            "x_ohm_per_km": 0.11,
+            "max_i_ka": 0.315,
+            "type": "cs",
+            "q_mm2": 150
+        },
+        "NA2XS2Y 1x120 RM/25 6/10 kV": {
+            "c_nf_per_km": 340,
+            "r_ohm_per_km": 0.253,
+            "x_ohm_per_km": 0.113,
+            "max_i_ka": 0.28,
+            "type": "cs",
+            "q_mm2": 120
+        },
+        "NA2XS2Y 1x70 RM/25 6/10 kV": {
+            "c_nf_per_km": 280,
+            "r_ohm_per_km": 0.443,
+            "x_ohm_per_km": 0.123,
+            "max_i_ka": 0.217,
+            "type": "cs",
+            "q_mm2": 70
+        },
+        "N2XS(FL)2Y 1x120 RM/35 64/110 kV": {
+            "c_nf_per_km": 112,
+            "r_ohm_per_km": 0.153,
+            "x_ohm_per_km": 0.166,
+            "max_i_ka": 0.366,
+            "type": "cs",
+            "q_mm2": 120
+        },
+        "N2XS(FL)2Y 1x185 RM/35 64/110 kV": {
+            "c_nf_per_km": 125,
+            "r_ohm_per_km": 0.099,
+            "x_ohm_per_km": 0.156,
+            "max_i_ka": 0.457,
+            "type": "cs",
+            "q_mm2": 185
+        },
+        "N2XS(FL)2Y 1x240 RM/35 64/110 kV": {
+            "c_nf_per_km": 135,
+            "r_ohm_per_km": 0.075,
+            "x_ohm_per_km": 0.149,
+            "max_i_ka": 0.526,
+            "type": "cs",
+            "q_mm2": 240
+        },
+        "N2XS(FL)2Y 1x300 RM/35 64/110 kV": {
+            "c_nf_per_km": 144,
+            "r_ohm_per_km": 0.06,
+            "x_ohm_per_km": 0.144,
+            "max_i_ka": 0.588,
+            "type": "cs",
+            "q_mm2": 300
+        },
+        "15-AL1/3-ST1A 0.4": {
+            "c_nf_per_km": 11,
+            "r_ohm_per_km": 1.8769,
+            "x_ohm_per_km": 0.35,
+            "max_i_ka": 0.105,
+            "type": "ol",
+            "q_mm2": 16
+        },
+        "24-AL1/4-ST1A 0.4": {
+            "c_nf_per_km": 11.25,
+            "r_ohm_per_km": 1.2012,
+            "x_ohm_per_km": 0.335,
+            "max_i_ka": 0.14,
+            "type": "ol",
+            "q_mm2": 24
+        },
+        "48-AL1/8-ST1A 0.4": {
+            "c_nf_per_km": 12.2,
+            "r_ohm_per_km": 0.5939,
+            "x_ohm_per_km": 0.3,
+            "max_i_ka": 0.21,
+            "type": "ol",
+            "q_mm2": 48
+        },
+        "94-AL1/15-ST1A 0.4": {
+            "c_nf_per_km": 13.2,
+            "r_ohm_per_km": 0.306,
+            "x_ohm_per_km": 0.29,
+            "max_i_ka": 0.35,
+            "type": "ol",
+            "q_mm2": 94
+        },
+        "34-AL1/6-ST1A 10.0": {
+            "c_nf_per_km": 9.7,
+            "r_ohm_per_km": 0.8342,
+            "x_ohm_per_km": 0.36,
+            "max_i_ka": 0.17,
+            "type": "ol",
+            "q_mm2": 34
+        },
+        "48-AL1/8-ST1A 10.0": {
+            "c_nf_per_km": 10.1,
+            "r_ohm_per_km": 0.5939,
+            "x_ohm_per_km": 0.35,
+            "max_i_ka": 0.21,
+            "type": "ol",
+            "q_mm2": 48
+        },
+        "70-AL1/11-ST1A 10.0": {
+            "c_nf_per_km": 10.4,
+            "r_ohm_per_km": 0.4132,
+            "x_ohm_per_km": 0.339,
+            "max_i_ka": 0.29,
+            "type": "ol",
+            "q_mm2": 70
+        },
+        "94-AL1/15-ST1A 10.0": {
+            "c_nf_per_km": 10.75,
+            "r_ohm_per_km": 0.306,
+            "x_ohm_per_km": 0.33,
+            "max_i_ka": 0.35,
+            "type": "ol",
+            "q_mm2": 94
+        },
+        "122-AL1/20-ST1A 10.0": {
+            "c_nf_per_km": 11.1,
+            "r_ohm_per_km": 0.2376,
+            "x_ohm_per_km": 0.323,
+            "max_i_ka": 0.41,
+            "type": "ol",
+            "q_mm2": 122
+        },
+        "149-AL1/24-ST1A 10.0": {
+            "c_nf_per_km": 11.25,
+            "r_ohm_per_km": 0.194,
+            "x_ohm_per_km": 0.315,
+            "max_i_ka": 0.47,
+            "type": "ol",
+            "q_mm2": 149
+        },
+        "34-AL1/6-ST1A 20.0": {
+            "c_nf_per_km": 9.15,
+            "r_ohm_per_km": 0.8342,
+            "x_ohm_per_km": 0.382,
+            "max_i_ka": 0.17,
+            "type": "ol",
+            "q_mm2": 34
+        },
+        "48-AL1/8-ST1A 20.0": {
+            "c_nf_per_km": 9.5,
+            "r_ohm_per_km": 0.5939,
+            "x_ohm_per_km": 0.372,
+            "max_i_ka": 0.21,
+            "type": "ol",
+            "q_mm2": 48
+        },
+        "70-AL1/11-ST1A 20.0": {
+            "c_nf_per_km": 9.7,
+            "r_ohm_per_km": 0.4132,
+            "x_ohm_per_km": 0.36,
+            "max_i_ka": 0.29,
+            "type": "ol",
+            "q_mm2": 70
+        },
+        "94-AL1/15-ST1A 20.0": {
+            "c_nf_per_km": 10,
+            "r_ohm_per_km": 0.306,
+            "x_ohm_per_km": 0.35,
+            "max_i_ka": 0.35,
+            "type": "ol",
+            "q_mm2": 94
+        },
+        "122-AL1/20-ST1A 20.0": {
+            "c_nf_per_km": 10.3,
+            "r_ohm_per_km": 0.2376,
+            "x_ohm_per_km": 0.344,
+            "max_i_ka": 0.41,
+            "type": "ol",
+            "q_mm2": 122
+        },
+        "149-AL1/24-ST1A 20.0": {
+            "c_nf_per_km": 10.5,
+            "r_ohm_per_km": 0.194,
+            "x_ohm_per_km": 0.337,
+            "max_i_ka": 0.47,
+            "type": "ol",
+            "q_mm2": 149
+        },
+        "184-AL1/30-ST1A 20.0": {
+            "c_nf_per_km": 10.75,
+            "r_ohm_per_km": 0.1571,
+            "x_ohm_per_km": 0.33,
+            "max_i_ka": 0.535,
+            "type": "ol",
+            "q_mm2": 184
+        },
+        "243-AL1/39-ST1A 20.0": {
+            "c_nf_per_km": 11,
+            "r_ohm_per_km": 0.1188,
+            "x_ohm_per_km": 0.32,
+            "max_i_ka": 0.645,
+            "type": "ol",
+            "q_mm2": 243
+        },
+        "149-AL1/24-ST1A 110.0": {
+            "c_nf_per_km": 8.75,
+            "r_ohm_per_km": 0.194,
+            "x_ohm_per_km": 0.41,
+            "max_i_ka": 0.47,
+            "type": "ol",
+            "q_mm2": 149
+        },
+        "184-AL1/30-ST1A 110.0": {
+            "c_nf_per_km": 8.8,
+            "r_ohm_per_km": 0.1571,
+            "x_ohm_per_km": 0.4,
+            "max_i_ka": 0.535,
+            "type": "ol",
+            "q_mm2": 184
+        },
+        "243-AL1/39-ST1A 110.0": {
+            "c_nf_per_km": 9,
+            "r_ohm_per_km": 0.1188,
+            "x_ohm_per_km": 0.39,
+            "max_i_ka": 0.645,
+            "type": "ol",
+            "q_mm2": 243
+        },
+        "305-AL1/39-ST1A 110.0": {
+            "c_nf_per_km": 9.2,
+            "r_ohm_per_km": 0.0949,
+            "x_ohm_per_km": 0.38,
+            "max_i_ka": 0.74,
+            "type": "ol",
+            "q_mm2": 305
+        },
+        "490-AL1/64-ST1A 220.0": {
+            "c_nf_per_km": 10,
+            "r_ohm_per_km": 0.059,
+            "x_ohm_per_km": 0.285,
+            "max_i_ka": 0.96,
+            "type": "ol",
+            "q_mm2": 490
+        },
+        "490-AL1/64-ST1A 380.0": {
+            "c_nf_per_km": 11,
+            "r_ohm_per_km": 0.059,
+            "x_ohm_per_km": 0.253,
+            "max_i_ka": 0.96,
+            "type": "ol",
+            "q_mm2": 490
+        }
+    },
+    "trafo": {
+        "160 MVA 380/110 kV": {
+            "i0_percent": 0.06,
+            "pfe_kw": 60,
+            "vscr_percent": 0.25,
+            "sn_kva": 160000.0,
+            "vn_lv_kv": 110.0,
+            "vn_hv_kv": 380.0,
+            "vsc_percent": 12.2,
+            "shift_degree": 0,
+            "vector_group": "Yy0",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "100 MVA 220/110 kV": {
+            "i0_percent": 0.06,
+            "pfe_kw": 55,
+            "vscr_percent": 0.26,
+            "sn_kva": 100000.0,
+            "vn_lv_kv": 110.0,
+            "vn_hv_kv": 220.0,
+            "vsc_percent": 12.0,
+            "shift_degree": 0,
+            "vector_group": "Yy0",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "63 MVA 110/20 kV": {
+            "i0_percent": 0.04,
+            "pfe_kw": 22,
+            "vscr_percent": 0.32,
+            "sn_kva": 63000,
+            "vn_lv_kv": 20.0,
+            "vn_hv_kv": 110.0,
+            "vsc_percent": 18,
+            "shift_degree": 150,
+            "vector_group": "YNd5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "40 MVA 110/20 kV": {
+            "i0_percent": 0.05,
+            "pfe_kw": 18,
+            "vscr_percent": 0.34,
+            "sn_kva": 40000,
+            "vn_lv_kv": 20.0,
+            "vn_hv_kv": 110.0,
+            "vsc_percent": 16.2,
+            "shift_degree": 150,
+            "vector_group": "YNd5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "25 MVA 110/20 kV": {
+            "i0_percent": 0.07,
+            "pfe_kw": 14,
+            "vscr_percent": 0.41,
+            "sn_kva": 25000,
+            "vn_lv_kv": 20.0,
+            "vn_hv_kv": 110.0,
+            "vsc_percent": 12,
+            "shift_degree": 150,
+            "vector_group": "YNd5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "63 MVA 110/10 kV": {
+            "sn_kva": 63000,
+            "vn_hv_kv": 110,
+            "vn_lv_kv": 10,
+            "vsc_percent": 18,
+            "vscr_percent": 0.32,
+            "pfe_kw": 22,
+            "i0_percent": 0.04,
+            "shift_degree": 150,
+            "vector_group": "YNd5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "40 MVA 110/10 kV": {
+            "sn_kva": 40000,
+            "vn_hv_kv": 110,
+            "vn_lv_kv": 10,
+            "vsc_percent": 16.2,
+            "vscr_percent": 0.34,
+            "pfe_kw": 18,
+            "i0_percent": 0.05,
+            "shift_degree": 150,
+            "vector_group": "YNd5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "25 MVA 110/10 kV": {
+            "sn_kva": 25000,
+            "vn_hv_kv": 110,
+            "vn_lv_kv": 10,
+            "vsc_percent": 12,
+            "vscr_percent": 0.41,
+            "pfe_kw": 14,
+            "i0_percent": 0.07,
+            "shift_degree": 150,
+            "vector_group": "YNd5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "63 MVA 110/20 kV v1.4.3 and older": {
+            "i0_percent": 0.086,
+            "pfe_kw": 33,
+            "vscr_percent": 0.322,
+            "sn_kva": 63000,
+            "vn_lv_kv": 20.0,
+            "vn_hv_kv": 110.0,
+            "vsc_percent": 11.2,
+            "shift_degree": 150,
+            "vector_group": "YNd5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "40 MVA 110/20 kV v1.4.3 and older": {
+            "i0_percent": 0.08,
+            "pfe_kw": 31,
+            "vscr_percent": 0.302,
+            "sn_kva": 40000,
+            "vn_lv_kv": 20.0,
+            "vn_hv_kv": 110.0,
+            "vsc_percent": 11.2,
+            "shift_degree": 150,
+            "vector_group": "YNd5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "25 MVA 110/20 kV v1.4.3 and older": {
+            "i0_percent": 0.071,
+            "pfe_kw": 29,
+            "vscr_percent": 0.282,
+            "sn_kva": 25000,
+            "vn_lv_kv": 20.0,
+            "vn_hv_kv": 110.0,
+            "vsc_percent": 11.2,
+            "shift_degree": 150,
+            "vector_group": "YNd5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "63 MVA 110/10 kV v1.4.3 and older": {
+            "sn_kva": 63000,
+            "vn_hv_kv": 110,
+            "vn_lv_kv": 10,
+            "vsc_percent": 10.04,
+            "vscr_percent": 0.31,
+            "pfe_kw": 31.51,
+            "i0_percent": 0.078,
+            "shift_degree": 150,
+            "vector_group": "YNd5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "40 MVA 110/10 kV v1.4.3 and older": {
+            "sn_kva": 40000,
+            "vn_hv_kv": 110,
+            "vn_lv_kv": 10,
+            "vsc_percent": 10.04,
+            "vscr_percent": 0.295,
+            "pfe_kw": 30.45,
+            "i0_percent": 0.076,
+            "shift_degree": 150,
+            "vector_group": "YNd5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "25 MVA 110/10 kV v1.4.3 and older": {
+            "sn_kva": 25000,
+            "vn_hv_kv": 110,
+            "vn_lv_kv": 10,
+            "vsc_percent": 10.04,
+            "vscr_percent": 0.276,
+            "pfe_kw": 28.51,
+            "i0_percent": 0.073,
+            "shift_degree": 150,
+            "vector_group": "YNd5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -9,
+            "tp_max": 9,
+            "tp_st_degree": 0,
+            "tp_st_percent": 1.5,
+            "tp_phase_shifter": false
+        },
+        "0.25 MVA 20/0.4 kV": {
+            "sn_kva": 250,
+            "vn_hv_kv": 20,
+            "vn_lv_kv": 0.4,
+            "vsc_percent": 6,
+            "vscr_percent": 1.44,
+            "pfe_kw": 0.8,
+            "i0_percent": 0.32,
+            "shift_degree": 150,
+            "vector_group": "Yzn5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -2,
+            "tp_max": 2,
+            "tp_st_degree": 0,
+            "tp_st_percent": 2.5,
+            "tp_phase_shifter": false
+        },
+        "0.4 MVA 20/0.4 kV": {
+            "sn_kva": 400,
+            "vn_hv_kv": 20,
+            "vn_lv_kv": 0.4,
+            "vsc_percent": 6,
+            "vscr_percent": 1.425,
+            "pfe_kw": 1.35,
+            "i0_percent": 0.3375,
+            "shift_degree": 150,
+            "vector_group": "Dyn5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -2,
+            "tp_max": 2,
+            "tp_st_degree": 0,
+            "tp_st_percent": 2.5,
+            "tp_phase_shifter": false
+        },
+        "0.63 MVA 20/0.4 kV": {
+            "sn_kva": 630,
+            "vn_hv_kv": 20,
+            "vn_lv_kv": 0.4,
+            "vsc_percent": 6,
+            "vscr_percent": 1.206,
+            "pfe_kw": 1.65,
+            "i0_percent": 0.2619,
+            "shift_degree": 150,
+            "vector_group": "Dyn5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -2,
+            "tp_max": 2,
+            "tp_st_degree": 0,
+            "tp_st_percent": 2.5,
+            "tp_phase_shifter": false
+        },
+        "0.25 MVA 10/0.4 kV": {
+            "sn_kva": 250,
+            "vn_hv_kv": 10,
+            "vn_lv_kv": 0.4,
+            "vsc_percent": 4,
+            "vscr_percent": 1.2,
+            "pfe_kw": 0.6,
+            "i0_percent": 0.24,
+            "shift_degree": 150,
+            "vector_group": "Dyn5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -2,
+            "tp_max": 2,
+            "tp_st_degree": 0,
+            "tp_st_percent": 2.5,
+            "tp_phase_shifter": false
+        },
+        "0.4 MVA 10/0.4 kV": {
+            "sn_kva": 400,
+            "vn_hv_kv": 10,
+            "vn_lv_kv": 0.4,
+            "vsc_percent": 4,
+            "vscr_percent": 1.325,
+            "pfe_kw": 0.95,
+            "i0_percent": 0.2375,
+            "shift_degree": 150,
+            "vector_group": "Dyn5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -2,
+            "tp_max": 2,
+            "tp_st_degree": 0,
+            "tp_st_percent": 2.5,
+            "tp_phase_shifter": false
+        },
+        "0.63 MVA 10/0.4 kV": {
+            "sn_kva": 630,
+            "vn_hv_kv": 10,
+            "vn_lv_kv": 0.4,
+            "vsc_percent": 4,
+            "vscr_percent": 1.0794,
+            "pfe_kw": 1.18,
+            "i0_percent": 0.1873,
+            "shift_degree": 150,
+            "vector_group": "Dyn5",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -2,
+            "tp_max": 2,
+            "tp_st_degree": 0,
+            "tp_st_percent": 2.5,
+            "tp_phase_shifter": false
+        }
+    },
+    "trafo3w": {
+        "63/25/38 MVA 110/20/10 kV": {
+            "sn_hv_kva": 63000,
+            "sn_mv_kva": 25000,
+            "sn_lv_kva": 38000,
+            "vn_hv_kv": 110,
+            "vn_mv_kv": 20,
+            "vn_lv_kv": 10,
+            "vsc_hv_percent": 10.4,
+            "vsc_mv_percent": 10.4,
+            "vsc_lv_percent": 10.4,
+            "vscr_hv_percent": 0.28,
+            "vscr_mv_percent": 0.32,
+            "vscr_lv_percent": 0.35,
+            "pfe_kw": 35,
+            "i0_percent": 0.89,
+            "shift_mv_degree": 0,
+            "shift_lv_degree": 0,
+            "vector_group": "YN0yn0yn0",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -10,
+            "tp_max": 10,
+            "tp_st_percent": 1.2
+        },
+        "63/25/38 MVA 110/10/10 kV": {
+            "sn_hv_kva": 63000,
+            "sn_mv_kva": 25000,
+            "sn_lv_kva": 38000,
+            "vn_hv_kv": 110,
+            "vn_mv_kv": 10,
+            "vn_lv_kv": 10,
+            "vsc_hv_percent": 10.4,
+            "vsc_mv_percent": 10.4,
+            "vsc_lv_percent": 10.4,
+            "vscr_hv_percent": 0.28,
+            "vscr_mv_percent": 0.32,
+            "vscr_lv_percent": 0.35,
+            "pfe_kw": 35,
+            "i0_percent": 0.89,
+            "shift_mv_degree": 0,
+            "shift_lv_degree": 0,
+            "vector_group": "YN0yn0yn0",
+            "tp_side": "hv",
+            "tp_mid": 0,
+            "tp_min": -10,
+            "tp_max": 10,
+            "tp_st_percent": 1.2
+        }
+    }
+},"storage":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"bus\",\"p_kw\",\"q_kvar\",\"sn_kva\",\"soc_percent\",\"min_e_kwh\",\"max_e_kwh\",\"scaling\",\"in_service\",\"type\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "name": "object",
+        "bus": "int64",
+        "p_kw": "float64",
+        "q_kvar": "float64",
+        "sn_kva": "float64",
+        "soc_percent": "float64",
+        "min_e_kwh": "float64",
+        "max_e_kwh": "float64",
+        "scaling": "float64",
+        "in_service": "bool",
+        "type": "object"
+    },
+    "orient": "split"
+},"switch":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"bus\",\"element\",\"et\",\"type\",\"closed\",\"name\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "bus": "int64",
+        "element": "int64",
+        "et": "object",
+        "type": "object",
+        "closed": "bool",
+        "name": "object"
+    },
+    "orient": "split"
+},"trafo":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"std_type\",\"hv_bus\",\"lv_bus\",\"sn_kva\",\"vn_hv_kv\",\"vn_lv_kv\",\"vsc_percent\",\"vscr_percent\",\"pfe_kw\",\"i0_percent\",\"shift_degree\",\"tp_side\",\"tp_mid\",\"tp_min\",\"tp_max\",\"tp_st_percent\",\"tp_st_degree\",\"tp_pos\",\"tp_phase_shifter\",\"parallel\",\"df\",\"in_service\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "name": "object",
+        "std_type": "object",
+        "hv_bus": "uint32",
+        "lv_bus": "uint32",
+        "sn_kva": "float64",
+        "vn_hv_kv": "float64",
+        "vn_lv_kv": "float64",
+        "vsc_percent": "float64",
+        "vscr_percent": "float64",
+        "pfe_kw": "float64",
+        "i0_percent": "float64",
+        "shift_degree": "float64",
+        "tp_side": "object",
+        "tp_mid": "int32",
+        "tp_min": "int32",
+        "tp_max": "int32",
+        "tp_st_percent": "float64",
+        "tp_st_degree": "float64",
+        "tp_pos": "int32",
+        "tp_phase_shifter": "bool",
+        "parallel": "uint32",
+        "df": "float64",
+        "in_service": "bool"
+    },
+    "orient": "split"
+},"trafo3w":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"std_type\",\"hv_bus\",\"mv_bus\",\"lv_bus\",\"sn_hv_kva\",\"sn_mv_kva\",\"sn_lv_kva\",\"vn_hv_kv\",\"vn_mv_kv\",\"vn_lv_kv\",\"vsc_hv_percent\",\"vsc_mv_percent\",\"vsc_lv_percent\",\"vscr_hv_percent\",\"vscr_mv_percent\",\"vscr_lv_percent\",\"pfe_kw\",\"i0_percent\",\"shift_mv_degree\",\"shift_lv_degree\",\"tp_side\",\"tp_mid\",\"tp_min\",\"tp_max\",\"tp_st_percent\",\"tp_st_degree\",\"tp_pos\",\"tap_at_star_point\",\"in_service\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "name": "object",
+        "std_type": "object",
+        "hv_bus": "uint32",
+        "mv_bus": "uint32",
+        "lv_bus": "uint32",
+        "sn_hv_kva": "uint64",
+        "sn_mv_kva": "uint64",
+        "sn_lv_kva": "uint64",
+        "vn_hv_kv": "float64",
+        "vn_mv_kv": "float64",
+        "vn_lv_kv": "float64",
+        "vsc_hv_percent": "float64",
+        "vsc_mv_percent": "float64",
+        "vsc_lv_percent": "float64",
+        "vscr_hv_percent": "float64",
+        "vscr_mv_percent": "float64",
+        "vscr_lv_percent": "float64",
+        "pfe_kw": "float64",
+        "i0_percent": "float64",
+        "shift_mv_degree": "float64",
+        "shift_lv_degree": "float64",
+        "tp_side": "object",
+        "tp_mid": "int32",
+        "tp_min": "int32",
+        "tp_max": "int32",
+        "tp_st_percent": "float64",
+        "tp_st_degree": "float64",
+        "tp_pos": "int32",
+        "tap_at_star_point": "bool",
+        "in_service": "bool"
+    },
+    "orient": "split"
+},"user_pf_options":{},"version":1.6,"ward":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"bus\",\"ps_kw\",\"qs_kvar\",\"qz_kvar\",\"pz_kw\",\"in_service\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "name": "object",
+        "bus": "uint32",
+        "ps_kw": "float64",
+        "qs_kvar": "float64",
+        "qz_kvar": "float64",
+        "pz_kw": "float64",
+        "in_service": "bool"
+    },
+    "orient": "split"
+},"xward":{
+    "_module": "pandas.core.frame",
+    "_class": "DataFrame",
+    "_object": "{\"columns\":[\"name\",\"bus\",\"ps_kw\",\"qs_kvar\",\"qz_kvar\",\"pz_kw\",\"r_ohm\",\"x_ohm\",\"vm_pu\",\"in_service\"],\"index\":[],\"data\":[]}",
+    "dtype": {
+        "name": "object",
+        "bus": "uint32",
+        "ps_kw": "float64",
+        "qs_kvar": "float64",
+        "qz_kvar": "float64",
+        "pz_kw": "float64",
+        "r_ohm": "float64",
+        "x_ohm": "float64",
+        "vm_pu": "float64",
+        "in_service": "bool"
+    },
+    "orient": "split"
+}}

--- a/pandapower/networks/power_system_test_cases.py
+++ b/pandapower/networks/power_system_test_cases.py
@@ -133,6 +133,30 @@ def case9():
     case9 = pp.from_json(_get_cases_path("case9.json"))
     return case9
 
+def case11_iwamoto():
+    """
+    Calls the json file case11_iwamoto.json which represents \
+    the 11 bus example from `S. Iwamoto ; Y. Tamura , \
+    A Load Flow Calculation Method for Ill-Conditioned Power Systems
+    <https://ieeexplore.ieee.org/document/4110791/>'_ \
+    IEEE Transactions on Power Apparatus and Systems
+
+    Its data origin is the paper \
+    `S.C. Tripathy, G. Durga Prasad, O.P. Malik, G.S. Hope, \
+    Load-Flow Solutions for Ill-Conditioned Power Systems by a Newton-Like Method
+    <https://ieeexplore.ieee.org/document/4111178/>`_\
+    IEEE  IEEE Transactions on Power Apparatus and Systems, 1982.
+
+    OUTPUT:
+         **net** - Returns the required network case11_iwamoto
+
+    EXAMPLE:
+         import pandapower.networks as pn
+
+         net = pn.case11_iwamoto()
+    """
+    case11 = pp.from_json(_get_cases_path("case11_iwamoto.json"))
+    return case11
 
 def case14():
     """


### PR DESCRIPTION
Implementation of the Iwamoto 11-bus testcase, as discussed in #114.
It reproduces the Ybus values and Sbus values from [Tripathy et al.](https://ieeexplore.ieee.org/document/4111178)