### PR TITLE
Voltage constaints for xward in OPF

### DIFF
--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -572,10 +572,11 @@ def _select_is_elements_numba(net, isolated_nodes=None, sequence=None):
 
 def _add_ppc_options(net, calculate_voltage_angles, trafo_model, check_connectivity, mode,
                      switch_rx_ratio, enforce_q_lims, recycle, delta=1e-10,
-                     voltage_depend_loads=False, trafo3w_losses="hv", init_vm_pu=1.0,
-                     init_va_degree=0, p_lim_default=1e9, q_lim_default=1e9,
-                     neglect_open_switch_branches=False, consider_line_temperature=False,
-                     distributed_slack=False, tdpf=False, tdpf_update_r_theta=True, tdpf_delay_s=None):
+                     delta_xward_vm_pu=1e-3, voltage_depend_loads=False,
+                     trafo3w_losses="hv", init_vm_pu=1.0, init_va_degree=0,
+                     p_lim_default=1e9, q_lim_default=1e9, neglect_open_switch_branches=False,
+                     consider_line_temperature=False, distributed_slack=False, tdpf=False,
+                     tdpf_update_r_theta=True, tdpf_delay_s=None):
     """
     creates dictionary for pf, opf and short circuit calculations from input parameters.
     """
@@ -600,6 +601,7 @@ def _add_ppc_options(net, calculate_voltage_angles, trafo_model, check_connectiv
         "tdpf_delay_s": tdpf_delay_s,
         "distributed_slack": distributed_slack,
         "delta": delta,
+        "delta_xward_vm_pu": delta_xward_vm_pu,
         "trafo3w_losses": trafo3w_losses,
         "init_vm_pu": init_vm_pu,
         "init_va_degree": init_va_degree,
@@ -1216,7 +1218,8 @@ def _init_rundcpp_options(net, trafo_model, trafo_loading, recycle, check_connec
 
 
 def _init_runopp_options(net, calculate_voltage_angles, check_connectivity, switch_rx_ratio, delta,
-                         init, numba, trafo3w_losses, consider_line_temperature=False, **kwargs):
+                         delta_xward_vm_pu, init, numba, trafo3w_losses,
+                         consider_line_temperature=False, **kwargs):
     if numba:
         numba = _check_if_numba_is_installed(numba)
     mode = "opf"
@@ -1237,15 +1240,15 @@ def _init_runopp_options(net, calculate_voltage_angles, check_connectivity, swit
                      mode=mode, switch_rx_ratio=switch_rx_ratio, init_vm_pu=init,
                      init_va_degree=init, enforce_q_lims=enforce_q_lims, recycle=recycle,
                      voltage_depend_loads=kwargs.get("voltage_depend_loads", False),
-                     delta=delta, trafo3w_losses=trafo3w_losses,
+                     delta=delta, delta_xward_vm_pu=delta_xward_vm_pu, trafo3w_losses=trafo3w_losses,
                      consider_line_temperature=consider_line_temperature)
     _add_opf_options(net, trafo_loading=trafo_loading, ac=ac, init=init, numba=numba,
                      lightsim2grid=lightsim2grid,
                      only_v_results=only_v_results, use_umfpack=use_umfpack, permc_spec=permc_spec)
 
 
-def _init_rundcopp_options(net, check_connectivity, switch_rx_ratio, delta, trafo3w_losses,
-                           **kwargs):
+def _init_rundcopp_options(net, check_connectivity, switch_rx_ratio, delta, delta_xward_vm_pu,
+                           trafo3w_losses, **kwargs):
     mode = "opf"
     ac = False
     init = "flat"
@@ -1264,7 +1267,8 @@ def _init_rundcopp_options(net, check_connectivity, switch_rx_ratio, delta, traf
                      trafo_model=trafo_model, check_connectivity=check_connectivity,
                      mode=mode, switch_rx_ratio=switch_rx_ratio, init_vm_pu=init,
                      init_va_degree=init, enforce_q_lims=enforce_q_lims, recycle=recycle,
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+                     voltage_depend_loads=False, delta=delta, delta_xward_vm_pu=delta_xward_vm_pu,
+                     trafo3w_losses=trafo3w_losses)
     _add_opf_options(net, trafo_loading=trafo_loading, init=init, ac=ac,
                      only_v_results=only_v_results,
                      use_umfpack=use_umfpack, permc_spec=permc_spec)

--- a/pandapower/build_bus.py
+++ b/pandapower/build_bus.py
@@ -352,6 +352,9 @@ def _fill_auxiliary_buses(net, ppc, bus_lookup, element, bus_column, aux):
     if net._options["mode"] == "opf":
         ppc["bus"][aux_idx, VMIN] = ppc["bus"][element_bus_idx, VMIN]
         ppc["bus"][aux_idx, VMAX] = ppc["bus"][element_bus_idx, VMAX]
+        if element == "xward":
+            ppc["bus"][aux_idx, VMAX] = net.xward.vm_pu + net._options["delta_xward_vm_pu"]
+            ppc["bus"][aux_idx, VMIN] = net.xward.vm_pu - net._options["delta_xward_vm_pu"]
 
     if net._options["init_vm_pu"] == "results":
         ppc["bus"][aux_idx, VM] = net["res_%s" % element]["vm_internal_pu"].values

--- a/pandapower/converter/powermodels/to_pm.py
+++ b/pandapower/converter/powermodels/to_pm.py
@@ -50,11 +50,11 @@ class NumpyEncoder(json.JSONEncoder):
 
 def convert_pp_to_pm(net, pm_file_path=None, correct_pm_network_data=True,
                      calculate_voltage_angles=True,
-                     ac=True, silence=True, trafo_model="t", delta=1e-8, trafo3w_losses="hv",
-                     check_connectivity=True, pp_to_pm_callback=None, pm_model="ACPPowerModel",
-                     pm_solver="ipopt",
-                     pm_mip_solver="cbc", pm_nl_solver="ipopt", opf_flow_lim="S", pm_tol=1e-8,
-                     voltage_depend_loads=False, from_time_step=None, to_time_step=None, **kwargs):
+                     ac=True, silence=True, trafo_model="t", delta=1e-8, delta_xward_vm_pu=1e-3,
+                     trafo3w_losses="hv", check_connectivity=True, pp_to_pm_callback=None,
+                     pm_model="ACPPowerModel", pm_solver="ipopt", pm_mip_solver="cbc",
+                     pm_nl_solver="ipopt", opf_flow_lim="S", pm_tol=1e-8, voltage_depend_loads=False,
+                     from_time_step=None, to_time_step=None, **kwargs):
     """
     Converts a pandapower net to a PowerModels.jl datastructure and saves it to a json file
     INPUT:
@@ -113,7 +113,7 @@ def convert_pp_to_pm(net, pm_file_path=None, correct_pm_network_data=True,
                      mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat",
                      enforce_q_lims=True, recycle=dict(_is_elements=False, ppc=False, Ybus=False),
                      voltage_depend_loads=voltage_depend_loads, delta=delta,
-                     trafo3w_losses=trafo3w_losses)
+                     delta_xward_vm_pu=delta_xward_vm_pu, trafo3w_losses=trafo3w_losses)
     _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
                      pp_to_pm_callback=pp_to_pm_callback, pm_solver=pm_solver, pm_model=pm_model,
                      correct_pm_network_data=correct_pm_network_data, silence=silence,
@@ -602,5 +602,3 @@ def allow_multi_ext_grids(net, pm, ext_grids=None):
     for b in target_pm_buses:
         pm["bus"][str(b)]["bus_type"] = 3
     return pm
-    
-   

--- a/pandapower/run.py
+++ b/pandapower/run.py
@@ -284,7 +284,7 @@ def rundcpp(net, trafo_model="t", trafo_loading="current", recycle=None, check_c
 
 
 def runopp(net, verbose=False, calculate_voltage_angles=True, check_connectivity=True,
-           suppress_warnings=True, switch_rx_ratio=2, delta=1e-10, init="flat", numba=True,
+           suppress_warnings=True, switch_rx_ratio=2, delta=1e-10, delta_xward_vm_pu=1e-3, init="flat", numba=True,
            trafo3w_losses="hv", consider_line_temperature=False, **kwargs):
     """
         Runs the  pandapower Optimal Power Flow.
