### PR TITLE
Removed unused option (no impact on calculation)

### DIFF
--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -459,7 +459,7 @@ def _add_opf_options(net, trafo_loading, ac, v_debug=False, **kwargs):
 
 
 def _add_sc_options(net, fault, case, lv_tol_percent, tk_s, topology, r_fault_ohm,
-                    x_fault_ohm, kappa, ip, ith, consider_sgens, branch_results, kappa_method):
+                    x_fault_ohm, kappa, ip, ith, branch_results, kappa_method):
     """
     creates dictionary for pf, opf and short circuit calculations from input parameters.
     """
@@ -474,7 +474,6 @@ def _add_sc_options(net, fault, case, lv_tol_percent, tk_s, topology, r_fault_oh
         "kappa": kappa,
         "ip": ip,
         "ith": ith,
-        "consider_sgens": consider_sgens,
         "branch_results": branch_results,
         "kappa_method": kappa_method
     }

--- a/pandapower/shortcircuit/calc_sc.py
+++ b/pandapower/shortcircuit/calc_sc.py
@@ -79,7 +79,7 @@ def calc_sc(net, fault="3ph", case='max', lv_tol_percent=10, topology="auto", ip
 
         **x_fault_ohm** (float, 0) fault reactance in Ohm
 
-        **consider_sgens** (bool, True) defines if short-circuit contribution of static generators should be considered or not
+        **branch_results** (bool, False) defines if short-circuit results should also be generated for branches
 
 
     OUTPUT:
@@ -117,7 +117,7 @@ def calc_sc(net, fault="3ph", case='max', lv_tol_percent=10, topology="auto", ip
     _add_sc_options(net, fault=fault, case=case, lv_tol_percent=lv_tol_percent, tk_s=tk_s,
                     topology=topology, r_fault_ohm=r_fault_ohm, kappa_method=kappa_method,
                     x_fault_ohm=x_fault_ohm, kappa=kappa, ip=ip, ith=ith,
-                    consider_sgens=False, branch_results=branch_results)
+                    branch_results=branch_results)
     if fault == "3ph":
         _calc_sc(net)
     if fault == "2ph":


### PR DESCRIPTION
Hi,

The `consider_sgens` option shown in the [latest documentation](https://pandapower.readthedocs.io/en/latest/shortcircuit/run.html) has no actual impact on the calculation output. It was simply set to `False` in the `_add_sc_options` method in `calc_sc.py`.

Considering this and the fact that I see no reason to include such an option, I would recommend removing it, hence the current PR. I assume it's an old option that was used during development.

I also added the option `branch_results`. I know it's not 100% ready, but it appears in the doc with no description so it should be described somehow.

I'm not very familiar with this but it *looks* like the doc is autogenerated from the docstring and [this file](https://github.com/e2nIEE/pandapower/blob/master/doc/shortcircuit/run.rst), which is fine, so I think this PR is complete.

Short-circuit pytest succeeds:

```
C:\Users\michel\gits\pandapower\pandapower\test\shortcircuit>pytest
============================= test session starts =============================
platform win32 -- Python 3.6.7, pytest-4.0.0, py-1.7.0, pluggy-0.8.0
rootdir: C:\Users\michel\gits\pandapower, inifile:
collected 26 items

test_1ph.py ...                                                          [ 11%]
test_gen.py ...                                                          [ 23%]
test_impedance.py ..                                                     [ 30%]
test_meshing_detection.py ....                                           [ 46%]
test_motor.py .                                                          [ 50%]
test_ring.py ...                                                         [ 61%]
test_sgen.py ...                                                         [ 73%]
test_trafo3w.py ..                                                       [ 80%]
test_transformer.py .....                                                [100%]

========================== 26 passed in 3.64 seconds ==========================
```

Comments welcome.

Thanks,

Michel