### PR TITLE
move check for existing results in case of init=results to options #262

### DIFF
--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -671,6 +671,13 @@ def _init_runpp_options(net, algorithm, calculate_voltage_angles, init,
     if init != "auto" and (init_va_degree is not None or init_vm_pu is not None):
         raise ValueError("Either define initialization through 'init' or through 'init_vm_pu' and 'init_va_degree'.")
 
+    init_from_results = init == "results" or (isinstance(init_vm_pu, str) and init_vm_pu=="results") \
+                                or (isinstance(init_va_degree, str) and init_va_degree=="results")
+    if init_from_results and len(net.res_bus) == 0:
+        init = "auto"
+        init_vm_pu = None
+        init_va_degree = None
+
     if init == "auto":
         if init_va_degree is None or (isinstance(init_va_degree, str) and init_va_degree == "auto"):
             init_va_degree = "dc" if calculate_voltage_angles else "flat"
@@ -683,6 +690,7 @@ def _init_runpp_options(net, algorithm, calculate_voltage_angles, init,
     else:
         init_vm_pu = init
         init_va_degree = init
+
 
     # init options
     net._options = {}

--- a/pandapower/build_bus.py
+++ b/pandapower/build_bus.py
@@ -181,18 +181,14 @@ def create_bus_lookup(net, bus_index, bus_is_idx, gen_is_mask, eg_is_mask, r_swi
 def get_voltage_init_vector(net, init_v, mode):
     if isinstance(init_v, str):
         if init_v == "results":
-            if len(net.res_bus) > 0:
-                # init voltage possible if bus results are available
-                if net.res_bus.index.equals(net.bus.index):
-                    # init bus voltages from results if the sorting is correct
-                    return net["res_bus"]["vm_pu" if mode == "magnitude" else "va_degree"].values
-                else:
-                    # cannot init from results, since sorting of results is different from element table
-                    UserWarning("Init from results not possible. Index of res_bus do not match with bus. "
-                                "You should sort res_bus before calling runpp.")
-                    return None
+            # init voltage possible if bus results are available
+            if net.res_bus.index.equals(net.bus.index):
+                # init bus voltages from results if the sorting is correct
+                return net["res_bus"]["vm_pu" if mode == "magnitude" else "va_degree"].values
             else:
-                # No results available. Cannot init from results
+                # cannot init from results, since sorting of results is different from element table
+                UserWarning("Init from results not possible. Index of res_bus do not match with bus. "
+                            "You should sort res_bus before calling runpp.")
                 return None
         if init_v == "flat":
             if mode == "magnitude":

--- a/pandapower/test/loadflow/test_runpp.py
+++ b/pandapower/test/loadflow/test_runpp.py
@@ -14,7 +14,7 @@ import pytest
 import pandapower as pp
 from pandapower.auxiliary import _check_connectivity, _add_ppc_options
 from pandapower.networks import create_cigre_network_mv, four_loads_with_branches_out, \
-    example_simple, simple_four_bus_system
+    example_simple, simple_four_bus_system, example_multivoltage
 from pandapower.pd2ppc import _pd2ppc
 from pandapower.pf.create_jacobian import _create_J_without_numba
 from pandapower.pf.run_newton_raphson_pf import _get_pf_variables_from_ppci
@@ -950,10 +950,19 @@ def test_dc_with_ext_grid_at_one_bus():
 
 def test_init_results_without_results():
     # should switch to "auto" mode and not fail
-    net = four_loads_with_branches_out()
+    net = example_multivoltage()
     pp.reset_results(net)
     pp.runpp(net, init="results")
-
+    assert net.converged
+    pp.reset_results(net)
+    pp.runpp(net, init_vm_pu="results")
+    assert net.converged
+    pp.reset_results(net)
+    pp.runpp(net, init_va_degree="results")
+    assert net.converged
+    pp.reset_results(net)
+    pp.runpp(net, init_va_degree="results", init_vm_pu="results")
+    assert net.converged
 
 def test_init_results():
     net = pp.create_empty_network()


### PR DESCRIPTION
Alternative solution to the problem discusse in #262, this makes #263 obsolete.