### PR TITLE
Fixed minor mistakes in OPF doc

### DIFF
--- a/doc/opf/formulation.rst
+++ b/doc/opf/formulation.rst
@@ -3,7 +3,7 @@
 Optimisation problem
 ======================
 
-The equation describes the basic formulation of the optimal power flow problem.
+The equation describes the basic formulation of the optimal power flow (OPF) problem.
 The pandapower optimal power flow can be constrained by either AC or DC loadflow equations.
 The branch constraints represent the maximum apparent power loading of transformers and the maximum line current loadings.
 The bus constraints can contain maximum and minimum voltage magnitude and angle.
@@ -19,7 +19,7 @@ The constraints are defined element wise in the respective element tables.
         & & operational \ power \ constraints \\
 
 
-**Generator Flexibilities / Operational power constraints**
+**Generator flexibilities / Operational power constraints**
 
 The active and reactive power generation of generators, loads, dc lines and static generators can be defined as a flexibility for the OPF.
 
@@ -29,9 +29,9 @@ The active and reactive power generation of generators, loads, dc lines and stat
    :delim: ;
 
 .. note::
-	Defining operational constraints is indispensable for the OPF, it will not start if contraints are not defined.
+	Defining operational constraints is indispensable for the OPF, it will not start if constraints are not defined.
 
-**Network Constraints**
+**Network constraints**
 
 The network constraints contain constraints for bus voltages and branch flows:
 
@@ -77,12 +77,12 @@ Polynomial cost functions can be specified using create_poly_cost():
 	Piecewise linear cost funcions for reactive power are not working at the moment with 2 segments or more.
 	Loads can only have 2 data points in their piecewise linear cost function for active power.
 
-Active and reactive power costs are calculted seperately. The costs of all types are summed up to determine the overall costs for a grid state.
+Active and reactive power costs are calculted separately. The costs of all types are summed up to determine the overall costs for a grid state.
 
 Visualization of cost functions
 --------------------------------
 
-**Minimizing Generation**
+**Minimizing generation**
 
 The most common optimization goal is the minimization of the overall generator feed in. The according cost function would be formulated like this:
 

--- a/doc/opf/opf_flexibility.csv
+++ b/doc/opf/opf_flexibility.csv
@@ -1,11 +1,11 @@
 **Constraint**;**Defined in**
 :math:`P_{min,i} \leq P_{g} \leq P_{max,g},\ g  \ \epsilon \ gen` ;net.gen.min_p_mw / net.gen.max_p_mw
-:math:`Q_{min,g} \leq Q_{g} \leq Q_{max,g},\ g  \ \epsilon \ gen` ;net.gen.min_q_kvar / net.gen.max_q_kvar
+:math:`Q_{min,g} \leq Q_{g} \leq Q_{max,g},\ g  \ \epsilon \ gen` ;net.gen.min_q_mvar / net.gen.max_q_mvar
 :math:`P_{min,sg} \leq P_{sg} \leq P_{max,sg},\ sg  \ \epsilon \ sgen` ;net.sgen.min_p_mw  / net.sgen.max_p_mw
-:math:`Q_{min,sg} \leq Q_{sg} \leq Q_{max,sg},\ sg  \ \epsilon \ sgen` ;net.sgen.min_q_kvar / net.sgen.max_q_kvar
+:math:`Q_{min,sg} \leq Q_{sg} \leq Q_{max,sg},\ sg  \ \epsilon \ sgen` ;net.sgen.min_q_mvar / net.sgen.max_q_mvar
 :math:`P_{max,g},\ g  \ \epsilon \ dcline` ;net.dcline.max_p_mw
-:math:`Q_{min,g} \leq Q_{g} \leq Q_{max,g},\ g  \ \epsilon \ dcline` ;net.dcline.min_q_from_kvar / net.dcline.max_q_from_kvar / net.dcline.min_q_to_kvar / net.dcline.max_q_to_kvar
+:math:`Q_{min,g} \leq Q_{g} \leq Q_{max,g},\ g  \ \epsilon \ dcline` ;net.dcline.min_q_from_mvar / net.dcline.max_q_from_mvar / net.dcline.min_q_to_mvar / net.dcline.max_q_to_mvar
 :math:`P_{min,eg} \leq P_{eg} \leq P_{max,eg},\ eg  \ \epsilon \ ext\_grid` ;net.ext_grid.min_p_mw  / net.ext_grid.max_p_mw
-:math:`Q_{min,eg} \leq Q_{eg} \leq Q_{max,eg},\ eg  \ \epsilon \ ext\_grid` ;net.ext_grid.min_q_kvar / net.ext_grid.max_q_kvar
-:math:`P_{min,ld} \leq P_{ld} \leq P_{max,ld},\ ld \ \epsilon \ load` ;net.sgen.min_p_mw  / net.sgen.max_p_mw
-:math:`Q_{min,ld} \leq Q_{ld} \leq Q_{max,ld},\ ld  \ \epsilon \ load` ;net.sgen.min_q_kvar / net.sgen.max_q_kvar
+:math:`Q_{min,eg} \leq Q_{eg} \leq Q_{max,eg},\ eg  \ \epsilon \ ext\_grid` ;net.ext_grid.min_q_mvar / net.ext_grid.max_q_mvar
+:math:`P_{min,ld} \leq P_{ld} \leq P_{max,ld},\ ld \ \epsilon \ load` ;net.load.min_p_mw  / net.load.max_p_mw
+:math:`Q_{min,ld} \leq Q_{ld} \leq Q_{max,ld},\ ld  \ \epsilon \ load` ;net.load.min_q_mvar / net.load.max_q_mvar


### PR DESCRIPTION
- Introduce OPF as abbreviation
- Fixed spelling mistakes 
- Uniform headings (capitalization)
- "kilo" to "mega"
 