### PR TITLE
added precise_float keyword to pp_hook for loading json networks

### DIFF
--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -268,9 +268,9 @@ def pp_hook(d):
                 d[key] = pp_hook(d[key])
 
         if class_name == 'Series':
-            return pd.read_json(obj, **d)
+            return pd.read_json(obj, precise_float=True, **d)
         elif class_name == "DataFrame":
-            df = pd.read_json(obj, **d)
+            df = pd.read_json(obj, precise_float=True, **d)
             try:
                 df.set_index(df.index.astype(numpy.int64), inplace=True)
             except (ValueError, TypeError, AttributeError):
@@ -330,7 +330,7 @@ def json_net(obj):
 def json_dataframe(obj):
     logger.debug('DataFrame')
     d = with_signature(obj, obj.to_json(orient='split',
-                                        default_handler=to_serializable, double_precision=14))
+                                        default_handler=to_serializable, double_precision=15))
     d.update({'dtype': obj.dtypes.astype('str').to_dict(), 'orient': 'split'})
     return d
 


### PR DESCRIPTION
I found that when saving an old network with the new json io and reloading it, there are some discrepancies, as some values are found not to precisely match, i.e. after saving and loading a value that was 0.95 could now be 0.9500000001. In order avoid this, a keyword was added to the pp_hook (namely precise_float for the function to load DataFrames from json). It should slow down the process slightly, but ensures that the values always remain the same after loading. Maybe in the long run this should be outsourced to a kwarg, but for now I think it is better to have a slower function (btw. for my network it was 755 ms vs. 725 ms) than unprecise values.