### PR TITLE
Setting dtypes of columns in convert_format only for versions <1.6

### DIFF
--- a/pandapower/control/basic_controller.py
+++ b/pandapower/control/basic_controller.py
@@ -4,11 +4,10 @@
 # and Energy System Technology (IEE), Kassel. All rights reserved.
 import copy
 from pandapower.auxiliary import get_free_id
-from pandapower.control.util.auxiliary import check_controller_frame, drop_same_type_existing_controllers, \
-    log_same_type_existing_controllers
+from pandapower.control.util.auxiliary import check_controller_frame, \
+    drop_same_type_existing_controllers, log_same_type_existing_controllers
 from pandapower.io_utils import JSONSerializableClass
 from builtins import object
-
 
 try:
     import pplog
@@ -40,7 +39,8 @@ class Controller(JSONSerializableClass):
         self.update_initialized(locals())
         self.index = self.add_controller_to_net(in_service=in_service, order=order,
                                                 level=level, index=index, recycle=recycle,
-                                                drop_same_existing_ctrl=drop_same_existing_ctrl, **kwargs)
+                                                drop_same_existing_ctrl=drop_same_existing_ctrl,
+                                                **kwargs)
 
     def __repr__(self):
         rep = "This " + self.__class__.__name__ + " has the following parameters: \n"
@@ -101,7 +101,6 @@ class Controller(JSONSerializableClass):
 
     def add_controller_to_net(self, in_service, order, level, index, recycle,
                               drop_same_existing_ctrl, **kwargs):
-
         """
         adds the controller to net['controller'] dataframe.
 

--- a/pandapower/control/util/auxiliary.py
+++ b/pandapower/control/util/auxiliary.py
@@ -67,9 +67,10 @@ def check_controller_frame(net):
     Purpose: to define at 1 place
     """
     if 'controller' not in net.keys():
-        columns = ['controller', 'in_service', 'order', 'level', 'recycle']
-        dtype = {'in_service': bool, 'recycle': bool}
-        net['controller'] = pd.DataFrame(columns=columns).astype(dtype=dtype)
+        net['controller'] = pd.DataFrame(
+           columns=['controller', 'in_service', 'order', 'level', 'recycle'])
+        net.controller.in_service.astype(bool)
+        net.controller.recycle.astype(bool)
 
 
 def mute_control(net):

--- a/pandapower/control/util/auxiliary.py
+++ b/pandapower/control/util/auxiliary.py
@@ -67,10 +67,10 @@ def check_controller_frame(net):
     Purpose: to define at 1 place
     """
     if 'controller' not in net.keys():
-        net['controller'] = pd.DataFrame(
-           columns=['controller', 'in_service', 'order', 'level', 'recycle'])
-        net.controller.in_service.astype(bool)
-        net.controller.recycle.astype(bool)
+        columns = ['controller', 'in_service', 'order', 'level', 'recycle']
+        dtype = {'in_service': bool, 'recycle': bool}
+        net['controller'] = pd.DataFrame(columns=columns).astype(dtype=dtype)
+
 
 def mute_control(net):
     """

--- a/pandapower/convert_format.py
+++ b/pandapower/convert_format.py
@@ -17,7 +17,7 @@ def convert_format(net):
     """
     Converts old nets to new format to ensure consistency. The converted net is returned.
     """
-    if isinstance(net.version, str) and version.parse(__version__) < version.parse(__version__):
+    if isinstance(net.version, str) and version.parse(net.version) >= version.parse(__version__):
         return net
     _add_nominal_power(net)
     _add_missing_tables(net)

--- a/pandapower/convert_format.py
+++ b/pandapower/convert_format.py
@@ -11,6 +11,7 @@ from pandapower.create import create_empty_network, create_poly_cost
 from pandapower.results import reset_results
 from pandapower import __version__
 
