### PR TITLE
Refactoring create_nxgraph

### DIFF
--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -705,6 +705,14 @@ def _init_runpp_options(net, algorithm, calculate_voltage_angles, init,
                     v_debug=v_debug)
     net._options.update(overrule_options)
 
+def _init_nx_options(net):
+    net._options = {}
+    _add_ppc_options(net, calculate_voltage_angles=False,
+                     trafo_model="t", check_connectivity=False,
+                     mode="nx", r_switch=0, init_vm_pu='flat', init_va_degree="flat",
+                     enforce_q_lims=False, recycle=False,
+                     voltage_depend_loads=False, delta=0, trafo3w_losses="hv")
+
 
 def _init_rundcpp_options(net, trafo_model, trafo_loading, recycle, check_connectivity, r_switch, trafo3w_losses):
     ac = False

--- a/pandapower/build_branch.py
+++ b/pandapower/build_branch.py
@@ -232,7 +232,8 @@ def _calc_branch_values_from_trafo_df(net, ppc, trafo_df=None):
     bus_lookup = net["_pd2ppc_lookups"]["bus"]
     if trafo_df is None:
         trafo_df = net["trafo"]
-    vn_lv = get_values(ppc["bus"][:, BASE_KV], get_trafo_values(trafo_df, "lv_bus"), bus_lookup)
+    lv_bus = get_trafo_values(trafo_df, "lv_bus")
+    vn_lv = ppc["bus"][bus_lookup[lv_bus], BASE_KV]
     ### Construct np.array to parse results in ###
     # 0:r_pu; 1:x_pu; 2:b_pu; 3:tab;
     vn_trafo_hv, vn_trafo_lv, shift = _calc_tap_from_dataframe(net, trafo_df)
@@ -436,20 +437,29 @@ def _calc_impedance_parameter(net, ppc):
     bus_lookup = net["_pd2ppc_lookups"]["bus"]
     f, t = net["_pd2ppc_lookups"]["branch"]["impedance"]
     branch = ppc["branch"]
-    sn_impedance = net["impedance"]["sn_mva"].values
-    sn_net = net.sn_mva
-    rij = net["impedance"]["rft_pu"].values
-    xij = net["impedance"]["xft_pu"].values
-    rji = net["impedance"]["rtf_pu"].values
-    xji = net["impedance"]["xtf_pu"].values
-    branch[f:t, F_BUS] = bus_lookup[net["impedance"]["from_bus"].values]
-    branch[f:t, T_BUS] = bus_lookup[net["impedance"]["to_bus"].values]
-    branch[f:t, BR_R] = rij / sn_impedance * sn_net
-    branch[f:t, BR_X] = xij / sn_impedance * sn_net
-    branch[f:t, BR_R_ASYM] = (rji - rij) / sn_impedance * sn_net
-    branch[f:t, BR_X_ASYM] = (xji - xij) / sn_impedance * sn_net
+    rij, xij, r_asym, x_asym = _calc_impedance_parameters_from_dataframe(net)
+    branch[f:t, BR_R] = rij
+    branch[f:t, BR_X] = xij
+    branch[f:t, BR_R_ASYM] = r_asym
+    branch[f:t, BR_X_ASYM] = x_asym
+    branch[f:t, F_BUS] = bus_lookup[net.impedance["from_bus"].values]
+    branch[f:t, T_BUS] = bus_lookup[net.impedance["to_bus"].values]
     branch[f:t, BR_STATUS] = net["impedance"]["in_service"].values
 
+def _calc_impedance_parameters_from_dataframe(net):
+    impedance = net.impedance
+    sn_impedance = impedance["sn_mva"].values
+    sn_net = net.sn_mva
+    rij = impedance["rft_pu"].values
+    xij = impedance["xft_pu"].values
+    rji = impedance["rtf_pu"].values
+    xji = impedance["xtf_pu"].values
+
+    r = rij / sn_impedance * sn_net
+    x = xij / sn_impedance * sn_net
+    r_asym = (rji - rij) / sn_impedance * sn_net
+    x_asym = (xji - xij) / sn_impedance * sn_net
+    return r, x, r_asym, x_asym
 
 def _calc_xward_parameter(net, ppc):
     bus_lookup = net["_pd2ppc_lookups"]["bus"]

--- a/pandapower/test/loadflow/result_test_network_generator.py
+++ b/pandapower/test/loadflow/result_test_network_generator.py
@@ -352,6 +352,8 @@ def add_test_impedance(net):
 
     pp.create_impedance(net, b2, b3, rft_pu=rij, xft_pu=xij, rtf_pu=rji, xtf_pu=xji,
                         sn_mva=s, index=pp.get_free_id(net.impedance) + 1)
+    pp.create_impedance(net, b2, b3, rft_pu=rij, xft_pu=xij, rtf_pu=rji, xtf_pu=xji,
+                        sn_mva=s, index=pp.get_free_id(net.impedance) + 1, in_service=False)
     pp.create_load(net, b3, p_mw=pl, q_mvar=ql)
     net.last_added_case = "test_impedance"
     return net

--- a/pandapower/test/loadflow/test_scenarios.py
+++ b/pandapower/test/loadflow/test_scenarios.py
@@ -393,14 +393,15 @@ def network_with_trafo3ws():
         pp.create_load(net, mv, p_mw=0.8, q_mvar=0)
         lv = pp.create_bus(net, vn_kv=0.4, zone="test_trafo3w")
         pp.create_load(net, lv, p_mw=0.5, q_mvar=0)
-        t3 = pp.create_transformer3w_from_parameters(net, hv_bus=hv, mv_bus=mv, lv_bus=lv,
-                                                     vn_hv_kv=20, vn_mv_kv=.6, vn_lv_kv=.4,
-                                                     sn_hv_mva=1, sn_mv_mva=0.7, sn_lv_mva=0.3,
-                                                     vk_hv_percent=1., vkr_hv_percent=.03,
-                                                     vk_mv_percent=.5, vkr_mv_percent=.02,
-                                                     vk_lv_percent=.25, vkr_lv_percent=.01,
-                                                     pfe_kw=0., i0_percent=0.0, name="test", 
-                                                     index=pp.get_free_id(net.trafo3w) + 1)
+        t3 = pp.create_transformer3w_from_parameters(net, hv_bus=hv, mv_bus=mv, lv_bus=lv, vn_hv_kv=22,
+                                                vn_mv_kv=.64, vn_lv_kv=.42, sn_hv_mva=1,
+                                                sn_mv_mva=0.7, sn_lv_mva=0.3, vk_hv_percent=1.,
+                                                vkr_hv_percent=.03, vk_mv_percent=.5,
+                                                vkr_mv_percent=.02, vk_lv_percent=.25,
+                                                vkr_lv_percent=.01, pfe_kw=.5, i0_percent=0.1,
+                                                name="test", index=pp.get_free_id(net.trafo3w) + 1,
+                                                tap_side="hv", tap_pos=2, tap_step_percent=1.25,
+                                                tap_min=-5, tap_neutral=0, tap_max=5)
     return (net, t3, hv, mv, lv)
         
     

