### PR TITLE
Added separation by substation feature

### DIFF
--- a/pandapower/networks/mv_oberrhein.py
+++ b/pandapower/networks/mv_oberrhein.py
@@ -9,10 +9,11 @@ import os
 import numpy as np
 
 import pandapower as pp
+import topology as top
 from pandapower import pp_dir
 
 
-def mv_oberrhein(scenario="load", cosphi_load=0.98, cosphi_pv=1.0, include_substations=False):
+def mv_oberrhein(scenario="load", cosphi_load=0.98, cosphi_pv=1.0, include_substations=False, separation_by_sub=False):
     """
     Loads the Oberrhein network, a generic 20 kV network serviced by two 25 MVA HV/MV transformer
     stations. The network supplies 141 MV/LV substations and 6 MV loads through four MV feeders.
@@ -39,14 +40,24 @@ def mv_oberrhein(scenario="load", cosphi_load=0.98, cosphi_pv=1.0, include_subst
         **include_substations** - (bool, False): if True, the transformers of the MV/LV level are
         modelled, otherwise the loads representing the LV networks are connected directly to the
         MV node
+        
+        **separation_by_sub** - (bool, False): if True, the network gets separated into two 
+        sections, referring to both substations
 
     OUTPUT:
          **net** - pandapower network
+         
+         **net0, net1** - both sections of the pandapower network
 
     EXAMPLE:
 
-    import pandapower.networks
-    net = pandapower.networks.mv_oberrhein("generation")
+        ``import pandapower.networks``
+    
+        ``net = pandapower.networks.mv_oberrhein("generation")``
+    
+        or with separation
+    
+        ``net0, net1 = pandapower.networks.mv_oberrhein(separation_by_sub=True)``
     """
     if include_substations:
         net = pp.from_json(os.path.join(pp_dir, "networks", "mv_oberrhein_substations.json"))
@@ -66,6 +77,20 @@ def mv_oberrhein(scenario="load", cosphi_load=0.98, cosphi_pv=1.0, include_subst
         net.trafo.tap_pos.loc[hv_trafos] = [0, 0]
     else:
         raise ValueError("Unknown scenario %s - chose 'load' or 'generation'" % scenario)
+        
+    if separation_by_sub == True:
+        # creating multigraph
+        mg = top.create_nxgraph(net)
+        # clustering connected buses
+        zones = [list(area) for area in top.connected_components(mg)]
+        net1 = pp.select_subnet(net, buses=zones[0], include_switch_buses=False, 
+                                include_results=True, keep_everything_else=True)
+        net0 = pp.select_subnet(net, buses=zones[1], include_switch_buses=False, 
+                                include_results=True, keep_everything_else=True)
+        
+        pp.runpp(net0); pp.runpp(net1)
+        return net0, net1
+
 
     pp.runpp(net)
     return net

--- a/pandapower/test/networks/test_mv_oberrhein.py
+++ b/pandapower/test/networks/test_mv_oberrhein.py
@@ -13,29 +13,38 @@ import pandapower.networks as pn
 def test_mv_oberrhein():
     scenarios = ["load", "generation"]
     include_substations = [False, True]
-
+    separation_by_sub = [False, True]
+    
     for i in scenarios:
         for j in include_substations:
-            net = pn.mv_oberrhein(scenario=i, include_substations=j)
-            pp.runpp(net)
-
-            if i == "load":
-                assert net.sgen.scaling.mean() < 0.2
-                assert net.load.scaling.mean() > 0.5
-            elif i == "generation":
-                net.sgen.scaling.mean() > 0.6
-                net.load.scaling.mean() < 0.2
-
-            if j is False:
-                assert len(net.bus) == 179
-                assert len(net.trafo) == 2
-            elif j is True:
-                assert len(net.bus) == 320
-                assert len(net.trafo) == 143
-
-            assert len(net.line) == 181
-            assert len(net.switch) == 322
-            assert net.converged
+            for k in separation_by_sub:
+                net = pn.mv_oberrhein(scenario=i, include_substations=j)
+                pp.runpp(net)
+    
+                if i == "load":
+                    assert net.sgen.scaling.mean() < 0.2
+                    assert net.load.scaling.mean() > 0.5
+                elif i == "generation":
+                    net.sgen.scaling.mean() > 0.6
+                    net.load.scaling.mean() < 0.2
+    
+                if j is False:
+                    assert len(net.bus) == 179
+                    assert len(net.trafo) == 2
+                elif j is True:
+                    assert len(net.bus) == 320
+                    assert len(net.trafo) == 143
+    
+                assert len(net.line) == 181
+                assert len(net.switch) == 322
+                assert net.converged
+                
+                if k is True:
+                    net0, net1 = pn.mv_oberrhein(scenario=i, include_substations=j, separation_by_sub=k)
+                    assert len(net1.keys()) == len(net0.keys()) == len(net.keys())
+                    assert net1.res_ext_grid.loc[1].all() == net.res_ext_grid.loc[1].all()
+                    assert net0.res_ext_grid.loc[0].all() == net.res_ext_grid.loc[0].all() 
+                    assert len(net.bus) == len(net0.bus) + len(net1.bus)
 
 if __name__ == '__main__':
     pytest.main(['-x', "test_mv_oberrhein.py"])


### PR DESCRIPTION
MV Oberrhein can now be separated into two different zones referring to both substations.
Also adjusted the oberrhein test.

After running all tests locally on my pc I got an assertion error on "test_dispatch1"

@SteffenMeinecke @friederikemeier 