### PR TITLE
changed deprecated ix to at in creating generic geodata

### DIFF
--- a/pandapower/plotting/generic_geodata.py
+++ b/pandapower/plotting/generic_geodata.py
@@ -40,8 +40,8 @@ def build_igraph_from_pp(net, respect_switches=False):
     nogolines = set(net.switch.element[(net.switch.et == "l") & (net.switch.closed == 0)]) \
                 if respect_switches else set()
     for lix in (ix for ix in net.line.index if ix not in nogolines):
-        l = net.line.ix[lix]
-        g.add_edge(pp_bus_mapping[l.from_bus], pp_bus_mapping[l.to_bus])
+        fb, tb = net.line.at[lix, "from_bus"], net.line.at[lix, "to_bus"]
+        g.add_edge(pp_bus_mapping[fb], pp_bus_mapping[tb])
     g.es["weight"] = net.line.length_km.values
 
     # add trafos


### PR DESCRIPTION
.ix is deprecated and leads to more or less undesired behaviour, as it has a fall-back to iloc, therefore some errors might be ignored silently. For this reason, I changed the respective calling function `build_igraph_from_pp` to use at instead of ix.

Hint: using `fb, tb = net.line.loc[lix, ["from_bus", "to_bus"]]` is more than 10 times slower than the version with at when iterating over the lines.

What might be even faster is not iterating, but putting `g.add_edges_from(zip(net.line.loc[~net.line.index.isin(nogolines), ["from_bus", "to_bus"]]))` or something of that kind.