### PR TITLE
Bugfix in create_series_reactor_as_impedance

### DIFF
--- a/pandapower/create.py
+++ b/pandapower/create.py
@@ -2286,7 +2286,7 @@ def create_series_reactor_as_impedance(net, from_bus, to_bus, r_ohm, x_ohm, sn_m
                           'to_bus %d (%.3f p.u.)' % (name, from_bus, net.bus.at[from_bus, 'vn_kv'],
                                                      to_bus, net.bus.at[to_bus, 'vn_kv']))
 
-    base_z_ohm = vn_kv ** 2 / (sn_mva * 1e-3)
+    base_z_ohm = vn_kv ** 2 / sn_mva
     rft_pu = r_ohm / base_z_ohm
     xft_pu = x_ohm / base_z_ohm
 

--- a/pandapower/test/api/test_create.py
+++ b/pandapower/test/api/test_create.py
@@ -46,9 +46,10 @@ def test_convenience_create_functions():
     assert net.sgen.name.at[sg0] == "sgen"
 
     tol = 1e-6
+    base_z = 110 ** 2 / 100
     sind = pp.create_series_reactor_as_impedance(net, b1, b2, r_ohm=100, x_ohm=200, sn_mva=100)
-    assert net.impedance.at[sind, 'rft_pu'] - 8.264463e-04 < tol
-    assert net.impedance.at[sind, 'xft_pu'] - 0.001653 < tol
+    assert net.impedance.at[sind, 'rft_pu'] - 100 / base_z < tol
+    assert net.impedance.at[sind, 'xft_pu'] - 200 / base_z < tol
 
     tid = pp.create_transformer_from_parameters(net, hv_bus=b2, lv_bus=b3, sn_mva=0.1, vn_hv_kv=110,
                                                 vn_lv_kv=20, vkr_percent=5, vk_percent=20,


### PR DESCRIPTION
For calculating the base Z value, sn_kva used to be divided by 1000 to convert it in sn_mva in the formula v^2/sn_mva.

After the transition to MW from kW, this is not necessary and produces incorrect per-unit values.
The division by 1000 is no longer necessary.