--- a/pandapower/test/topology/test_create_graph.py
+++ b/pandapower/test/topology/test_create_graph.py
@@ -107,6 +107,9 @@ def test_trafo3w():
 
 def test_trafo3w_impedances(network_with_trafo3ws):
     net, t3, hv, mv, lv = network_with_trafo3ws
+    net.trafo3w.vn_hv_kv = 20
+    net.trafo3w.vn_mv_kv = 0.6
+    net.trafo3w.vn_lv_kv = 0.4
     t3 = net.trafo3w.index[0]
     mg = create_nxgraph(net, calc_z=True)
     trafo3 = net.trafo3w.loc[t3]

--- a/pandapower/test/topology/test_create_graph.py
+++ b/pandapower/test/topology/test_create_graph.py
@@ -3,16 +3,183 @@
 # Copyright (c) 2016-2018 by University of Kassel and Fraunhofer Institute for Energy Economics
 # and Energy System Technology (IEE), Kassel. All rights reserved.
 
-
-import numpy as np
-import pandapower as pp
+from itertools import combinations
 import pytest
-import pandapower.topology as top
-import pandapower.networks as nw
 
+from pandapower.topology import create_nxgraph
+import pandapower as pp
+import numpy as np
+from pandapower.test.loadflow.test_scenarios import network_with_trafo3ws
+from pandapower.test.loadflow.result_test_network_generator import add_test_trafo3w, \
+                                                                   add_test_trafo, add_test_line, \
+                                                                   add_test_impedance, \
+                                                                   add_test_bus_bus_switch
 
+def test_line():
+    net = pp.create_empty_network()
+    add_test_line(net)
+    line, open_loop_line, oos_line = net.line.index
+    f, t = net.line.from_bus.at[line], net.line.to_bus.at[line]
+    
+    #check that oos lines are neglected and switches are respected   
+    mg = create_nxgraph(net)
+    assert list(mg.get_edge_data(f, t).keys()) == [("line", line)]
 
-if __name__ == '__main__':
-    net = nw.example_multivoltage()
-    mg = top.create_nxgraph(net, calc_r_ohm=True)
-#    pytest.main([__file__])
+    #check respect_switches
+    mg = create_nxgraph(net, respect_switches=False)
+    assert list(mg.get_edge_data(f, t).keys()) == [("line", line), ("line", open_loop_line)]
+
+    #check not including lines
+    mg = create_nxgraph(net, include_lines=False)
+    assert mg.get_edge_data(f, t) is None
+    
+    #check edge attributes
+    mg = create_nxgraph(net, calc_z=True)
+    line_tab = net.line.loc[line]
+    par = mg.get_edge_data(f, t, key=("line", line))
+    r = line_tab.length_km / line_tab.parallel * line_tab.r_ohm_per_km
+    x = line_tab.length_km / line_tab.parallel * line_tab.x_ohm_per_km
+    z = np.sqrt(r**2 + x**2)
+    assert np.isclose(par["r_ohm"], r)
+    assert np.isclose(par["x_ohm"], x)
+    assert np.isclose(par["z_ohm"], z)
+    assert np.isclose(par["weight"], line_tab.length_km)
+    assert par["path"] == 1  
+
+def test_trafo():
+    net = pp.create_empty_network()
+    add_test_trafo(net)
+    trafo, open_loop_trafo, oos_trafo = net.trafo.index
+    f, t = net.trafo.hv_bus.at[trafo], net.trafo.lv_bus.at[trafo]
+    
+    #check that oos trafos are neglected and switches are respected
+    mg = create_nxgraph(net)
+    assert list(mg.get_edge_data(f, t).keys()) == [("trafo", trafo)]
+    
+    #check respect_switches
+    mg = create_nxgraph(net, respect_switches=False)
+    assert list(mg.get_edge_data(f, t).keys()) == [("trafo", trafo), ("trafo", open_loop_trafo)]
+
+    #check not including trafos
+    mg = create_nxgraph(net, include_trafos=False)
+    assert mg.get_edge_data(f, t) is None   
+
+    #check edge attributes
+    net.trafo.vn_hv_kv = 20
+    net.trafo.vn_lv_kv = 0.4
+    net.trafo.pfe_kw = 0
+    net.trafo.i0_percent = 0
+    mg = create_nxgraph(net, calc_z=True)
+    trafo_tab = net.trafo.loc[trafo]
+    par = mg.get_edge_data(f, t, key=("trafo", trafo))
+    base_Z=(trafo_tab.sn_mva) / (trafo_tab.vn_hv_kv ** 2)
+    r = (trafo_tab.vkr_percent/100) / base_Z / trafo_tab.parallel
+    z = (trafo_tab.vk_percent/100)  / base_Z / trafo_tab.parallel
+    assert np.isclose(par["r_ohm"], r)
+    assert np.isclose(par["z_ohm"], z)
+    assert par["weight"] == 0
+    assert par["path"] == 1  
+
+def test_trafo3w():
+    net = pp.create_empty_network()
+    add_test_trafo3w(net)
+    t1, t2 = net.trafo3w.index
+    trafo3 = net.trafo3w.iloc[t1]
+    hv, mv, lv = trafo3.hv_bus, trafo3.mv_bus, trafo3.lv_bus
+    mg = create_nxgraph(net)
+    for f, t in combinations([hv, mv, lv], 2):
+        assert list(mg.get_edge_data(f, t).keys()) == [("trafo3w", t1)]
+   
+    net.trafo3w.in_service.at[t2] = True
+    mg = create_nxgraph(net)
+    for f, t in combinations([hv, mv, lv], 2):
+        assert list(mg.get_edge_data(f, t).keys()) == [("trafo3w", t1), ("trafo3w", t2)]
+      
+    for sb in [hv, mv, lv]:
+        sw = pp.create_switch(net, bus=sb, element=t1, et="t3", closed=False)
+        mg = create_nxgraph(net)
+        for f, t in combinations([hv, mv, lv], 2):
+            if sb == f or t == sb:
+                assert list(mg.get_edge_data(f, t).keys()) == [("trafo3w", t2)]
+            else:
+                assert list(mg.get_edge_data(f, t).keys()) == [("trafo3w", t1), ("trafo3w", t2)]
+        net.switch.closed.at[sw] = True
+
+def test_trafo3w_impedances(network_with_trafo3ws):
+    net, t3, hv, mv, lv = network_with_trafo3ws
+    t3 = net.trafo3w.index[0]
+    mg = create_nxgraph(net, calc_z=True)
+    trafo3 = net.trafo3w.loc[t3]
+    hv, mv, lv = trafo3.hv_bus, trafo3.mv_bus, trafo3.lv_bus
+    base_Z_hv  = min(trafo3.sn_hv_mva, trafo3.sn_mv_mva) / (trafo3.vn_hv_kv ** 2)
+    base_Z_mv = min(trafo3.sn_mv_mva, trafo3.sn_lv_mva) / (trafo3.vn_hv_kv ** 2)
+    base_Z_lv = min(trafo3.sn_hv_mva, trafo3.sn_lv_mva) / (trafo3.vn_hv_kv ** 2)
+
+    par = mg.get_edge_data(hv, mv, key=("trafo3w", t3))
+    assert np.isclose(par["r_ohm"], (trafo3.vkr_hv_percent/100) / base_Z_hv)
+    assert np.isclose(par["z_ohm"], (trafo3.vk_hv_percent/100) / base_Z_hv)
+    assert par["weight"] == 0
+    assert par["path"] == 1
+    
+    par = mg.get_edge_data(mv, lv, key=("trafo3w", t3))
+    assert np.isclose(par["r_ohm"], (trafo3.vkr_mv_percent/100) / base_Z_mv)
+    assert np.isclose(par["z_ohm"], (trafo3.vk_mv_percent/100) / base_Z_mv)
+    assert par["weight"] == 0
+    assert par["path"] == 1    
+    
+    par = mg.get_edge_data(hv, lv, key=("trafo3w", t3))
+    assert np.isclose(par["r_ohm"], (trafo3.vkr_lv_percent/100) / base_Z_lv)
+    assert np.isclose(par["z_ohm"], (trafo3.vk_lv_percent/100) / base_Z_lv)
+    assert par["weight"] == 0
+    assert par["path"] == 1
+
+def test_impedance():
+    net = pp.create_empty_network()
+    add_test_impedance(net)
+    impedance, oos_impedance = net.impedance.index
+    f, t = net.impedance.from_bus.at[impedance], net.impedance.to_bus.at[impedance]
+    
+    #check that oos impedances are neglected and switches are respected   
+    mg = create_nxgraph(net)
+    assert list(mg.get_edge_data(f, t).keys()) == [("impedance", impedance)]
+
+    #check not including impedances
+    mg = create_nxgraph(net, include_impedances=False)
+    assert mg.get_edge_data(f, t) is None
+    
+    #check edge attributes
+    mg = create_nxgraph(net, calc_z=True)
+    #TODO check R/X/Z values
+    par = mg.get_edge_data(f, t, key=("impedance", impedance))
+    assert np.isclose(par["weight"], 0)
+    assert par["path"] == 1  
+
+def test_bus_bus_switches():
+    net = pp.create_empty_network()
+    add_test_bus_bus_switch(net)
+    s = net.switch.index[0]
+    f, t = net.switch.bus.iloc[0], net.switch.element.iloc[0]
+    
+    net.switch.closed.at[s] = True
+    mg = create_nxgraph(net)
+    assert list(mg.get_edge_data(f, t)) == [("switch", s)]
+
+    net.switch.closed.at[s] = False
+    mg = create_nxgraph(net)
+    assert mg.get_edge_data(f, t) is None
+    
+    mg = create_nxgraph(net, respect_switches=False)
+    assert list(mg.get_edge_data(f, t)) == [("switch", s)]
+
+def test_nogo():
+    net = pp.create_empty_network()
+    add_test_line(net)
+    mg = create_nxgraph(net)
+    bus_index = net.bus.index.tolist()
+    assert list(mg.nodes()) == bus_index
+    mg = create_nxgraph(net, nogobuses=[0])
+    bus_index.remove(0)
+    assert list(mg.nodes()) == bus_index 
+
+if __name__ == '__main__':  
+    pytest.main(__file__)

