### PR TITLE
Changes in Plotly

### DIFF
--- a/pandapower/plotting/plotly/pf_res_plotly.py
+++ b/pandapower/plotting/plotly/pf_res_plotly.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 def pf_res_plotly(net, cmap="Jet", use_line_geodata=None, on_map=False, projection=None,
                   map_style='basic', figsize=1, aspectratio='auto', line_width=2, bus_size=10,
+                  climits_volt = (0.9,1.1), climits_load = (0,100), cpos_volt = 1.0, cpos_load = 1.1,
                   filename="temp-plot.html"):
     """
     Plots a pandapower network in plotly
@@ -62,6 +63,14 @@ def pf_res_plotly(net, cmap="Jet", use_line_geodata=None, on_map=False, projecti
 
         **bus_size** (float, 10.0) -  size of buses to plot.
 
+        **climits_volt** (tuple, (0.9, 1.0)) - limits of the colorbar for voltage
+
+        **climits_load** (tuple, (0, 100)) - limits of the colorbar for line_loading
+
+        **cpos_volt** (float, 1.0) - position of the bus voltage colorbar
+
+        **cpos_load** (float, 1.1) - position of the loading percent colorbar
+
         **filename** (str, "temp-plot.html") - filename / path to plot to. Should end on *.html
 
     """
@@ -98,7 +107,8 @@ def pf_res_plotly(net, cmap="Jet", use_line_geodata=None, on_map=False, projecti
             'V_a = ' + net.res_bus.va_degree.round(precision).astype(str) + ' deg').tolist()
     hoverinfo = pd.Series(index=net.bus.index, data=hoverinfo)
     bus_trace = create_bus_trace(net, net.bus.index, size=bus_size, infofunc=hoverinfo, cmap=cmap,
-                                 cbar_title='Bus Voltage [pu]', cmin=0.9, cmax=1.1)
+                                 cbar_title='Bus Voltage [pu]', cmin=climits_volt[0], cmax=climits_volt[1],
+                                 cpos=cpos_volt)
 
     # ----- Lines ------
     # if bus geodata is available, but no line geodata