+
 def convert_format(net):
     """
     Converts old nets to new format to ensure consistency. The converted net is returned.
@@ -50,7 +51,8 @@ def _convert_to_generation_system(net):
                 net[element][column] = values
     pq_measurements = net.measurement[net.measurement.measurement_type.isin(["p", "q"])].index
     net.measurement.loc[pq_measurements, ["value", "std_dev"]] *= 1e-3
-        
+
+
 def _convert_costs(net):
     if "polynomial_cost" in net:
         for cost in net.polynomial_cost.itertuples():
@@ -64,18 +66,20 @@ def _convert_costs(net):
                 cp1 = values[1]
                 cp2 = values[0]
             create_poly_cost(net, et=cost.element_type, element=cost.element, cp0_eur=cp0,
-                             cp1_eur_per_mw=cp1*1e3, cp2_eur_per_mw2=cp2*1e6)
+                             cp1_eur_per_mw=cp1 * 1e3, cp2_eur_per_mw2=cp2 * 1e6)
         del net.polynomial_cost
     if "piecewise_linear_cost" in net:
         if len(net.piecewise_linear_cost) > 0:
             raise NotImplementedError
         del net.piecewise_linear_cost
 
+
 def _add_nominal_power(net):
     if "sn_kva" not in net:
         net.sn_kva = 1e3
     if "sn_kva" in net.keys():
         net.sn_mva = net.pop("sn_kva") * 1e-3
+
 
 def _add_missing_tables(net):
     net_new = create_empty_network()
@@ -84,13 +88,13 @@ def _add_missing_tables(net):
             net[key] = net_new[key]
         elif key not in net.keys():
             net[key] = net_new[key]
-    
-    
+
+
 def _create_seperate_cost_tables(net):
     if "cost_per_kw" in net.gen:
         for index, cost in net.gen.cost_per_kw.iteritems():
             if not np.isnan(cost):
-                create_poly_cost(net, index, "gen", cp1_eur_per_mw=cost*1e3)
+                create_poly_cost(net, index, "gen", cp1_eur_per_mw=cost * 1e3)
 
     if "cost_per_kw" in net.sgen:
         for index, cost in net.sgen.cost_per_kw.iteritems():
@@ -106,20 +110,21 @@ def _create_seperate_cost_tables(net):
         for index, cost in net.gen.cost_per_kvar.iteritems():
             if not np.isnan(cost):
                 create_poly_cost(net, index, "ext_grid", cp1_eur_per_mw=0,
-                                 cq1_eur_per_mvar=cost*1e3)
+                                 cq1_eur_per_mvar=cost * 1e3)
 
     if "cost_per_kvar" in net.sgen:
         for index, cost in net.sgen.cost_per_kvar.iteritems():
             if not np.isnan(cost):
                 create_poly_cost(net, index, "sgen", cp1_eur_per_mw=0,
-                                 cq1_eur_per_mvar=cost*1e3)
+                                 cq1_eur_per_mvar=cost * 1e3)
 
     if "cost_per_kvar" in net.ext_grid:
         for index, cost in net.ext_grid.cost_per_kvar.iteritems():
             if not np.isnan(cost):
                 create_poly_cost(net, index, "ext_grid", cp1_eur_per_mw=0,
-                                 cq1_eur_per_mvar=cost*1e3)
-    
+                                 cq1_eur_per_mvar=cost * 1e3)
+
+
 def _rename_columns(net):
     net.line.rename(columns={'imax_ka': 'max_i_ka'}, inplace=True)
     for typ, data in net.std_types["line"].items():
@@ -133,10 +138,10 @@ def _rename_columns(net):
         else:
             net.measurement["side"] = None
             bus_measurements = net.measurement.element_type == "bus"
-            net.measurement.loc[bus_measurements, "element"] = net.measurement.loc[
-                    bus_measurements, "bus"].values
-            net.measurement.loc[~bus_measurements, "side"] = net.measurement.loc[
-                    ~bus_measurements, "bus"].values
+            net.measurement.loc[bus_measurements, "element"] = \
+                net.measurement.loc[bus_measurements, "bus"].values
+            net.measurement.loc[~bus_measurements, "side"] = \
+                net.measurement.loc[~bus_measurements, "bus"].values
             net.measurement.rename(columns={'type': 'measurement_type'}, inplace=True)
             net.measurement.drop(["bus"], axis=1, inplace=True)
     if "options" in net:
@@ -145,13 +150,14 @@ def _rename_columns(net):
                 net["options"]["recycle"]["_is_elements"] = copy.deepcopy(
                     net["options"]["recycle"]["is_elems"])
                 net["options"]["recycle"].pop("is_elems", None)
-            
+
+
 def _add_missing_columns(net):
     for element in ["trafo", "line"]:
         if "df" not in net[element]:
             net[element]["df"] = 1.0
     if "coords" not in net.bus_geodata:
-        net.bus_geodata["coords"] = None        
+        net.bus_geodata["coords"] = None
     if not "tap_at_star_point" in net.trafo3w:
         net.trafo3w["tap_at_star_point"] = False
     if not "tap_step_degree" in net.trafo3w:
@@ -175,7 +181,7 @@ def _add_missing_columns(net):
 
     if "g_us_per_km" not in net.line:
         net.line["g_us_per_km"] = 0.
-        
+
     if "slack" not in net.gen:
         net.gen["slack"] = False
 
@@ -193,12 +199,13 @@ def _add_missing_columns(net):
 
     if "name" not in net.measurement:
         net.measurement.insert(0, "name", None)
-        
+
+
 def _update_trafo_type_parameter_names(net):
     for element in ('trafo', 'trafo3w'):
         for type in net.std_types[element].keys():
             keys = {col: _update_column(col) for col in net.std_types[element][type].keys() if
-                            col.startswith("tp") or col.startswith("vsc")}
+                    col.startswith("tp") or col.startswith("vsc")}
             for old_key, new_key in keys.items():
                 net.std_types[element][type][new_key] = net.std_types[element][type].pop(old_key)
 
@@ -209,6 +216,7 @@ def _update_trafo_parameter_names(net):
                         col.startswith("tp") or col.startswith("vsc")}
         net[element].rename(columns=replace_cols, inplace=True)
     _update_trafo_type_parameter_names(net)
+
 
 def _update_column(column):
     column = column.replace("tp_", "tap_")
@@ -236,6 +244,7 @@ def _set_data_type_of_columns(net):
                         net[key][col] = net[key][col].astype(new_net[key][col].dtype,
                                                              errors="ignore")
 
+
 def _convert_to_mw(net):
     replace = [("kw", "mw"), ("kvar", "mvar"), ("kva", "mva")]
     for element, tab in net.items():
@@ -254,5 +263,5 @@ def _convert_to_mw(net):
             for parameter, value in parameters.items():
                 for old, new in replace:
                     if old in parameter and parameter != "pfe_kw":
-                        parameters[parameter.replace(old, new)] = value*1e-3
+                        parameters[parameter.replace(old, new)] = value * 1e-3
                         del parameters[parameter]

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -9,6 +9,7 @@ import pandapower as pp
 import numpy
 import numbers
 import json
+import json.encoder
 from json.encoder import encode_basestring_ascii, encode_basestring, INFINITY, _make_iterencode
 import copy
 import networkx
@@ -32,13 +33,12 @@ try:
 except ImportError:
     GEOPANDAS_INSTALLED = False
 
-
 try:
     import shapely.geometry
+
     SHAPELY_INSTALLED = True
 except ImportError:
     SHAPELY_INSTALLED = False
-    
 
 try:
     import pplog as logging
@@ -68,10 +68,11 @@ def coords_to_df(value, geotype="line"):
         geo["y"] = value["y"].values
     return geo
 
+
 def to_dict_of_dfs(net, include_results=False, fallback_to_pickle=True, include_empty_tables=True):
     dodfs = dict()
     dtypes = []
-    dodfs["parameters"] = dict() #pd.DataFrame(columns=["parameter"])
+    dodfs["parameters"] = dict()  # pd.DataFrame(columns=["parameter"])
     for item, value in net.items():
         # dont save internal variables and results (if not explicitely specified)
         if item.startswith("_") or (item.startswith("res") and not include_results):
@@ -95,7 +96,7 @@ def to_dict_of_dfs(net, include_results=False, fallback_to_pickle=True, include_
         # value is pandas DataFrame
         if include_empty_tables and value.empty:
             continue
-        
+
         if item == "bus_geodata":
             geo = coords_to_df(value, geotype="bus")
             if GEOPANDAS_INSTALLED and isinstance(value, geopandas.GeoDataFrame):
@@ -183,13 +184,10 @@ def restore_all_dtypes(net, dtypes):
             if v["dtype"] == "object":
                 c = net[v.element][v.column]
                 net[v.element][v.column] = numpy.where(c.isnull(), None, c)
-#                net[v.element][v.column] = net[v.element][v.column].fillna(value=None)
+                # net[v.element][v.column] = net[v.element][v.column].fillna(value=None)
             net[v.element][v.column] = net[v.element][v.column].astype(v["dtype"])
         except KeyError:
             pass
-
-
-import json.encoder
 
 
 class PPJSONEncoder(json.JSONEncoder):
@@ -262,17 +260,19 @@ class PPJSONDecoder(json.JSONDecoder):
     def __init__(self, *args, **kwargs):
         super().__init__(object_hook=pp_hook, *args, **kwargs)
 
+
 def pp_hook(d):
     if '_module' in d and '_class' in d:
-        if "_object" in d:         
-            obj = d.pop('_object') 
-        elif "_init" in d: 
-            return d #backwards compatibility
+        if "_object" in d:
+            obj = d.pop('_object')
+        elif "_init" in d:
+            return d  # backwards compatibility
         else:
-            obj = {"_init": d, "_state": dict()} #backwards compatibility
+            obj = {"_init": d, "_state": dict()}  # backwards compatibility
+
         class_name = d.pop('_class')
         module_name = d.pop('_module')
-#        print(class_name, module_name)
+        # print(class_name, module_name)
         keys = copy.deepcopy(list(d.keys()))
         for key in keys:
             if isinstance(d[key], dict):
@@ -301,7 +301,7 @@ def pp_hook(d):
         elif SHAPELY_INSTALLED and module_name == "shapely":
             return shapely.geometry.shape(obj)
         elif class_name == "pandapowerNet":
-            if isinstance(obj, str): #backwards compatibility
+            if isinstance(obj, str):  # backwards compatibility
                 from pandapower import from_json_string
                 return from_json_string(obj)
             else:
@@ -316,7 +316,8 @@ def pp_hook(d):
             if isclass(class_) and issubclass(class_, JSONSerializableClass):
                 needs_net = "net" in signature(class_.__init__).parameters.keys()
                 if needs_net and not hasattr(pp_hook, "net"):
-                    return json.dumps({"_object": obj, "_class": class_name, "_module": module_name})
+                    return json.dumps(
+                        {"_object": obj, "_class": class_name, "_module": module_name})
                 else:
                     if isinstance(obj, str):
                         obj = json.loads(obj, cls=PPJSONDecoder)
@@ -330,12 +331,11 @@ def pp_hook(d):
 
 
 class JSONSerializableClass(object):
-    
     json_excludes = ["net", "self", "__class__"]
-    
+
     def __init__(self):
         self._init = dict()
-        
+
     def update_initialized(self, parameters):
         """
         Saves all parameters as object attributes
