### PR TITLE
Added more std_types for overhead lines

### DIFF
--- a/pandapower/std_types.py
+++ b/pandapower/std_types.py
@@ -479,7 +479,7 @@ def add_basic_std_types(net):
 
         # Overhead Lines, all from S.742f, Heuck: Elektrische Energieversorgung -
         # Vierweg+Teubner 2013
-        # 679/86 from S. 362, Flosdorff, Hilgarth: Elektrische Energieverteilung - Teubner 2005
+        # 679/86 110 from S. 362, Flosdorff, Hilgarth: Elektrische Energieverteilung - Teubner 2005
 
         # Low Voltage
         "15-AL1/3-ST1A 0.4":
@@ -631,6 +631,14 @@ def add_basic_std_types(net):
 
         # High Voltage
         # c acd x values are estimated for 4 m conductor distance, single bundle and "Donaumast"
+        "48-AL1/8-ST1A 110.0":
+        {"c_nf_per_km": 8,
+            "r_ohm_per_km": 0.5939,
+            "x_ohm_per_km": 0.46,
+            "max_i_ka": 0.210,
+            "type": "ol",
+            "q_mm2": 48,
+            "alpha": alpha_al},
         "70-AL1/11-ST1A 110.0":
         {"c_nf_per_km": 8.4,
             "r_ohm_per_km": 0.4132,

--- a/pandapower/std_types.py
+++ b/pandapower/std_types.py
@@ -718,20 +718,36 @@ def add_basic_std_types(net):
         # quad bundle conductor. The c values are estimated.
         "490-AL1/64-ST1A 220.0":
         {"c_nf_per_km": 10,
-            "r_ohm_per_km": 0.059,
-            "x_ohm_per_km": 0.285,
-            "max_i_ka": 0.96,
-            "type": "ol",
-            "q_mm2": 490,
-            "alpha": alpha_al},
+             "r_ohm_per_km": 0.059,
+             "x_ohm_per_km": 0.285,
+             "max_i_ka": 0.96,
+             "type": "ol",
+             "q_mm2": 490,
+             "alpha": alpha_al},
+        "679-AL1/86-ST1A 220.0":
+        {"c_nf_per_km": 11.7,
+             "r_ohm_per_km": 0.042,
+             "x_ohm_per_km": 0.275,
+             "max_i_ka": 0.1150,
+             "type": "ol",
+             "q_mm2": 679,
+             "alpha": alpha_al},
         "490-AL1/64-ST1A 380.0":
         {"c_nf_per_km": 11,
-            "r_ohm_per_km": 0.059,
-            "x_ohm_per_km": 0.253,
-            "max_i_ka": 0.96,
-            "type": "ol",
-            "q_mm2": 490,
-            "alpha": alpha_al}
+             "r_ohm_per_km": 0.059,
+             "x_ohm_per_km": 0.253,
+             "max_i_ka": 0.96,
+             "type": "ol",
+             "q_mm2": 490,
+             "alpha": alpha_al},
+        "679-AL1/86-ST1A 380.0":
+        {"c_nf_per_km": 14.6,
+             "r_ohm_per_km": 0.042,
+             "x_ohm_per_km": 0.25,
+             "max_i_ka": 0.1150,
+             "type": "ol",
+             "q_mm2": 679,
+             "alpha": alpha_al}
     }
     create_std_types(net, data=linetypes, element="line")
 

--- a/pandapower/std_types.py
+++ b/pandapower/std_types.py
@@ -479,6 +479,7 @@ def add_basic_std_types(net):
 
         # Overhead Lines, all from S.742f, Heuck: Elektrische Energieversorgung -
         # Vierweg+Teubner 2013
+        # 679/86 from S. 362, Flosdorff, Hilgarth: Elektrische Energieverteilung - Teubner 2005
 
         # Low Voltage
         "15-AL1/3-ST1A 0.4":
@@ -629,6 +630,31 @@ def add_basic_std_types(net):
             "alpha": alpha_al},
 
         # High Voltage
+        # c acd x values are estimated for 4 m conductor distance, single bundle and "Donaumast"
+        "70-AL1/11-ST1A 110.0":
+        {"c_nf_per_km": 8.4,
+            "r_ohm_per_km": 0.4132,
+            "x_ohm_per_km": 0.45,
+            "max_i_ka": 0.290,
+            "type": "ol",
+            "q_mm2": 70,
+            "alpha": alpha_al},
+        "94-AL1/15-ST1A 110.0":
+        {"c_nf_per_km": 8.65,
+            "r_ohm_per_km": 0.3060,
+            "x_ohm_per_km": 0.44,
+            "max_i_ka": 0.350,
+            "type": "ol",
+            "q_mm2": 94,
+            "alpha": alpha_al},
+        "122-AL1/20-ST1A 110.0":
+        {"c_nf_per_km": 8.5,
+            "r_ohm_per_km": 0.2376,
+            "x_ohm_per_km": 0.43,
+            "max_i_ka": 0.410,
+            "type": "ol",
+            "q_mm2": 122,
+            "alpha": alpha_al},
         "149-AL1/24-ST1A 110.0":
         {"c_nf_per_km": 8.75,
             "r_ohm_per_km": 0.1940,
@@ -661,9 +687,25 @@ def add_basic_std_types(net):
             "type": "ol",
             "q_mm2": 305,
             "alpha": alpha_al},
+        "490-AL1/64-ST1A 110.0":
+        {"c_nf_per_km": 9.75,
+            "r_ohm_per_km": 0.059,
+            "x_ohm_per_km": 0.37,
+            "max_i_ka": 0.960,
+            "type": "ol",
+            "q_mm2": 490,
+            "alpha": alpha_al},
+        "679-AL1/86-ST1A 110.0":
+        {"c_nf_per_km": 9.95,
+            "r_ohm_per_km": 0.042,
+            "x_ohm_per_km": 0.36,
+            "max_i_ka": 0.1150,
+            "type": "ol",
+            "q_mm2": 679,
+            "alpha": alpha_al},
 
         # Transmission System
-        # The following values of c and x are depend on the geometries of the  overhead line
+        # The following values of c and x depend on the geometries of the  overhead line
         # Here it is assumed that for x the 220kV line uses twin conductors and the 380kV line uses
         # quad bundle conductor. The c values are estimated.
         "490-AL1/64-ST1A 220.0":


### PR DESCRIPTION
Added several 110 kV overhead line types:

- 48-AL1/8-ST1A 110.0
- 70-AL1/11-ST1A 110.0
- 94-AL1/15-ST1A 110.0
- 122-AL1/20-ST1A 110.0
- 490-AL1/64-ST1A 110.0
- 679-AL1/86-ST1A 110.0

And one more type for 220 and 380 kV power lines:

- 679-AL1/86-ST1A 220.0
- 679-AL1/86-ST1A 380.0