### PR TITLE
run_timeseries deprecates output_writer keyword argument

### DIFF
--- a/tutorials/time_series.ipynb
+++ b/tutorials/time_series.ipynb
@@ -135,7 +135,7 @@
         "colab_type": "text"
       },
       "source": [
-        "We start by creating a simple example pandapower net consinsting of five buses, a transfomer, three lines, a load and a sgen. "
+        "We start by creating a simple example pandapower net consisting of five buses, a transfomer, three lines, a load and a sgen. "
       ]
     },
     {

--- a/tutorials/time_series.ipynb
+++ b/tutorials/time_series.ipynb
@@ -123,7 +123,7 @@
         "    ow = create_output_writer(net, time_steps, output_dir=output_dir)\n",
         "\n",
         "    # 5. the main time series function\n",
-        "    run_timeseries(net, time_steps, output_writer=ow)"
+        "    run_timeseries(net, time_steps)"
       ],
       "execution_count": 0,
       "outputs": []

--- a/tutorials/time_series_advanced_output.ipynb
+++ b/tutorials/time_series_advanced_output.ipynb
@@ -88,7 +88,7 @@
     "    ow = create_output_writer(net, time_steps, output_dir)\n",
     "\n",
     "    # 5. the main time series function\n",
-    "    run_timeseries(net, time_steps, output_writer=ow)"
+    "    run_timeseries(net, time_steps)"
    ]
   },
   {

--- a/tutorials/time_series_advanced_output.ipynb
+++ b/tutorials/time_series_advanced_output.ipynb
@@ -95,7 +95,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We start by creating a simple example pandapower net consinsting of five buses, a transfomer, three lines, a load and a sgen. "
+    "We start by creating a simple example pandapower net consisting of five buses, a transfomer, three lines, a load and a sgen. "
    ]
   },
   {


### PR DESCRIPTION
This PR simply removes the unneeded output_writer argument, avoiding the deprecation message,
since OutputWriter constructor takes a *net* argument and assigns itself.