@@ -347,6 +347,8 @@ def runopp(net, verbose=False, calculate_voltage_angles=True, check_connectivity
 
             **delta** (float, 1e-10) - power tolerance
 
+            **delta_xward_vm_pu** (float, 1e-3) - tolerance of the auxiliary bus of the xward
+
             **trafo3w_losses** (str, "hv") - defines where open loop losses of three-winding transformers are considered. Valid options are "hv", "mv", "lv" for HV/MV/LV side or "star" for the star point.
 
             **consider_line_temperature** (bool, False) - adjustment of line impedance based on provided\
@@ -367,7 +369,8 @@ def runopp(net, verbose=False, calculate_voltage_angles=True, check_connectivity
     _check_necessary_opf_parameters(net, logger)
     _init_runopp_options(net, calculate_voltage_angles=calculate_voltage_angles,
                          check_connectivity=check_connectivity,
-                         switch_rx_ratio=switch_rx_ratio, delta=delta, init=init, numba=numba,
+                         switch_rx_ratio=switch_rx_ratio, delta=delta,
+                         delta_xward_vm_pu=delta_xward_vm_pu, init=init, numba=numba,
                          trafo3w_losses=trafo3w_losses,
                          consider_line_temperature=consider_line_temperature, **kwargs)
     _check_bus_index_and_print_warning_if_high(net)
@@ -376,7 +379,7 @@ def runopp(net, verbose=False, calculate_voltage_angles=True, check_connectivity
 
 
 def rundcopp(net, verbose=False, check_connectivity=True, suppress_warnings=True,
-             switch_rx_ratio=0.5, delta=1e-10, trafo3w_losses="hv", **kwargs):
+             switch_rx_ratio=0.5, delta=1e-10, delta_xward_vm_pu=1e-3, trafo3w_losses="hv", **kwargs):
     """
     Runs the  pandapower Optimal Power Flow.
     Flexibilities, constraints and cost parameters are defined in the pandapower element tables.
@@ -409,6 +412,8 @@ def rundcopp(net, verbose=False, check_connectivity=True, suppress_warnings=True
 
         **delta** (float, 1e-10) - power tolerance
 
+        **delta_xward_vm_pu** (float, 1e-3) - tolerance of the auxiliary bus of the xward
+
         **trafo3w_losses** (str, "hv") - defines where open loop losses of three-winding transformers are considered. Valid options are "hv", "mv", "lv" for HV/MV/LV side or "star" for the star point.
     """
     if (not net.sgen.empty) & ("controllable" not in net.sgen.columns):
@@ -419,6 +424,7 @@ def rundcopp(net, verbose=False, check_connectivity=True, suppress_warnings=True
 
     _init_rundcopp_options(net, check_connectivity=check_connectivity,
                            switch_rx_ratio=switch_rx_ratio, delta=delta,
+                           delta_xward_vm_pu=delta_xward_vm_pu,
                            trafo3w_losses=trafo3w_losses, **kwargs)
     _check_bus_index_and_print_warning_if_high(net)
     _check_gen_index_and_print_warning_if_high(net)

--- a/pandapower/runpm.py
+++ b/pandapower/runpm.py
@@ -11,11 +11,11 @@ from pandapower.opf.run_powermodels import _runpm
 
 
 def runpm(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_angles=True,
-          trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-          correct_pm_network_data=True, silence=True, pm_model="ACPPowerModel", pm_solver="ipopt",
-          pm_mip_solver="cbc", pm_nl_solver="ipopt", pm_time_limits=None, pm_log_level=0,
-          delete_buffer_file=True, pm_file_path = None, opf_flow_lim="S", pm_tol=1e-8,
-          pdm_dev_mode=False, **kwargs):  # pragma: no cover
+          trafo_model="t", delta=1e-8, delta_xward_vm_pu=1e-3, trafo3w_losses="hv",
+          check_connectivity=True, correct_pm_network_data=True, silence=True,
+          pm_model="ACPPowerModel", pm_solver="ipopt", pm_mip_solver="cbc", pm_nl_solver="ipopt",
+          pm_time_limits=None, pm_log_level=0, delete_buffer_file=True, pm_file_path = None,
+          opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):  # pragma: no cover
     """
         Runs  optimal power flow from PowerModels.jl via PandaModels.jl
 
@@ -80,7 +80,8 @@ def runpm(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_angles
                      trafo_model=trafo_model, check_connectivity=check_connectivity,
                      mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat",
                      enforce_q_lims=True, recycle=dict(_is_elements=False, ppc=False, Ybus=False),
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+                     voltage_depend_loads=False, delta=delta, delta_xward_vm_pu=delta_xward_vm_pu,
+                     trafo3w_losses=trafo3w_losses)
     _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
                      pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_opf", pm_solver=pm_solver, pm_model=pm_model,
                      correct_pm_network_data=correct_pm_network_data, silence=silence, pm_mip_solver=pm_mip_solver,
@@ -103,7 +104,8 @@ def runpm_dc_opf(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
                      trafo_model=trafo_model, check_connectivity=check_connectivity,
                      mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat",
                      enforce_q_lims=True, recycle=dict(_is_elements=False, ppc=False, Ybus=False),
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+                     voltage_depend_loads=False, delta=delta, delta_xward_vm_pu=delta_xward_vm_pu,
+                     trafo3w_losses=trafo3w_losses)
     _add_opf_options(net, trafo_loading='power', ac=False, init="flat", numba=True,
                      pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_opf",
                      correct_pm_network_data=correct_pm_network_data, silence=silence, pm_model=pm_model, pm_solver=pm_solver,
@@ -125,7 +127,8 @@ def runpm_ac_opf(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
                      trafo_model=trafo_model, check_connectivity=check_connectivity,
                      mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat",
                      enforce_q_lims=True, recycle=dict(_is_elements=False, ppc=False, Ybus=False),
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+                     voltage_depend_loads=False, delta=delta, delta_xward_vm_pu=delta_xward_vm_pu,
+                     trafo3w_losses=trafo3w_losses)
     _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
                      pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_opf", pm_model="ACPPowerModel", pm_solver=pm_solver,
                      correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
@@ -136,11 +139,11 @@ def runpm_ac_opf(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
 
 
 def runpm_tnep(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_angles=True,
-               trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-               pm_model="ACPPowerModel", pm_solver="juniper", correct_pm_network_data=True, silence=True,
-               pm_nl_solver="ipopt", pm_mip_solver="cbc", pm_time_limits=None, pm_log_level=0,
-               delete_buffer_file=True, pm_file_path=None, opf_flow_lim="S", pm_tol=1e-8,
-               pdm_dev_mode=False, **kwargs):
+               trafo_model="t", delta=1e-8, delta_xward_vm_pu=1e-3, trafo3w_losses="hv",
+               check_connectivity=True, pm_model="ACPPowerModel", pm_solver="juniper",
+               correct_pm_network_data=True, silence=True, pm_nl_solver="ipopt", pm_mip_solver="cbc",
+               pm_time_limits=None, pm_log_level=0, delete_buffer_file=True, pm_file_path=None,
+               opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
     """
     Runs transmission network extension planning (tnep) optimization from PowerModels.jl via PandaModels.jl
     """
@@ -158,7 +161,8 @@ def runpm_tnep(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_a
                      trafo_model=trafo_model, check_connectivity=check_connectivity,
                      mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat",
                      enforce_q_lims=True, recycle=dict(_is_elements=False, ppc=False, Ybus=False),
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+                     voltage_depend_loads=False, delta=delta, delta_xward_vm_pu=delta_xward_vm_pu,
+                     trafo3w_losses=trafo3w_losses)
     _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
                      pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_tnep", pm_model=pm_model, pm_solver=pm_solver,
                      correct_pm_network_data=correct_pm_network_data, silence=silence, pm_nl_solver=pm_nl_solver,
@@ -198,13 +202,14 @@ def runpm_ots(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_an
     read_ots_results(net)
 
 def runpm_storage_opf(net, from_time_step, to_time_step, calculate_voltage_angles=True,
-                      trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-                      n_timesteps=24, time_elapsed=1., correct_pm_network_data=True, silence=True,
-                      pm_solver="juniper", pm_mip_solver="cbc", pm_nl_solver="ipopt",
-                      pm_model="ACPPowerModel", pm_time_limits=None, pm_log_level=0,
-                      opf_flow_lim="S", charge_efficiency=1., discharge_efficiency=1., 
-                      standby_loss=1e-8, p_loss=1e-8, q_loss=1e-8, pm_tol=1e-4, pdm_dev_mode=False, 
-                      delete_buffer_file=True, pm_file_path = None, **kwargs):  
+                      trafo_model="t", delta=1e-8, delta_xward_vm_pu=1e-3, trafo3w_losses="hv",
+                      check_connectivity=True, n_timesteps=24, time_elapsed=1.,
+                      correct_pm_network_data=True, silence=True, pm_solver="juniper",
+                      pm_mip_solver="cbc", pm_nl_solver="ipopt", pm_model="ACPPowerModel",
+                      pm_time_limits=None, pm_log_level=0, opf_flow_lim="S", charge_efficiency=1.,
+                      discharge_efficiency=1., standby_loss=1e-8, p_loss=1e-8, q_loss=1e-8,
+                      pm_tol=1e-4, pdm_dev_mode=False, delete_buffer_file=True, pm_file_path = None,
+                      **kwargs):
     """
     Runs a non-linear power system optimization with storages and time series using PandaModels.jl.
     """
@@ -217,7 +222,8 @@ def runpm_storage_opf(net, from_time_step, to_time_step, calculate_voltage_angle
                      trafo_model=trafo_model, check_connectivity=check_connectivity,
                      mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat",
                      enforce_q_lims=True, recycle=dict(_is_elements=False, ppc=False, Ybus=False),
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+                     voltage_depend_loads=False, delta=delta, delta_xward_vm_pu=delta_xward_vm_pu,
+                     trafo3w_losses=trafo3w_losses)
     _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
                      pp_to_pm_callback=add_storage_opf_settings, julia_file="run_powermodels_multi_storage",
                      correct_pm_network_data=correct_pm_network_data, silence=silence, pm_model=pm_model,

--- a/pandapower/test/opf/test_basic.py
+++ b/pandapower/test/opf/test_basic.py
@@ -952,5 +952,54 @@ def test_gen_violated_p_vm_limits(four_bus_net):
     assert min_vm_pu < net.res_bus.at[bus, "vm_pu"] < max_vm_pu
 
 
+def test_xward():
+    #FIXME: Ideas for a test needed, or remove the test.
+    #TODO: Remove the next three lines
+    import warnings
+    warnings.simplefilter(action='ignore', category=FutureWarning)
+
+    net=pp.create_empty_network()
+    pp.create_bus(net, 0.4, min_vm_pu=0.9, max_vm_pu=1.1)
+    pp.create_bus(net, 0.4, min_vm_pu=0.9, max_vm_pu=1.1)
+    pp.create_line(net,0,1,1, "NAYY 4x50 SE", "line")
+    pp.create_ext_grid(net,0)
+    pp.create_xward(
+        net,
+        bus=1,
+        pz_mw=0.03,
+        qz_mvar=0.01,
+        ps_mw=-0.03,
+        qs_mvar=0.01,
+        vm_pu=0.895,
+        x_ohm=0.01,
+        r_ohm=0.02,
+    )
+    pp.runpp(net)
+    #TODO: Remove print statement
+    print(
+        net.res_xward.vm_pu.iloc[0] - net["_options"]["delta_xward_vm_pu"],
+        net.res_xward.vm_internal_pu.iloc[0],
+        net.res_xward.vm_pu.iloc[0] + net["_options"]["delta_xward_vm_pu"],
+    )
+    assert not (
+        (net.res_xward.vm_pu.iloc[0] - net["_options"]["delta_xward_vm_pu"])
+        <= net.res_xward.vm_internal_pu.iloc[0]
+        <= (net.res_xward.vm_pu.iloc[0] + net["_options"]["delta_xward_vm_pu"])
+    )
+    pp.runopp(net)
+    #TODO: Remove print statement
+    print(
+        net.res_xward.vm_pu.iloc[0] - net["_options"]["delta_xward_vm_pu"],
+        net.res_xward.vm_internal_pu.iloc[0],
+        net.res_xward.vm_pu.iloc[0] + net["_options"]["delta_xward_vm_pu"],
+    )
+    assert (
+        (net.res_xward.vm_pu.iloc[0] - net["_options"]["delta_xward_vm_pu"])
+        <= net.res_xward.vm_internal_pu.iloc[0]
+        <= (net.res_xward.vm_pu.iloc[0] + net["_options"]["delta_xward_vm_pu"])
+    )
+
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-xs"])


### PR DESCRIPTION
@friederikemeier @rbolgaryn 

Shortly before pd2ppc() is executed, reset_results() is called inside _optimal_powerflow.py. Since net.res_xward.internal_vm_pu is needed, i added an if clause which prevents the clearing of this column in case of an OPF with xward elements. Inside _fill_auxiliary_buses(), these values are then assigned to the constraints of the internal buses of the xward.

This pull request is not final since issues remain. I have not been able to constrain the vm_internal_pu values with higher accuracy then 0.1, since the opf fails. Especially the q_mvar values in the result tables differ greatly between power flow and opf. Are the constraints for p_mw and q_mvar for xwards correct?

Here is an example:
`pp.runpp(net)`
`print(net.res_xward)`  
`pp.runopp(net, OPF_VIOLATION=1e-3, PDIPM_COSTTOL=1e-3, PDIPM_FEASTOL=1e-3, PDIPM_GRADTOL=1e-3, PDIPM_COMPTOL=1e-3, PDIPM_MAX_IT=1000, SCPDIPM_RED_IT=20)`
`print(net.res_xward)`
![image](https://user-images.githubusercontent.com/49401816/68087894-1be4c500-fe5a-11e9-9c84-4b8b8f08d9cd.png)
