### PR TITLE
Fixed inverse behaviour of include_empty_tables=False on pp.to_excel

### DIFF
--- a/pandapower/create.py
+++ b/pandapower/create.py
@@ -25,7 +25,10 @@ def create_empty_network(name="", f_hz=50., sn_mva=1, add_stdtypes=True):
 
         **sn_mva** (float, 1e3) - reference apparent power for per unit system
 
-        **add_stdtypes** (boolean, True) - Includes standard types to net
+        **add_stdtypes** (boolean/tuple, True) - If True, includes standard types to creation
+                                  net. Otherwise a tuple of string must be specified. Accepted
+                                  values are 'line', 'trafo' and 'trafo3w'.
+                                                 
 
     OUTPUT:
         **net** (attrdict) - PANDAPOWER attrdict with empty tables:
@@ -349,7 +352,20 @@ def create_empty_network(name="", f_hz=50., sn_mva=1, add_stdtypes=True):
         if isinstance(net[s], list):
             net[s] = pd.DataFrame(zeros(0, dtype=net[s]), index=pd.Int64Index([]))
     if add_stdtypes:
-        add_basic_std_types(net)
+        if isinstance(add_stdtypes, bool):
+            add_basic_std_types(net)
+        elif isinstance(add_stdtypes, (str, int, float)):
+            raise UserWarning("add_stdtypes must be a tuple!")
+        else:
+            for typ_name in add_stdtypes:
+                if isinstance(typ_name, (bool, int, float)):
+                    raise UserWarning("add_stdtypes tuple values must be strings!")
+                if typ_name == 'line':
+                    add_basic_std_types(net, add_trafo=False, add_trafo3w=False)
+                elif typ_name == 'trafo':
+                    add_basic_std_types(net, add_lines=False, add_trafo3w=False)
+                elif typ_name == 'trafo3w':
+                    add_basic_std_types(net, add_lines=False, add_trafo=False)
     else:
         net.std_types = {"line": {}, "trafo": {}, "trafo3w": {}}
     reset_results(net)

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -95,7 +95,7 @@ def to_dict_of_dfs(net, include_results=False, fallback_to_pickle=True, include_
             continue
 
         # value is pandas DataFrame
-        if include_empty_tables and value.empty:
+        if not include_empty_tables and value.empty:
             continue
 
         if item == "bus_geodata":

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -153,7 +153,12 @@ def df_to_coords(net, item, table):
 
 
 def from_dict_of_dfs(dodfs):
-    net = create_empty_network()
+    sheets = ('line_std_types', 'trafo_std_types', 'trafo3w_std_types')
+    types = ('line', 'trafo', 'trafo3w')
+    # creates each std_types independently
+    add_stdtypes = tuple(t for sh, t in zip(sheets, types) if sh in dodfs.keys())
+
+    net = create_empty_network(add_stdtypes=add_stdtypes)
     for c in dodfs["parameters"].columns:
         net[c] = dodfs["parameters"].at[0, c]
     for item, table in dodfs.items():

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -80,7 +80,8 @@ def to_dict_of_dfs(net, include_results=False, fallback_to_pickle=True, include_
             continue
         elif item == "std_types":
             for t in net.std_types.keys():  # which are ["line", "trafo", "trafo3w"]
-                dodfs["%s_std_types" % t] = pd.DataFrame(net.std_types[t]).T
+                if net.std_types[t]:  # to avoid empty excel sheets
+                    dodfs["%s_std_types" % t] = pd.DataFrame(net.std_types[t]).T
             continue
         elif item == "user_pf_options":
             if len(value) > 0:

--- a/pandapower/std_types.py
+++ b/pandapower/std_types.py
@@ -308,7 +308,23 @@ def add_temperature_coefficient(net, fill=None):
     parameter_from_std_type(net, "alpha", fill=fill)
 
 
-def add_basic_std_types(net):
+def add_basic_std_types(net, add_lines=True, add_trafo=True, add_trafo3w=True):
+    """
+    Add standard types to net and return them as requested.
+
+    INPUT:
+        **add_lines** (bool, True) - If True add and return linetypes.
+
+        **add_trafo** (bool, True) - If True add and return trafotypes.
+
+        **add_trafo3w** (bool, True) - If True add and return trafo3wtypes.
+
+    OUTPUT:
+        **req_stdtypes** (tuple) - Requested standard types as a tuple in the
+                                   order (linetypes,trafotypes,trafo3wtypes)
+                                   by default.
+    """
+    return_list = list()
     if "std_types" not in net:
         net.std_types = {"line": {}, "trafo": {}, "trafo3w": {}}
 
@@ -749,7 +765,9 @@ def add_basic_std_types(net):
              "q_mm2": 679,
              "alpha": alpha_al}
     }
-    create_std_types(net, data=linetypes, element="line")
+    if add_lines:
+        create_std_types(net, data=linetypes, element="line")
+        return_list.append(linetypes)
 
     trafotypes = {
         # derived from Oswald - Transformatoren - Vorlesungsskript Elektrische Energieversorgung I
@@ -1002,7 +1020,9 @@ def add_basic_std_types(net):
             "tap_step_percent": 2.5,
             "tap_phase_shifter": False},
     }
-    create_std_types(net, data=trafotypes, element="trafo")
+    if add_trafo:
+        create_std_types(net, data=trafotypes, element="trafo")
+        return_list.append(trafotypes)
 
     trafo3wtypes = {
         # generic trafo3w
@@ -1053,5 +1073,7 @@ def add_basic_std_types(net):
             "tap_max": 10,
             "tap_step_percent": 1.2}
     }
-    create_std_types(net, data=trafo3wtypes, element="trafo3w")
-    return linetypes, trafotypes, trafo3wtypes
+    if add_trafo3w:
+        create_std_types(net, data=trafo3wtypes, element="trafo3w")
+        return_list.append(trafo3wtypes)
+    return tuple(return_list)


### PR DESCRIPTION
- **Commit 1**: Fixed inverse behaviour of `include_empty_tables` on pp.to_excel function. `include_empty_tables=False` keyword argument was generating multiple "empty" excel sheets.

- **Commit 2**: Added flexibility at importing standard types on empty network and during excel importing, workbooks without `std_types` were importing all standard library. Now it depends on sheet names. _Docstrings_ added.

- **Commit 3**: At excel exporting time, if net doesn't have `std_types` empty sheets were created without much meaning.