### PR TITLE
Use _preserve_dtypes for net.controller table

### DIFF
--- a/pandapower/control/basic_controller.py
+++ b/pandapower/control/basic_controller.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2016-2019 by University of Kassel and Fraunhofer Institute for Energy Economics
 # and Energy System Technology (IEE), Kassel. All rights reserved.
 import copy
-from pandapower.auxiliary import get_free_id
+from pandapower.auxiliary import get_free_id, _preserve_dtypes
 from pandapower.control.util.auxiliary import check_controller_frame, \
     drop_same_type_existing_controllers, log_same_type_existing_controllers
 from pandapower.io_utils import JSONSerializableClass
@@ -125,9 +125,10 @@ class Controller(JSONSerializableClass):
         else:
             log_same_type_existing_controllers(self.net, type(self), index=index, **kwargs)
 
-        self.net.controller.loc[
-            index, ['controller', 'in_service', 'order', 'level', 'recycle']] = \
-            self, in_service, order, level, recycle
+        dtypes = self.net.controller.dtypes
+        columns = ['controller', 'in_service', 'order', 'level', 'recycle']
+        self.net.controller.loc[index, columns] = self, in_service, order, level, recycle
+        _preserve_dtypes(self.net.controller, dtypes)
         return index
 
     def time_step(self, time):

--- a/pandapower/control/util/auxiliary.py
+++ b/pandapower/control/util/auxiliary.py
@@ -67,10 +67,10 @@ def check_controller_frame(net):
     Purpose: to define at 1 place
     """
     if 'controller' not in net.keys():
-        net['controller'] = pd.DataFrame(
-           columns=['controller', 'in_service', 'order', 'level', 'recycle'])
-        net.controller.in_service.astype(bool)
-        net.controller.recycle.astype(bool)
+        columns = ['controller', 'in_service', 'order', 'level', 'recycle']
+        dtype = {'controller': object, 'in_service': bool, 'order': np.float64, 'level': object,
+                 'recycle': bool}
+        net['controller'] = pd.DataFrame(columns=columns).astype(dtype=dtype)
 
 
 def mute_control(net):


### PR DESCRIPTION
The former implementation of check_controller_frame had "astype" statements with no effect.

The new implementation sets the dtypes explicitly, and _preserve_dtypes is used when adding a new controller to the DataFrame.

Additional tests have been added to test_control.