--- a/pandapower/test/topology/test_create_graph.py
+++ b/pandapower/test/topology/test_create_graph.py
@@ -23,11 +23,11 @@ def test_line():
     
     #check that oos lines are neglected and switches are respected   
     mg = create_nxgraph(net)
-    assert list(mg.get_edge_data(f, t).keys()) == [("line", line)]
+    assert set(mg.get_edge_data(f, t).keys()) == {("line", line)}
 
     #check respect_switches
     mg = create_nxgraph(net, respect_switches=False)
-    assert list(mg.get_edge_data(f, t).keys()) == [("line", line), ("line", open_loop_line)]
+    assert set(mg.get_edge_data(f, t).keys()) == {("line", line), ("line", open_loop_line)}
 
     #check not including lines
     mg = create_nxgraph(net, include_lines=False)
@@ -54,11 +54,11 @@ def test_trafo():
     
     #check that oos trafos are neglected and switches are respected
     mg = create_nxgraph(net)
-    assert list(mg.get_edge_data(f, t).keys()) == [("trafo", trafo)]
+    assert set(mg.get_edge_data(f, t).keys()) == {("trafo", trafo)}
     
     #check respect_switches
     mg = create_nxgraph(net, respect_switches=False)
-    assert list(mg.get_edge_data(f, t).keys()) == [("trafo", trafo), ("trafo", open_loop_trafo)]
+    assert set(mg.get_edge_data(f, t).keys()) == {("trafo", trafo), ("trafo", open_loop_trafo)}
 
     #check not including trafos
     mg = create_nxgraph(net, include_trafos=False)
@@ -88,21 +88,21 @@ def test_trafo3w():
     hv, mv, lv = trafo3.hv_bus, trafo3.mv_bus, trafo3.lv_bus
     mg = create_nxgraph(net)
     for f, t in combinations([hv, mv, lv], 2):
-        assert list(mg.get_edge_data(f, t).keys()) == [("trafo3w", t1)]
+        assert set(mg.get_edge_data(f, t).keys()) == {("trafo3w", t1)}
    
     net.trafo3w.in_service.at[t2] = True
     mg = create_nxgraph(net)
     for f, t in combinations([hv, mv, lv], 2):
-        assert list(mg.get_edge_data(f, t).keys()) == [("trafo3w", t1), ("trafo3w", t2)]
+        assert set(mg.get_edge_data(f, t).keys()) == {("trafo3w", t1), ("trafo3w", t2)}
       
     for sb in [hv, mv, lv]:
         sw = pp.create_switch(net, bus=sb, element=t1, et="t3", closed=False)
         mg = create_nxgraph(net)
         for f, t in combinations([hv, mv, lv], 2):
             if sb == f or t == sb:
-                assert list(mg.get_edge_data(f, t).keys()) == [("trafo3w", t2)]
+                assert set(mg.get_edge_data(f, t).keys()) == {("trafo3w", t2)}
             else:
-                assert list(mg.get_edge_data(f, t).keys()) == [("trafo3w", t1), ("trafo3w", t2)]
+                assert set(mg.get_edge_data(f, t).keys()) == {("trafo3w", t1), ("trafo3w", t2)}
         net.switch.closed.at[sw] = True
 
 def test_trafo3w_impedances(network_with_trafo3ws):