@@ -109,7 +119,6 @@ def pf_res_plotly(net, cmap="Jet", use_line_geodata=None, on_map=False, projecti
     elif use_line_geodata and len(net.line_geodata) == 0:
         logger.warning("No or insufficient line geodata available --> only bus geodata will be used.")
         use_line_geodata = False
-    idx = net.line.index
     # hoverinfo which contains name and pf results
     hoverinfo = (
             net.line.name.astype(str) + '<br />' +
@@ -122,9 +131,10 @@ def pf_res_plotly(net, cmap="Jet", use_line_geodata=None, on_map=False, projecti
                                     infofunc=hoverinfo,
                                     cmap=cmap_lines,
                                     cmap_vals=net.res_line['loading_percent'].values,
-                                    cmin=0,
-                                    cmax=100,
-                                    cbar_title='Line Loading [%]')
+                                    cmin=climits_load[0],
+                                    cmax=climits_load[1],
+                                    cbar_title='Line Loading [%]',
+                                    cpos=cpos_load)
 
     # ----- Trafos ------
     # hoverinfo which contains name and pf results

--- a/pandapower/plotting/plotly/pf_res_plotly.py
+++ b/pandapower/plotting/plotly/pf_res_plotly.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 
 def pf_res_plotly(net, cmap="Jet", use_line_geodata=None, on_map=False, projection=None,
                   map_style='basic', figsize=1, aspectratio='auto', line_width=2, bus_size=10,
-                  climits_volt = (0.9,1.1), climits_load = (0,100), cpos_volt = 1.0, cpos_load = 1.1,
+                  climits_volt=(0.9, 1.1), climits_load=(0, 100), cpos_volt=1.0, cpos_load=1.1,
                   filename="temp-plot.html"):
     """
     Plots a pandapower network in plotly

--- a/pandapower/plotting/plotly/traces.py
+++ b/pandapower/plotting/plotly/traces.py
@@ -201,13 +201,14 @@ def create_bus_trace(net, buses=None, size=5, patch_type="circle", color="blue",
                                      color=cmap_vals, cmin=cmin, cmax=cmax,
                                      colorscale=cmap,
                                      colorbar=ColorBar(thickness=10,
-                                                       x=1.0,
-                                                       titleside='right'),
+                                                       x=1.0),
                                      symbol=patch_type
                                      )
 
         if cbar_title:
             bus_trace['marker']['colorbar']['title'] = cbar_title
+
+        bus_trace['marker']['colorbar']['title']['side'] = 'right'
 
     return [bus_trace]
 
@@ -376,11 +377,12 @@ def create_line_trace(net, lines=None, use_line_geodata=True, respect_switches=F
                                             color='rgb(255,255,255)',
                                             colorscale=cbar_cmap_name,
                                             colorbar=ColorBar(thickness=10,
-                                                              x=1.1,
-                                                              titleside='right'),
+                                                              x=1.1),
                                             ))
             if cbar_title:
                 lines_cbar['marker']['colorbar']['title'] = cbar_title
+
+            lines_cbar['marker']['colorbar']['title']['side'] = 'right'
 
             line_traces.append(lines_cbar)
         except:

--- a/pandapower/plotting/plotly/traces.py
+++ b/pandapower/plotting/plotly/traces.py
@@ -119,7 +119,7 @@ def create_edge_center_trace(line_trace, size=1, patch_type="circle", color="whi
 
 def create_bus_trace(net, buses=None, size=5, patch_type="circle", color="blue", infofunc=None,
                      trace_name='buses', legendgroup=None, cmap=None, cmap_vals=None,
-                     cbar_title=None, cmin=None, cmax=None, colormap_column="vm_pu"):
+                     cbar_title=None, cmin=None, cmax=None, cpos=1.0, colormap_column="vm_pu"):
     """
     Creates a plotly trace of pandapower buses.
 
@@ -156,6 +156,8 @@ def create_bus_trace(net, buses=None, size=5, patch_type="circle", color="blue",
         **cmin** (float, None) - colorbar range minimum
 
         **cmax** (float, None) - colorbar range maximum
+
+        **cpos** (float, 1.1) - position of the colorbar
 
         **colormap_column** (str, "vm_pu") - set color of bus according to this variable
 
@@ -201,7 +203,7 @@ def create_bus_trace(net, buses=None, size=5, patch_type="circle", color="blue",
                                      color=cmap_vals, cmin=cmin, cmax=cmax,
                                      colorscale=cmap,
                                      colorbar=ColorBar(thickness=10,
-                                                       x=1.0),
+                                                       x=cpos),
                                      symbol=patch_type
                                      )
 
@@ -248,7 +250,7 @@ def _get_line_geodata_plotly(net, lines, use_line_geodata):
 def create_line_trace(net, lines=None, use_line_geodata=True, respect_switches=False, width=1.0,
                       color='grey', infofunc=None, trace_name='lines', legendgroup=None,
                       cmap=None, cbar_title=None, show_colorbar=True, cmap_vals=None, cmin=None,
-                      cmax=None):
+                      cmax=None, cpos=1.1):
     """
     Creates a plotly trace of pandapower lines.
 
@@ -285,6 +287,8 @@ def create_line_trace(net, lines=None, use_line_geodata=True, respect_switches=F
         **cmin** (float, None) - colorbar range minimum
 
         **cmax** (float, None) - colorbar range maximum
+
+        **cpos** (float, 1.1) - position of the colorbar
 
         """
 
@@ -377,7 +381,7 @@ def create_line_trace(net, lines=None, use_line_geodata=True, respect_switches=F
                                             color='rgb(255,255,255)',
                                             colorscale=cbar_cmap_name,
                                             colorbar=ColorBar(thickness=10,
-                                                              x=1.1),
+                                                              x=cpos),
                                             ))
             if cbar_title:
                 lines_cbar['marker']['colorbar']['title'] = cbar_title


### PR DESCRIPTION
There are two changes I made in plotting.plotly

1.) As the position of the colorbar-title can't be set by the variable titleside anymore, I made some changes so that the title of the colorbar is now at the right position again.
2.) I thought it would make sense to be able to change the voltage and load colorbar limits as the relevant limits might not be 0.9 and 1.1 in case of voltage and 0 and 100 in case of loading in a heatmap. 
This, however, might cause collusions between the two colorbars. Therefore I also intoduced the variable colorbar_position. Maybe it is a bit of an overload and could be moved to **kwargs instead.

What do you think?