### PR TITLE
Fix #253 Avoid auto fusing of buses with elements and bb switches in state estimation

### DIFF
--- a/pandapower/estimation/state_estimation.py
+++ b/pandapower/estimation/state_estimation.py
@@ -9,7 +9,7 @@ from scipy.sparse.linalg import spsolve
 from scipy.stats import chi2
 
 from pandapower.estimation.wls_ppc_conversions import _add_measurements_to_ppc, \
-    _build_measurement_vectors, _init_ppc
+    _build_measurement_vectors, _init_ppc, _add_aux_elements_for_bb_switch, _drop_aux_elements_for_bb_switch
 from pandapower.estimation.results import _copy_power_flow_results, _rename_results
 from pandapower.idx_brch import F_BUS, T_BUS, BR_STATUS, PF, PT, QF, QT
 from pandapower.auxiliary import _add_pf_options, get_values, _clean_up
@@ -27,7 +27,7 @@ std_logger = logging.getLogger(__name__)
 
 
 def estimate(net, init='flat', tolerance=1e-6, maximum_iterations=10,
-             calculate_voltage_angles=True):
+             calculate_voltage_angles=True, fuse_all_bb_switches=True):
     """
     Wrapper function for WLS state estimation.
 
@@ -46,6 +46,11 @@ def estimate(net, init='flat', tolerance=1e-6, maximum_iterations=10,
 
         **calculate_voltage_angles** - (boolean) - Take into account absolute voltage angles and phase
         shifts in transformers, if init is 'slack'. Default is True.
+        
+        **fuse_all_bb_switches** - (bool) - if true when considering bus-bus-switches the buses
+        will fused (Default behaviour) otherwise auxiliary lines will be added between those buses 
+        where an element is connected to them in order to clear the p,q results on each buses 
+        instead of fusing them all together
 
     OUTPUT:
         **successful** (boolean) - Was the state estimation successful?
@@ -63,7 +68,7 @@ def estimate(net, init='flat', tolerance=1e-6, maximum_iterations=10,
             delta_start = res_bus.va_degree.values
     elif init != 'flat':
         raise UserWarning("Unsupported init value. Using flat initialization.")
-    return wls.estimate(v_start, delta_start, calculate_voltage_angles)
+    return wls.estimate(v_start, delta_start, calculate_voltage_angles, fuse_all_bb_switches)
 
 
 def remove_bad_data(net, init='flat', tolerance=1e-6, maximum_iterations=10,
@@ -186,7 +191,7 @@ class state_estimation(object):
         self.delta = None
         self.bad_data_present = None
 
-    def estimate(self, v_start=None, delta_start=None, calculate_voltage_angles=True):
+    def estimate(self, v_start=None, delta_start=None, calculate_voltage_angles=True, fuse_all_bb_switches=True):
         """
         The function estimate is the main function of the module. It takes up to three input
         arguments: v_start, delta_start and calculate_voltage_angles. The first two are the initial
@@ -214,6 +219,11 @@ class state_estimation(object):
         OPTIONAL:
             **calculate_voltage_angles** - (bool) - Take into account absolute voltage angles and
             phase shifts in transformers Default is True.
+            
+            **fuse_all_bb_switches** - (bool) - if true when considering bus-bus-switches the buses
+            will fused (Default behaviour) otherwise auxiliary lines will be added between those buses 
+            where an element is connected to them in order to clear the p,q results on each buses 
+            instead of fusing them all together
 
         OUTPUT:
             **successful** (boolean) - True if the estimation process was successful
@@ -229,6 +239,12 @@ class state_estimation(object):
         if self.net is None:
             raise UserWarning("Component was not initialized with a network.")
         t0 = time()
+        
+        # change the configuration of the pp net to avoid auto fusing of buses connected
+        # through bb switch with elements on each bus if this feature enabled
+        if not fuse_all_bb_switches and not self.net.switch.empty:
+            _add_aux_elements_for_bb_switch(self.net)
+        
         # add initial values for V and delta
         # node voltages
         # V<delta
@@ -369,6 +385,9 @@ class state_estimation(object):
                                                    mapping_table)
         
         _clean_up(self.net)
+        # clear the aux elements and calculation results created for the substitution of bb switches
+        if not fuse_all_bb_switches and not self.net.switch.empty:
+            _drop_aux_elements_for_bb_switch(self.net)
 
         # store variables required for chi^2 and r_N_max test:
         self.R_inv = r_inv.toarray()

