### PR TITLE
WiP: networkx MultiGraph method edges_iter -> edges

### DIFF
--- a/pandapower/plotting/generic_geodata.py
+++ b/pandapower/plotting/generic_geodata.py
@@ -117,7 +117,7 @@ def create_generic_coordinates(net, mg=None, library="igraph", respect_switches=
         else:
             nxg = copy.deepcopy(mg)
         # workaround for bug in agraph
-        for u, v in nxg.edges_iter(data=False, keys=False):
+        for u, v in nxg.edges(data=False, keys=False):
             if 'key' in nxg[int(u)][int(v)]:
                 del nxg[int(u)][int(v)]['key']
             if 'key' in nxg[int(u)][int(v)][0]:


### PR DESCRIPTION
The stable version of networkx.MultiGraph uses `edges` to return the iterator, not `edges_iter`. See here: https://networkx.github.io/documentation/stable/reference/classes/multigraph.html

I would like to test this completely but I'm having issues with the compilation of graphviz, sorry. I recommend someone tests this before merging (not that it has any chance of breaking anything, but other changes might be required).

Edit: Added "WiP" for this reason (couldn't test).

Michel