### PR TITLE
extended toolbox function reindex_buses for partial bus lookup

### DIFF
--- a/pandapower/toolbox.py
+++ b/pandapower/toolbox.py
@@ -604,7 +604,7 @@ def add_zones_to_elements(net, replace=True, elements=None, **kwargs):
     add_column_from_node_to_elements(net, "zone", replace=replace, elements=elements, **kwargs)
 
 
-def reindex_buses(net, bus_lookup):
+def reindex_buses(net, bus_lookup, partial_lookup=False):
     """
     Changes the index of net.bus and considers the new bus indices in all other pandapower element
     tables.
@@ -613,7 +613,15 @@ def reindex_buses(net, bus_lookup):
       **net** - pandapower network
 
       **bus_lookup** (dict) - the keys are the old bus indices, the values the new bus indices
+
+    OPTIONAL:
+      **partial_lookup** (bool, default False) - flag if bus_lookup is only part of the bus indices
     """
+    if partial_lookup:
+        full_bus_lookup = copy.deepcopy(bus_lookup)
+        full_bus_lookup.update({b: b for b in net.bus.index if b not in bus_lookup})
+        bus_lookup = full_bus_lookup
+
     net.bus.index = get_indices(net.bus.index, bus_lookup)
     net.res_bus.index = get_indices(net.res_bus.index, bus_lookup)
 


### PR DESCRIPTION
It should be possible to only give a lookup for some of the buses for which to change the indices and keep the indices for all other buses. This can be switched on with the partial flag. It would also make sense to always automatically check if all bus indices given in the lookup occur in the net and the values don't appear in the rest of the bus indices and then extend the lookup.