--- a/pandapower/test/estimation/test_wls_estimation.py
+++ b/pandapower/test/estimation/test_wls_estimation.py
@@ -628,6 +628,55 @@ def test_network_with_trafo3w_with_disabled_branch():
     assert success
     assert (np.nanmax(np.abs(net.res_bus.vm_pu.values - net.res_bus_est.vm_pu.values)) < 0.006)
     assert (np.nanmax(np.abs(net.res_bus.va_degree.values- net.res_bus_est.va_degree.values)) < 0.006)
+    
+
+def test_net_with_bb_switch():
+    net = pp.create_empty_network()
+    pp.create_bus(net, name="bus1", vn_kv=10.)
+    pp.create_bus(net, name="bus2", vn_kv=10.)
+    pp.create_bus(net, name="bus3", vn_kv=10.)
+    pp.create_bus(net, name="bus4", vn_kv=110.)
+    pp.create_ext_grid(net, bus=3, vm_pu=1.0)
+    pp.create_line_from_parameters(net, 0, 1, 10, r_ohm_per_km=.59, x_ohm_per_km=.35, c_nf_per_km=10.1,
+                                   max_i_ka=1)
+    pp.create_transformer(net, 3, 0, std_type="40 MVA 110/10 kV")
+
+    pp.create_load(net, 0, p_mw=.350, q_mvar=.100)
+    pp.create_load(net, 1, p_mw=.450, q_mvar=.100)
+    pp.create_load(net, 2, p_mw=.250, q_mvar=.100)
+
+    # Created bb switch
+    pp.create_switch(net, 1, element=2, et='b')
+    pp.runpp(net, calculate_voltage_angles=True)
+
+    pp.create_measurement(net, "v", "bus", r2(net.res_bus.vm_pu.iloc[0], .002), .002, element=0)
+    pp.create_measurement(net, "v", "bus", r2(net.res_bus.vm_pu.iloc[1], .002), .002, element=1)
+    pp.create_measurement(net, "v", "bus", r2(net.res_bus.vm_pu.iloc[3], .002), .002, element=3)
+
+    pp.create_measurement(net, "p", "bus", -r2(net.res_bus.p_mw.iloc[3], .002), .002, element=3)
+    pp.create_measurement(net, "q", "bus", -r2(net.res_bus.q_mvar.iloc[3], .002), .002, element=3)
+
+    # If measurement on the bus with bb-switch activated, it will incluence the results of the merged bus
+    pp.create_measurement(net, "p", "bus", -r2(net.res_bus.p_mw.iloc[2], .001), .001, element=2)
+    pp.create_measurement(net, "q", "bus", -r2(net.res_bus.q_mvar.iloc[2], .001), .001, element=2)
+    pp.create_measurement(net, "p", "bus", -r2(net.res_bus.p_mw.iloc[1], .001), .001, element=1)
+    pp.create_measurement(net, "q", "bus", -r2(net.res_bus.q_mvar.iloc[1], .001), .001, element=1)
+
+    pp.create_measurement(net, "p", "line", r2(net.res_line.p_from_mw.iloc[0], .002), .002, 0, side='from')
+    pp.create_measurement(net, "q", "line", r2(net.res_line.q_from_mvar.iloc[0], .002), .002, 0, side='from')
+
+    pp.create_measurement(net, "p", "trafo", r2(net.res_trafo.p_hv_mw.iloc[0], .001), .01,
+                          side="hv", element=0)  
+    pp.create_measurement(net, "q", "trafo", r2(net.res_trafo.q_hv_mvar.iloc[0], .001), .01,
+                          side="hv", element=0)  
+
+    success = estimate(net, tolerance=1e-5, fuse_all_bb_switches=False)
+    assert success
+    assert np.allclose(net.res_bus.va_degree.values,net.res_bus_est.va_degree.values, 1e-2)
+    assert np.allclose(net.res_bus.vm_pu.values,net.res_bus_est.vm_pu.values, 1e-2)
+    # asserting with more tolerance since the added impedance will cause some inaccuracy
+    assert np.allclose(net.res_bus.p_mw.values,net.res_bus_est.p_mw.values, atol=1e-2)
+    assert np.allclose(net.res_bus.q_mvar.values,net.res_bus_est.q_mvar.values, atol=1e-2)
 
 
 def r(v=0.03):


### PR DESCRIPTION
Fix #253 

- in case of bb switches, with the option fuse_all_bb_switch disabled, the module will find such auto fused buses with elements on them, and create auxiliary buses to substitute the bus in the original topology with bb switches, the original bus will then connect to the auxiliary bus with a short piece of line, thus avoiding
auto fusing, this process will be done in the estimation function before the pd2ppc conversion and and cleaned at the end of the function ofr the unnecessary information

- Added test case