@@ -346,7 +346,7 @@ class JSONSerializableClass(object):
             if excluded in parameters:
                 del parameters[excluded]
         self._init.update(parameters)
-                        
+
     def to_json(self):
         """
         Each controller should have this method implemented. The resulting json string should be readable by
@@ -360,10 +360,10 @@ class JSONSerializableClass(object):
         d["_init"] = {key: val for key, val in self._init.items() if
                       key in init_parameters and key not in self.json_excludes}
         d["has_net"] = "net" in init_parameters
-        d["_state"] = {key: val for key, val in self.__dict__.items() if key not in 
+        d["_state"] = {key: val for key, val in self.__dict__.items() if key not in
                        self.json_excludes and not callable(val)}
         return d
-        
+
     @classmethod
     def from_dict(cls, d):
         state = d["_state"]
@@ -379,6 +379,7 @@ class JSONSerializableClass(object):
         d = json.loads(json_string, cls=PPJSONDecoder)
         return JSONSerializableClass.from_dict(d)
 
+
 def restore_jsoned_objects(net):
     pp_hook.net = net
     for element in ["controller", "loadcase"]:
@@ -387,8 +388,9 @@ def restore_jsoned_objects(net):
                 try:
                     pp_hook(c)
                 except Exception as e:
-                    logger.warning("did not load %s with index %u: %s"%(element, i, e))
+                    logger.warning("did not load %s with index %u: %s" % (element, i, e))
     del pp_hook.net
+
 
 def with_signature(obj, val, obj_module=None, obj_class=None):
     if obj_module is None:
@@ -506,17 +508,20 @@ def json_networkx(obj):
     d = with_signature(obj, json_string, obj_module="networkx")
     return d
 
+
 @to_serializable.register(JSONSerializableClass)
 def controller_to_serializable(obj):
     logger.debug('JSONSerializableClass')
     d = with_signature(obj, obj.to_json())
     return d
 
+
 def mkdirs_if_not_existent(dir):
     if os.path.isdir(dir) == False:
         os.makedirs(dir)
         return True
     return False
+
 
 if SHAPELY_INSTALLED:
     @to_serializable.register(shapely.geometry.LineString)
@@ -525,13 +530,15 @@ if SHAPELY_INSTALLED:
         json_string = shapely.geometry.mapping(obj)
         d = with_signature(obj, json_string, obj_module="shapely")
         return d
-    
+
+
     @to_serializable.register(shapely.geometry.Point)
     def json_point(obj):
         logger.debug("shapely Point")
         json_string = shapely.geometry.mapping(obj)
         d = with_signature(obj, json_string, obj_module="shapely")
         return d
+
 
     @to_serializable.register(shapely.geometry.Polygon)
     def json_polygon(obj):


### PR DESCRIPTION
After the implementation of new json IO, the dtypes are stored in the json file and are restored when loading the net. Therefore, the setting of dtypes in convert_format is no longer necessary, especially in the case when the user sets a different dtype of a column on purpose.

The functionality can still be used manually, with the function set_data_type_of_columns_to_default in pandapower.toolbox. The function overwrites the dtypes of all columns in element tables to match the dtypes in pandapower.create_empty_network.