@@ -144,7 +144,7 @@ def test_impedance():
     
     #check that oos impedances are neglected and switches are respected   
     mg = create_nxgraph(net)
-    assert list(mg.get_edge_data(f, t).keys()) == [("impedance", impedance)]
+    assert set(mg.get_edge_data(f, t).keys()) == {("impedance", impedance)}
 
     #check not including impedances
     mg = create_nxgraph(net, include_impedances=False)
@@ -165,14 +165,14 @@ def test_bus_bus_switches():
     
     net.switch.closed.at[s] = True
     mg = create_nxgraph(net)
-    assert list(mg.get_edge_data(f, t)) == [("switch", s)]
+    assert set(mg.get_edge_data(f, t)) == {("switch", s)}
 
     net.switch.closed.at[s] = False
     mg = create_nxgraph(net)
     assert mg.get_edge_data(f, t) is None
     
     mg = create_nxgraph(net, respect_switches=False)
-    assert list(mg.get_edge_data(f, t)) == [("switch", s)]
+    assert set(mg.get_edge_data(f, t)) == {("switch", s)}
 
 def test_nogo():
     net = pp.create_empty_network()

--- a/pandapower/topology/create_graph.py
+++ b/pandapower/topology/create_graph.py
@@ -105,7 +105,7 @@ def create_nxgraph(net, respect_switches=True, include_lines=True,
         if respect_switches:
             mask = (net.switch.et.values == "l") & open_sw
             if mask.any():
-                open_switch = np.isin(indices[:, INDEX], net.switch.element.values[mask])
+                open_switch = np.in1d(indices[:, INDEX], net.switch.element.values[mask])
                 in_service &= ~open_switch
 
         parameter[:, WEIGHT] = line.length_km.values
@@ -142,7 +142,7 @@ def create_nxgraph(net, respect_switches=True, include_lines=True,
             if respect_switches:
                 mask = (net.switch.et.values == "t") & open_sw
                 if mask.any():
-                    open_switch = np.isin(indices[:, INDEX], net.switch.element.values[mask])
+                    open_switch = np.in1d(indices[:, INDEX], net.switch.element.values[mask])
                     in_service &= ~open_switch
 
             if calc_z:
@@ -166,7 +166,7 @@ def create_nxgraph(net, respect_switches=True, include_lines=True,
             if respect_switches:
                 mask = (net.switch.et.values == "t3") & open_sw
                 if mask.any():
-                    open_switch = np.isin(net.trafo3w.index, net.switch.element.values[mask])
+                    open_switch = np.in1d(net.trafo3w.index, net.switch.element.values[mask])
                     open_element_bus_combos = net.switch[["element", "bus"]].values[mask].tolist()
             for f, t in combinations(sides, 2):
                 indices, parameter, in_service = init_par(trafo3w, calc_z)

--- a/pandapower/topology/create_graph.py
+++ b/pandapower/topology/create_graph.py
@@ -13,23 +13,29 @@ except ImportError:
 
 from pandapower.pd2ppc import _init_ppc
 from pandapower.auxiliary import _init_runpp_options, _select_is_elements_numba 
-from pandapower.idx_brch import BR_R, BR_X, F_BUS, T_BUS
 from pandapower.idx_bus import BASE_KV
 
 from pandapower.build_branch import _calc_impedance_parameters_from_dataframe,\
                                     _calc_branch_values_from_trafo_df, \
                                     _trafo_df_from_trafo3w
 from pandapower.build_bus import _build_bus_ppc
-BR_Z = 4
-WEIGHT = 5
-INDEX = 6
+
+INDEX = 0
+F_BUS = 1
+T_BUS = 2
+
+WEIGHT = 0
+BR_R = 1
+BR_X = 2
+BR_Z = 3
+
 logger = logging.getLogger(__name__)
 
 
 def create_nxgraph(net, respect_switches=True, include_lines=True,
                    include_trafos=True, include_impedances=True,
                    nogobuses=None, notravbuses=None, multi=True,
-                   add_impedances=False):
+                   calc_z=False):
     """
      Converts a pandapower network into a NetworkX graph, which is a is a simplified representation
      of a network's topology, reduced to nodes and edges. Busses are being represented by nodes
@@ -85,83 +91,113 @@ def create_nxgraph(net, respect_switches=True, include_lines=True,
     else:
         mg = nx.Graph()
     mg.add_nodes_from(net.bus.index)
-    
-    if add_impedances:
-        ppc = get_nx_ppc(net)
-    if respect_switches:
-        closed_sw = net.switch.closed.values == False
+   
+    open_sw = net.switch.closed.values == False   
+    if calc_z:
+        ppc = get_nx_ppc(net)        
+        
     if include_lines:        
-        if respect_switches:
-            mask = (net.switch.et.values == "l") & closed_sw
-            nogolines = set(net.switch.element.values[mask])
-        else:
-            nogolines = None
         line = net.line
-        edge_par = init_par(line)
-        edge_par[:, F_BUS] = line.from_bus.values
-        edge_par[:, T_BUS] = line.to_bus.values
-        if add_impedances:
+        indices, parameter, in_service = init_par(line, calc_z)
+        indices[:, F_BUS] = line.from_bus.values
+        indices[:, T_BUS] = line.to_bus.values
+
+        if respect_switches:
+            mask = (net.switch.et.values == "l") & open_sw
+            if mask.any():
+                open_switch = np.isin(indices[:, INDEX], net.switch.element.values[mask])
+                in_service &= ~open_switch
+
+        parameter[:, WEIGHT] = line.length_km.values
+        if calc_z:
             line_length = line.length_km.values / line.parallel.values
             r = line.r_ohm_per_km.values * line_length
             x = line.x_ohm_per_km.values * line_length
-            edge_par[:, BR_R] = r
-            edge_par[:, BR_X] = x
-        edge_par[:, WEIGHT] = line.length_km.values
-        add_edges(mg, edge_par, net, "line", add_impedances, nogolines)
+            parameter[:, BR_R] = r
+            parameter[:, BR_X] = x
+            
+        add_edges(mg, indices, parameter, in_service, net, "line", calc_z)
 
     if include_impedances and len(net.impedance):
         impedance = net.impedance
-        edge_par = init_par(impedance)
-        edge_par[:, F_BUS] = impedance.from_bus.values
-        edge_par[:, T_BUS] = impedance.to_bus.values
-        if add_impedances:
-            baseR = get_baseR(net, ppc, impedance.bus.values)
+        indices, parameter, in_service = init_par(impedance, calc_z)
+        indices[:, F_BUS] = impedance.from_bus.values
+        indices[:, T_BUS] = impedance.to_bus.values
+        
+        if calc_z:
+            baseR = get_baseR(net, ppc, impedance.from_bus.values)
             r, x, _, _ = _calc_impedance_parameters_from_dataframe(net)
-            edge_par[:, BR_R] = r
-            edge_par[:, BR_X] = x
-        add_edges(mg, edge_par, net, "impedance", add_impedances)
+            parameter[:, BR_R] = r * baseR
+            parameter[:, BR_X] = x * baseR
+            
+        add_edges(mg, indices, parameter, in_service, net, "impedance", calc_z)
         
     if include_trafos:
         trafo = net.trafo
         if len(trafo.index):
+            indices, parameter, in_service = init_par(trafo, calc_z)
+            indices[:, F_BUS] = trafo.hv_bus.values
+            indices[:, T_BUS] = trafo.lv_bus.values
+    
             if respect_switches:
-                mask = (net.switch.et.values == "t") & closed_sw
-                nogotrafos = set(net.switch.element.values[mask])
-            else:
-                nogotrafos = None
-            edge_par = init_par(trafo)
-            edge_par[:, F_BUS] = trafo.hv_bus.values
-            edge_par[:, T_BUS] = trafo.lv_bus.values
-            if add_impedances:
+                mask = (net.switch.et.values == "t") & open_sw
+                if mask.any():
+                    open_switch = np.isin(indices[:, INDEX], net.switch.element.values[mask])
+                    in_service &= ~open_switch
+
+            if calc_z:
                 baseR = get_baseR(net, ppc, trafo.hv_bus.values)
                 r, x, _, _, _ = _calc_branch_values_from_trafo_df(net, ppc, trafo)
-                edge_par[:, BR_R] = r * baseR
-                edge_par[:, BR_X] = x * baseR
-            add_edges(mg, edge_par, net, "trafo", add_impedances, nogotrafos)
+                parameter[:, BR_R] = r * baseR
+                parameter[:, BR_X] = x * baseR
+            
+            add_edges(mg, indices, parameter, in_service, net, "trafo", calc_z)
 
         trafo3w = net.trafo3w
         if len(trafo3w):
-            if respect_switches:
-                mask = (net.switch.et.values == "t3") & closed_sw
-                nogotrafo3w = net.switch[["element", "bus"]].values[mask].tolist()
-            else:
-                nogotrafo3w = None
             sides = ["hv", "mv", "lv"]
-            if add_impedances:     
+            if calc_z:     
                 trafo_df = _trafo_df_from_trafo3w(net)
                 r_all, x_all, _, _, _ = _calc_branch_values_from_trafo_df(net, ppc, trafo_df)
                 r = {side: r for side, r in zip(sides, np.split(r_all, 3))}
                 x = {side: x for side, x in zip(sides, np.split(x_all, 3))}
                 baseR = get_baseR(net, ppc, trafo3w.hv_bus.values)
+            open_switch = np.zeros(trafo3w.shape[0], dtype=bool)
+            if respect_switches:
+                mask = (net.switch.et.values == "t3") & open_sw
+                if mask.any():
+                    open_switch = np.isin(net.trafo3w.index, net.switch.element.values[mask])
+                    open_element_bus_combos = net.switch[["element", "bus"]].values[mask].tolist()
             for f, t in combinations(sides, 2):
-                edge_par = init_par(trafo3w)
-                edge_par[:, F_BUS] = trafo3w["%s_bus"%f].values
-                edge_par[:, T_BUS] = trafo3w["%s_bus"%t].values
-                if add_impedances:     
-                    edge_par[:, BR_R] = (r[f] + r[t]) * baseR
-                    edge_par[:, BR_X] = (x[f] + x[t]) * baseR
-                add_edges(mg, edge_par, net, "trafo3w", add_impedances, 
-                          nogotrafo3w)
+                indices, parameter, in_service = init_par(trafo3w, calc_z)
+                indices[:, F_BUS] = trafo3w["%s_bus"%f].values
+                indices[:, T_BUS] = trafo3w["%s_bus"%t].values
+                
+                if open_switch.any():
+                    no_branch_at = [([b[INDEX], b[F_BUS]] in open_element_bus_combos or
+                                     [b[INDEX], b[T_BUS]] in open_element_bus_combos) 
+                                      for b in indices[open_switch]]
+                    in_service[open_switch] = ~np.array(no_branch_at)
+                
+                if calc_z:     
+                    parameter[:, BR_R] = (r[f] + r[t]) * baseR
+                    parameter[:, BR_X] = (x[f] + x[t]) * baseR
+                        
+                add_edges(mg, indices, parameter, in_service, net, "trafo3w", calc_z)
+
+
+    switch = net.switch
+    if len(switch):
+        if respect_switches:
+            # add edges for closed bus-bus switches
+            in_service = (switch.et.values == "b") & ~open_sw
+        else:
+            # add edges for any bus-bus switches
+            in_service = (switch.et.values == "b")
+        indices, parameter = init_par(switch, calc_z)
+        indices[:, F_BUS] = switch.bus.values
+        indices[:, T_BUS] = switch.element.values
+        add_edges(mg, indices, parameter, in_service, net, "switch", calc_z)
                 
     # nogobuses are a nogo
     if nogobuses is not None:
@@ -177,35 +213,38 @@ def create_nxgraph(net, respect_switches=True, include_lines=True,
     mg.remove_nodes_from(net.bus.index[~net.bus.in_service.values])
     return mg
 
-def add_edges(mg, parameters, net, element, add_impedances, nogo=None):
-    parameters[:, BR_Z] = np.sqrt(parameters[:, BR_R]**2 + parameters[:, BR_X]**2)
-    is_par = parameters[net[element].in_service.values]
-    for p in is_par:
-        fb = int(p[F_BUS])
-        tb = int(p[T_BUS])
-        index = int(p[INDEX])
-        if nogo is not None:
-            #for trafo3w the bus of the open switch is relevant
-            if element == "trafo3w":
-                #don't add an edge with an open switch
-                if [index, fb] in nogo or [index, tb] in nogo:
-                    continue        
-            elif index in nogo:
-                continue
-        weights = {"weight": p[WEIGHT], "path": 1}
-        if add_impedances:
-            weights.update({"r_ohm": p[BR_R], "x_ohm": p[BR_X], "z_ohm": p[BR_Z]})   
-        mg.add_edge(fb, tb, key=(element, index),  **weights)
+
+def add_edges(mg, indices, parameter, in_service, net, element, calc_z):
+    if calc_z:
+        parameter[:, BR_Z] = np.sqrt(parameter[:, BR_R]**2 + parameter[:, BR_X]**2)
+    for idx, p in zip(indices[in_service], parameter[in_service]):
+        if calc_z:
+            weights = {"weight": p[WEIGHT], "path": 1, "r_ohm": p[BR_R], "x_ohm": p[BR_X],
+                       "z_ohm": p[BR_Z]}
+        else:
+             weights = {"weight": p[WEIGHT], "path": 1}           
+        mg.add_edge(idx[F_BUS], idx[T_BUS], key=(element, idx[INDEX]),  **weights)
+
 
 def get_baseR(net, ppc, buses):
     bus_lookup = net._pd2ppc_lookups["bus"]
     base_kv = ppc["bus"][bus_lookup[buses], BASE_KV]
     return np.square(base_kv) / net.sn_mva
+  
     
-def init_par(tab):
-    parameters = np.zeros((tab.shape[0], 8))
-    parameters[:, INDEX] = tab.index
-    return parameters
+def init_par(tab, calc_z):
+    n = tab.shape[0]
+    indices = np.zeros((n, 3), dtype=np.int)
+    indices[:, INDEX] = tab.index
+    if calc_z:
+        parameters = np.zeros((n, 4), dtype=np.float)
+    else:
+        parameters = np.zeros((n, 1), dtype=np.float)
+    
+    if "in_service" in tab:
+        return indices, parameters, tab.in_service.values.copy()
+    else:
+        return indices, parameters
             
 
 def get_nx_ppc(net):
@@ -218,44 +257,3 @@ def get_nx_ppc(net):
     ppc = _init_ppc(net)
     _build_bus_ppc(net, ppc)
     return ppc
-
-    
-if __name__ == '__main__':
-    import pandapower.networks as nw
-    net = nw.case9241pegase()
-    net = nw.mv_oberrhein(include_substations=True)
-#    net = nw.example_simple()
-#    pp.runpp(net)
-#    net.line.at[0, "in_service"] = False
-
-#    ppc = get_nx_ppc(net)
-#    
-#    line = net.line
-#    r = line.r_ohm_per_km.values * line.length_km.values / line.parallel.values
-#    x = line.x_ohm_per_km.values * line.length_km.values / line.parallel.values
-#    
-##    pp.runpp(net)
-#
-##    line = net.line.iloc[0]
-##    print(mg.get_edge_data(line.from_bus, line.to_bus))
-##    
-##    trafo = net.trafo.iloc[0]
-##    print(mg.get_edge_data(trafo.hv_bus, trafo.lv_bus))
-#    
-#    
-    net = nw.example_multivoltage()
-    trafo3 = net.trafo3w.iloc[0]
-#    pp.create_switch(net, bus=trafo3.mv_bus, element=0, et="t3", closed=False)
-
-    mg = create_nxgraph(net)
-    print(mg.get_edge_data(trafo3.hv_bus, trafo3.lv_bus))
-
-    print(mg.get_edge_data(trafo3.hv_bus, trafo3.mv_bus))
-
-    print(mg.get_edge_data(trafo3.mv_bus, trafo3.lv_bus))
-#    r, x, z = get_z_from_ppc(net)
-#    f, t = net._pd2ppc_lookups["branch"]["trafo"]
-#    pp.runpp(net)
-#    print(net._ppc["branch"][f, BR_R])
-#    print(net._ppc["branch"][f, BR_X])
-#    max(r[f:t] - (net.line.length_km*net.line.r_ohm_per_km).values)

--- a/pandapower/topology/create_graph.py
+++ b/pandapower/topology/create_graph.py
@@ -5,18 +5,31 @@
 
 import networkx as nx
 import numpy as np
-
+from itertools import combinations
 try:
     import pplog as logging
 except ImportError:
     import logging
 
+from pandapower.pd2ppc import _init_ppc
+from pandapower.auxiliary import _init_runpp_options, _select_is_elements_numba 
+from pandapower.idx_brch import BR_R, BR_X, F_BUS, T_BUS
+from pandapower.idx_bus import BASE_KV
+
+from pandapower.build_branch import _calc_impedance_parameters_from_dataframe,\
+                                    _calc_branch_values_from_trafo_df, \
+                                    _trafo_df_from_trafo3w
+from pandapower.build_bus import _build_bus_ppc
+BR_Z = 4
+WEIGHT = 5
+INDEX = 6
 logger = logging.getLogger(__name__)
 
 
-def create_nxgraph(net, respect_switches=True, include_lines=True, include_trafos=True,
-                   include_impedances=True, nogobuses=None, notravbuses=None, multi=True,
-                   calc_r_ohm=False, calc_z_ohm=False):
+def create_nxgraph(net, respect_switches=True, include_lines=True,
+                   include_trafos=True, include_impedances=True,
+                   nogobuses=None, notravbuses=None, multi=True,
+                   add_impedances=False):
     """
      Converts a pandapower network into a NetworkX graph, which is a is a simplified representation
      of a network's topology, reduced to nodes and edges. Busses are being represented by nodes
@@ -72,126 +85,84 @@ def create_nxgraph(net, respect_switches=True, include_lines=True, include_trafo
     else:
         mg = nx.Graph()
     mg.add_nodes_from(net.bus.index)
-    if include_lines:
-        # lines with open switches can be excluded
-        nogolines = set(net.switch.element[
-            (net.switch.et == "l") & (net.switch.closed == 0)]) if respect_switches else set()
-
-        line_edge_data=net.line[net.line.in_service & ~net.line.index.isin(nogolines)]
-
-        if calc_r_ohm:
-            line_edge_data['R_ohm']=net.line.r_ohm_per_km * net.line.length_km
-        if calc_z_ohm:
-            line_edge_data['Z_ohm']=np.sqrt((net.line.r_ohm_per_km * net.line.length_km) ** 2 + (net.line.x_ohm_per_km * net.line.length_km) ** 2)
-
-        for line in line_edge_data.itertuples():
-            weights={'weight': line.length_km, 'path': 1}
-            if calc_r_ohm:
-                weights['R_ohm']=line.R_ohm
-            if calc_z_ohm:
-                weights['Z_ohm']=line.Z_ohm
-            mg.add_edge(line.from_bus, line.to_bus, key=('line', line.Index), **weights)
-
-    if include_impedances:
-        # due to changed behaviour: give a warning to the user
-        if not include_lines and len(net.impedance) > 0:
-            logger.warning('Change notice: per unit impedance elements are included in the graph, '
-                           'even though lines are not. If this behaviour is undesired, set the '
-                           'parameter "include_impedances" to False')
-
-        imp_edge_data=net.impedance[net.impedance.in_service]
-
-        if calc_r_ohm or calc_z_ohm:
-            base_Z=(net.sn_mva) / net.bus.loc[imp_edge_data.from_bus].vn_kv.values ** 2
-        if calc_r_ohm:
-            imp_edge_data['R_ohm']=imp_edge_data.rft_pu.abs() / base_Z
-        if calc_z_ohm:
-            imp_edge_data['Z_ohm']=np.sqrt(imp_edge_data.rft_pu ** 2 + imp_edge_data.xft_pu ** 2) / base_Z
-
-        for imp in imp_edge_data.itertuples():
-            weights={'weight': 0, 'path': 1}
-            if calc_r_ohm:
-                weights['R_ohm']=imp.R_ohm
-            if calc_z_ohm:
-                weights['Z_ohm']=imp.Z_ohm
-            mg.add_edge(imp.from_bus, imp.to_bus, key=('impedance', imp.Index), **weights)
-
-    if include_trafos:
-        nogotrafos = set(net.switch.element[
-            (net.switch.et == "t") & (net.switch.closed == 0)]) if respect_switches else set()
-
-        trafo_edge_data=net.trafo[net.trafo.in_service & ~net.trafo.index.isin(nogotrafos)]
-
-        if calc_r_ohm or calc_z_ohm:
-            base_Z=(trafo_edge_data.sn_mva) / (trafo_edge_data.vn_hv_kv ** 2)
-        if calc_r_ohm:
-            trafo_edge_data['R_ohm']=(trafo_edge_data.vkr_percent/100) / base_Z
-        if calc_z_ohm:
-            trafo_edge_data['Z_ohm']=(trafo_edge_data.vk_percent/100)  / base_Z
-
-        for trafo in trafo_edge_data.itertuples():
-            weights={'weight': 0}
-            if calc_r_ohm:
-                weights['R_ohm']=trafo.R_ohm
-            if calc_z_ohm:
-                weights['Z_ohm']=trafo.Z_ohm
-            mg.add_edge(trafo.hv_bus, trafo.lv_bus, key=('trafo', trafo.Index), **weights)
-
-        #Three-winding transformers:
-        trafo3w_edge_data=net.trafo3w[net.trafo3w.in_service]
-
-        if calc_r_ohm or calc_z_ohm:
-            if (any(trafo3w_edge_data.hv_bus == trafo3w_edge_data.mv_bus) |
-                any(trafo3w_edge_data.mv_bus == trafo3w_edge_data.lv_bus) |
-                any(trafo3w_edge_data.hv_bus == trafo3w_edge_data.lv_bus)):
-                raise UserWarning("A three-winding transformer has two sides connected "
-                                  "to the same bus. Resistanc/impedance calculation as "
-                                  "edge weight is not implemented for this case!")
-
-            base_Z_hv = (trafo3w_edge_data[['sn_hv_mva', 'sn_mv_mva']].min(axis=1)) / (trafo3w_edge_data.vn_hv_kv ** 2)
-            base_Z_mv = (trafo3w_edge_data[['sn_mv_mva', 'sn_lv_mva']].min(axis=1)) / (trafo3w_edge_data.vn_hv_kv ** 2)
-            base_Z_lv = (trafo3w_edge_data[['sn_hv_mva', 'sn_lv_mva']].min(axis=1)) / (trafo3w_edge_data.vn_hv_kv ** 2)
-        if calc_r_ohm:
-            trafo3w_edge_data['R_hv_ohm']= (trafo3w_edge_data.vkr_hv_percent/100) / base_Z_hv
-            trafo3w_edge_data['R_mv_ohm']= (trafo3w_edge_data.vkr_mv_percent/100) / base_Z_mv
-            trafo3w_edge_data['R_lv_ohm']= (trafo3w_edge_data.vkr_lv_percent/100) / base_Z_lv
-        if calc_z_ohm:
-            trafo3w_edge_data['Z_hv_ohm']= (trafo3w_edge_data.vk_hv_percent/100) / base_Z_hv
-            trafo3w_edge_data['Z_mv_ohm']= (trafo3w_edge_data.vk_mv_percent/100) / base_Z_mv
-            trafo3w_edge_data['Z_lv_ohm']= (trafo3w_edge_data.vk_lv_percent/100) / base_Z_lv
-
-        for trafo3w in trafo3w_edge_data.itertuples():
-            weights_hv={'weight': 0}
-            weights_mv={'weight': 0}
-            weights_lv={'weight': 0}
-            if calc_r_ohm:
-                weights_hv['R_ohm']=trafo3w.R_hv_ohm
-                weights_mv['R_ohm']=trafo3w.R_mv_ohm
-                weights_lv['R_ohm']=trafo3w.R_lv_ohm
-            if calc_z_ohm:
-                weights_hv['Z_ohm']=trafo3w.Z_hv_ohm
-                weights_mv['Z_ohm']=trafo3w.Z_mv_ohm
-                weights_lv['Z_ohm']=trafo3w.Z_lv_ohm
-
-            mg.add_edge(trafo3w.hv_bus, trafo3w.mv_bus, key=('trafo3w', trafo3w.Index), **weights_hv)
-            mg.add_edge(trafo3w.mv_bus, trafo3w.lv_bus, key=('trafo3w', trafo3w.Index), **weights_mv)
-            mg.add_edge(trafo3w.hv_bus, trafo3w.lv_bus, key=('trafo3w', trafo3w.Index), **weights_lv)
-
+    
+    if add_impedances:
+        ppc = get_nx_ppc(net)
     if respect_switches:
-        # add edges for closed bus-bus switches
-        bs = net.switch[(net.switch.et == "b") & (net.switch.closed == 1)]
-    else:
-        # add edges for any bus-bus switches
-        bs = net.switch[net.switch.et == "b"]
+        closed_sw = net.switch.closed.values == False
+    if include_lines:        
+        if respect_switches:
+            mask = (net.switch.et.values == "l") & closed_sw
+            nogolines = set(net.switch.element.values[mask])
+        else:
+            nogolines = None
+        line = net.line
+        edge_par = init_par(line)
+        edge_par[:, F_BUS] = line.from_bus.values
+        edge_par[:, T_BUS] = line.to_bus.values
+        if add_impedances:
+            line_length = line.length_km.values / line.parallel.values
+            r = line.r_ohm_per_km.values * line_length
+            x = line.x_ohm_per_km.values * line_length
+            edge_par[:, BR_R] = r
+            edge_par[:, BR_X] = x
+        edge_par[:, WEIGHT] = line.length_km.values
+        add_edges(mg, edge_par, net, "line", add_impedances, nogolines)
 
-    for switch in bs.itertuples():
-        weights={"weight": 0}
-        if calc_r_ohm:
-            weights['R_ohm']=0
-        if calc_z_ohm:
-            weights['Z_ohm']=0
-        mg.add_edge(switch.bus, switch.element, key=('switch', switch.Index), **weights)
+    if include_impedances and len(net.impedance):
+        impedance = net.impedance
+        edge_par = init_par(impedance)
+        edge_par[:, F_BUS] = impedance.from_bus.values
+        edge_par[:, T_BUS] = impedance.to_bus.values
+        if add_impedances:
+            baseR = get_baseR(net, ppc, impedance.bus.values)
+            r, x, _, _ = _calc_impedance_parameters_from_dataframe(net)
+            edge_par[:, BR_R] = r
+            edge_par[:, BR_X] = x
+        add_edges(mg, edge_par, net, "impedance", add_impedances)
+        
+    if include_trafos:
+        trafo = net.trafo
+        if len(trafo.index):
+            if respect_switches:
+                mask = (net.switch.et.values == "t") & closed_sw
+                nogotrafos = set(net.switch.element.values[mask])
+            else:
+                nogotrafos = None
+            edge_par = init_par(trafo)
+            edge_par[:, F_BUS] = trafo.hv_bus.values
+            edge_par[:, T_BUS] = trafo.lv_bus.values
+            if add_impedances:
+                baseR = get_baseR(net, ppc, trafo.hv_bus.values)
+                r, x, _, _, _ = _calc_branch_values_from_trafo_df(net, ppc, trafo)
+                edge_par[:, BR_R] = r * baseR
+                edge_par[:, BR_X] = x * baseR
+            add_edges(mg, edge_par, net, "trafo", add_impedances, nogotrafos)
 
+        trafo3w = net.trafo3w
+        if len(trafo3w):
+            if respect_switches:
+                mask = (net.switch.et.values == "t3") & closed_sw
+                nogotrafo3w = net.switch[["element", "bus"]].values[mask].tolist()
+            else:
+                nogotrafo3w = None
+            sides = ["hv", "mv", "lv"]
+            if add_impedances:     
+                trafo_df = _trafo_df_from_trafo3w(net)
+                r_all, x_all, _, _, _ = _calc_branch_values_from_trafo_df(net, ppc, trafo_df)
+                r = {side: r for side, r in zip(sides, np.split(r_all, 3))}
+                x = {side: x for side, x in zip(sides, np.split(x_all, 3))}
+                baseR = get_baseR(net, ppc, trafo3w.hv_bus.values)
+            for f, t in combinations(sides, 2):
+                edge_par = init_par(trafo3w)
+                edge_par[:, F_BUS] = trafo3w["%s_bus"%f].values
+                edge_par[:, T_BUS] = trafo3w["%s_bus"%t].values
+                if add_impedances:     
+                    edge_par[:, BR_R] = (r[f] + r[t]) * baseR
+                    edge_par[:, BR_X] = (x[f] + x[t]) * baseR
+                add_edges(mg, edge_par, net, "trafo3w", add_impedances, 
+                          nogotrafo3w)
+                
     # nogobuses are a nogo
     if nogobuses is not None:
         for b in nogobuses:
@@ -203,5 +174,88 @@ def create_nxgraph(net, respect_switches=True, include_lines=True, include_trafo
                     del mg[b][i]  # networkx versions < 2.0
                 except:
                     del mg._adj[b][i]  # networkx versions 2.0
-    mg.remove_nodes_from(net.bus[~net.bus.in_service].index)
+    mg.remove_nodes_from(net.bus.index[~net.bus.in_service.values])
     return mg
+
+def add_edges(mg, parameters, net, element, add_impedances, nogo=None):
+    parameters[:, BR_Z] = np.sqrt(parameters[:, BR_R]**2 + parameters[:, BR_X]**2)
+    is_par = parameters[net[element].in_service.values]
+    for p in is_par:
+        fb = int(p[F_BUS])
+        tb = int(p[T_BUS])
+        index = int(p[INDEX])
+        if nogo is not None:
+            #for trafo3w the bus of the open switch is relevant
+            if element == "trafo3w":
+                #don't add an edge with an open switch
+                if [index, fb] in nogo or [index, tb] in nogo:
+                    continue        
+            elif index in nogo:
+                continue
+        weights = {"weight": p[WEIGHT], "path": 1}
+        if add_impedances:
+            weights.update({"r_ohm": p[BR_R], "x_ohm": p[BR_X], "z_ohm": p[BR_Z]})   
+        mg.add_edge(fb, tb, key=(element, index),  **weights)
+
+def get_baseR(net, ppc, buses):
+    bus_lookup = net._pd2ppc_lookups["bus"]
+    base_kv = ppc["bus"][bus_lookup[buses], BASE_KV]
+    return np.square(base_kv) / net.sn_mva
+    
+def init_par(tab):
+    parameters = np.zeros((tab.shape[0], 8))
+    parameters[:, INDEX] = tab.index
+    return parameters
+            
+
+def get_nx_ppc(net):
+    _init_runpp_options(net, algorithm='nr', calculate_voltage_angles="auto",
+                        init="auto", max_iteration="auto", tolerance_mva=1e-8,
+                        trafo_model="t", trafo_loading="current",
+                        enforce_q_lims=False, check_connectivity=True,
+                        voltage_depend_loads=True)
+    net["_is_elements"] = _select_is_elements_numba(net)
+    ppc = _init_ppc(net)
+    _build_bus_ppc(net, ppc)
+    return ppc
+
+    
+if __name__ == '__main__':
+    import pandapower.networks as nw
+    net = nw.case9241pegase()
+    net = nw.mv_oberrhein(include_substations=True)
+#    net = nw.example_simple()
+#    pp.runpp(net)
+#    net.line.at[0, "in_service"] = False
+
+#    ppc = get_nx_ppc(net)
+#    
+#    line = net.line
+#    r = line.r_ohm_per_km.values * line.length_km.values / line.parallel.values
+#    x = line.x_ohm_per_km.values * line.length_km.values / line.parallel.values
+#    
+##    pp.runpp(net)
+#
+##    line = net.line.iloc[0]
+##    print(mg.get_edge_data(line.from_bus, line.to_bus))
+##    
+##    trafo = net.trafo.iloc[0]
+##    print(mg.get_edge_data(trafo.hv_bus, trafo.lv_bus))
+#    
+#    
+    net = nw.example_multivoltage()
+    trafo3 = net.trafo3w.iloc[0]
+#    pp.create_switch(net, bus=trafo3.mv_bus, element=0, et="t3", closed=False)
+
+    mg = create_nxgraph(net)
+    print(mg.get_edge_data(trafo3.hv_bus, trafo3.lv_bus))
+
+    print(mg.get_edge_data(trafo3.hv_bus, trafo3.mv_bus))
+
+    print(mg.get_edge_data(trafo3.mv_bus, trafo3.lv_bus))
+#    r, x, z = get_z_from_ppc(net)
+#    f, t = net._pd2ppc_lookups["branch"]["trafo"]
+#    pp.runpp(net)
+#    print(net._ppc["branch"][f, BR_R])
+#    print(net._ppc["branch"][f, BR_X])
+#    max(r[f:t] - (net.line.length_km*net.line.r_ohm_per_km).values)


### PR DESCRIPTION
Completely new implementation for create_nxgraph. Improvements compared to the previous version:

- much faster by using numpy instead of pandas ins many places
- uses the functions from build_branch to calculate branch impedances
- correctly considers trafo3w switches
- added tests for all relevant elements

See further discussion in #271.