### PR TITLE
Bug fixing in state estimation and support auto addition for p,q injection measurements duplication 

### DIFF
--- a/pandapower/create.py
+++ b/pandapower/create.py
@@ -2438,7 +2438,9 @@ def create_measurement(net, meas_type, element_type, value, std_dev, element, si
             raise UserWarning("More than one measurement of this type exists")
 
     dtypes = net.measurement.dtypes
-    net.measurement.loc[index] = [name, meas_type.lower(), element_type, element, value, std_dev, side]
+    columns = ['name', 'measurement_type', 'element_type', 'element', 'value', 'std_dev', 'side']
+    net.measurement.loc[index, columns] =\
+        [name, meas_type.lower(), element_type, element, value, std_dev, side]
     _preserve_dtypes(net.measurement, dtypes)
     return index
 

--- a/pandapower/create.py
+++ b/pandapower/create.py
@@ -2438,7 +2438,7 @@ def create_measurement(net, meas_type, element_type, value, std_dev, element, si
             raise UserWarning("More than one measurement of this type exists")
 
     dtypes = net.measurement.dtypes
-    columns = ['name', 'measurement_type', 'element_type', 'element', 'value', 'std_dev', 'side']
+    columns = ["name", "measurement_type", "element_type", "element", "value", "std_dev", "side"]
     net.measurement.loc[index, columns] =\
         [name, meas_type.lower(), element_type, element, value, std_dev, side]
     _preserve_dtypes(net.measurement, dtypes)

--- a/pandapower/estimation/ppc_conversions.py
+++ b/pandapower/estimation/ppc_conversions.py
@@ -79,7 +79,9 @@ def _add_aux_elements_for_bb_switch(net):
     aux_switch.loc[element_to_be_replaced.index, 'element'] =\
         bus_aux_mapping[element_to_be_replaced].values.astype(int)
     aux_switch['closed'] = aux_switch['original_closed']
-    net.switch = net.switch.append(aux_switch, ignore_index=True, sort=False)
+    #For Py34
+    net.switch = net.switch.append(aux_switch, ignore_index=True)
+#    net.switch = net.switch.append(aux_switch, ignore_index=True, sort=False)
 
     # create auxiliary lines as small impedance
     for bus_ori, bus_aux in bus_aux_mapping.iteritems():

--- a/pandapower/test/estimation/test_wls_estimation.py
+++ b/pandapower/test/estimation/test_wls_estimation.py
@@ -689,16 +689,16 @@ def test_net_with_bb_switch_no_fusing():
     assert np.allclose(net.res_bus.va_degree.values,net.res_bus_est.va_degree.values, 1e-2)
     assert np.allclose(net.res_bus.vm_pu.values,net.res_bus_est.vm_pu.values, 1e-2)
     # asserting with more tolerance since the added impedance will cause some inaccuracy
-    assert np.allclose(net.res_bus.p_mw.values,net.res_bus_est.p_mw.values, atol=1e-1)
-    assert np.allclose(net.res_bus.q_mvar.values,net.res_bus_est.q_mvar.values, atol=1e-1)
+    assert np.allclose(net.res_bus.p_mw.values,net.res_bus_est.p_mw.values, 1e-1)
+    assert np.allclose(net.res_bus.q_mvar.values,net.res_bus_est.q_mvar.values, 1e-1)
 
 
 def test_net_with_bb_switch_fusing():
     net = create_net_with_bb_switch()
     success = estimate(net, tolerance=1e-5, fuse_all_bb_switches=True)
     assert success
-    assert np.allclose(net.res_bus.va_degree.values,net.res_bus_est.va_degree.values, 1e-1)
-    assert np.allclose(net.res_bus.vm_pu.values,net.res_bus_est.vm_pu.values, 1e-1)
+    assert np.allclose(net.res_bus.va_degree.values,net.res_bus_est.va_degree.values, 5e-2)
+    assert np.allclose(net.res_bus.vm_pu.values,net.res_bus_est.vm_pu.values, 5e-2)
     # Test on p,q injctions on bus will be skipped because on fused buses
     # the difference can no longer be told
 

--- a/pandapower/test/estimation/test_wls_estimation.py
+++ b/pandapower/test/estimation/test_wls_estimation.py
@@ -640,9 +640,8 @@ def test_network_with_trafo3w_with_disabled_branch():
     assert success
     assert (np.nanmax(np.abs(net.res_bus.vm_pu.values - net.res_bus_est.vm_pu.values)) < 0.006)
     assert (np.nanmax(np.abs(net.res_bus.va_degree.values- net.res_bus_est.va_degree.values)) < 0.006)
-    
 
-def test_net_with_bb_switch():
+def create_net_with_bb_switch():  
     net = pp.create_empty_network()
     pp.create_bus(net, name="bus1", vn_kv=10.)
     pp.create_bus(net, name="bus2", vn_kv=10.)
@@ -680,15 +679,28 @@ def test_net_with_bb_switch():
     pp.create_measurement(net, "p", "trafo", r2(net.res_trafo.p_hv_mw.iloc[0], .001), .01,
                           side="hv", element=0)  
     pp.create_measurement(net, "q", "trafo", r2(net.res_trafo.q_hv_mvar.iloc[0], .001), .01,
-                          side="hv", element=0)  
+                          side="hv", element=0) 
+    return net
 
+def test_net_with_bb_switch_no_fusing():
+    net = create_net_with_bb_switch()
     success = estimate(net, tolerance=1e-5, fuse_all_bb_switches=False)
     assert success
     assert np.allclose(net.res_bus.va_degree.values,net.res_bus_est.va_degree.values, 1e-2)
     assert np.allclose(net.res_bus.vm_pu.values,net.res_bus_est.vm_pu.values, 1e-2)
     # asserting with more tolerance since the added impedance will cause some inaccuracy
-    assert np.allclose(net.res_bus.p_mw.values,net.res_bus_est.p_mw.values, atol=1e-2)
-    assert np.allclose(net.res_bus.q_mvar.values,net.res_bus_est.q_mvar.values, atol=1e-2)
+    assert np.allclose(net.res_bus.p_mw.values,net.res_bus_est.p_mw.values, atol=1e-1)
+    assert np.allclose(net.res_bus.q_mvar.values,net.res_bus_est.q_mvar.values, atol=1e-1)
+
+
+def test_net_with_bb_switch_fusing():
+    net = create_net_with_bb_switch()
+    success = estimate(net, tolerance=1e-5, fuse_all_bb_switches=True)
+    assert success
+    assert np.allclose(net.res_bus.va_degree.values,net.res_bus_est.va_degree.values, 1e-1)
+    assert np.allclose(net.res_bus.vm_pu.values,net.res_bus_est.vm_pu.values, 1e-1)
+    # Test on p,q injctions on bus will be skipped because on fused buses
+    # the difference can no longer be told
 
 def test_net_with_zero_injection():
     # Created on Mon Dec 10 10:20:09 2018
@@ -726,6 +738,7 @@ def test_net_with_zero_injection():
     assert success
     assert np.abs(net.res_bus_est.at[1, 'p_mw']) < 1e-8
     assert np.abs(net.res_bus_est.at[1, 'q_mvar']) < 1e-8
+
 
 def r(v=0.03):
     return np.random.normal(1.0, v)

--- a/pandapower/toolbox.py
+++ b/pandapower/toolbox.py
@@ -1381,9 +1381,11 @@ def drop_duplicated_measurements(net, buses=None, keep="first"):
     bus_meas = net.measurement.loc[net.measurement.element_type == "bus"]
     analyzed_meas = bus_meas.loc[net.measurement.element.isin(buses).fillna("nan")]
     # drop duplicates
-    idx_to_drop = analyzed_meas.index[analyzed_meas.duplicated(subset=[
-        "measurement_type", "element_type", "side", "element"], keep=keep)]
-    net.measurement.drop(idx_to_drop, inplace=True)
+    if not analyzed_meas.duplicated(subset=[
+        "measurement_type", "element_type", "side", "element"], keep=keep).empty:
+        idx_to_drop = analyzed_meas.index[analyzed_meas.duplicated(subset=[
+            "measurement_type", "element_type", "side", "element"], keep=keep)]
+        net.measurement.drop(idx_to_drop, inplace=True)
 
 
 def fuse_buses(net, b1, b2, drop=True):


### PR DESCRIPTION
Bug fixed in create measurement in case of user defined column existed in measurement table
Bug fixed in trafo3w branch mapping in state estimation
Bug fixed in replace bb switch with small impedance

P, Q injection measurement on the same ppci bus (fused from same pp buses) will be added together if replace with impedance is not wanted and warning will be shown if such case happened, and also added test case, as mentioned in #277 