### PR TITLE
Quiet down the warnings emitted by the unit tests.

### DIFF
--- a/pandapower/build_bus.py
+++ b/pandapower/build_bus.py
@@ -562,7 +562,8 @@ def _add_motor_impedances_ppc(net, ppc):
     r_motor = motor.rx * x_motor
     y_motor = 1 / (r_motor + x_motor * 1j)
 
-    buses, gs, bs = _sum_by_group(motor_buses_ppc, y_motor.real, y_motor.imag)
+    y_motor_np = y_motor.to_numpy()
+    buses, gs, bs = _sum_by_group(motor_buses_ppc, y_motor_np.real, y_motor_np.imag)
     ppc["bus"][buses, GS] = gs
     ppc["bus"][buses, BS] = bs
 

--- a/pandapower/build_bus.py
+++ b/pandapower/build_bus.py
@@ -563,11 +563,7 @@ def _add_motor_impedances_ppc(net, ppc):
     r_motor = motor.rx * x_motor
     y_motor = 1 / (r_motor + x_motor * 1j)
 
-    if version.parse(pd.__version__) < version.parse("0.24"):
-        buses, gs, bs = _sum_by_group(motor_buses_ppc, y_motor.real, y_motor.imag)
-    else:
-        y_motor_np = y_motor.to_numpy()
-        buses, gs, bs = _sum_by_group(motor_buses_ppc, y_motor_np.real, y_motor_np.imag)
+    buses, gs, bs = _sum_by_group(motor_buses_ppc, y_motor.real, y_motor.imag)
     ppc["bus"][buses, GS] = gs
     ppc["bus"][buses, BS] = bs
 

--- a/pandapower/build_bus.py
+++ b/pandapower/build_bus.py
@@ -9,6 +9,7 @@ from itertools import chain
 
 import numpy as np
 import pandas as pd
+from packaging import version
 
 from pandapower.auxiliary import _sum_by_group
 from pandapower.pypower.idx_bus import BUS_I, BASE_KV, PD, QD, GS, BS, VMAX, VMIN, BUS_TYPE, NONE, VM, VA,\
@@ -562,8 +563,11 @@ def _add_motor_impedances_ppc(net, ppc):
     r_motor = motor.rx * x_motor
     y_motor = 1 / (r_motor + x_motor * 1j)
 
-    y_motor_np = y_motor.to_numpy()
-    buses, gs, bs = _sum_by_group(motor_buses_ppc, y_motor_np.real, y_motor_np.imag)
+    if version.parse(pd.__version__) < version.parse("0.24"):
+        buses, gs, bs = _sum_by_group(motor_buses_ppc, y_motor.real, y_motor.imag)
+    else:
+        y_motor_np = y_motor.to_numpy()
+        buses, gs, bs = _sum_by_group(motor_buses_ppc, y_motor_np.real, y_motor_np.imag)
     ppc["bus"][buses, GS] = gs
     ppc["bus"][buses, BS] = bs
 

--- a/pandapower/create.py
+++ b/pandapower/create.py
@@ -2021,8 +2021,10 @@ def create_transformer3w(net, hv_bus, mv_bus, lv_bus, std_type, name=None, tap_p
     dd = pd.DataFrame(v, index=[index])
     if version.parse(pd.__version__) < version.parse("0.21"):
         net["trafo3w"] = net["trafo3w"].append(dd).reindex_axis(net["trafo3w"].columns, axis=1)
-    else:
+    elif version.parse(pd.__version__) < version.parse("0.23"):
         net["trafo3w"] = net["trafo3w"].append(dd).reindex(net["trafo3w"].columns, axis=1)
+    else:
+        net["trafo3w"] = net["trafo3w"].append(dd, sort=True).reindex(net["trafo3w"].columns, axis=1)
 
     if not isnan(max_loading_percent):
         if "max_loading_percent" not in net.trafo3w.columns:

--- a/pandapower/pd2ppc_zero.py
+++ b/pandapower/pd2ppc_zero.py
@@ -240,7 +240,8 @@ def _add_ext_grid_sc_impedance_zero(net, ppc):
         x0_grid = net.ext_grid["x0x_%s" % case] * x_grid
         r0_grid = net.ext_grid["r0x0_%s" % case] * x0_grid
     y0_grid = 1 / (r0_grid + x0_grid*1j)
-    buses, gs, bs = aux._sum_by_group(eg_buses_ppc, y0_grid.real, y0_grid.imag)
+    y0_grid_np = y0_grid.to_numpy()
+    buses, gs, bs = aux._sum_by_group(eg_buses_ppc, y0_grid_np.real, y0_grid_np.imag)
     ppc["bus"][buses, GS] = gs
     ppc["bus"][buses, BS] = bs
 

--- a/pandapower/pd2ppc_zero.py
+++ b/pandapower/pd2ppc_zero.py
@@ -243,11 +243,7 @@ def _add_ext_grid_sc_impedance_zero(net, ppc):
         r0_grid = net.ext_grid["r0x0_%s" % case] * x0_grid
     y0_grid = 1 / (r0_grid + x0_grid*1j)
 
-    if version.parse(pd.__version__) < version.parse("0.24"):
-        buses, gs, bs = aux._sum_by_group(eg_buses_ppc, y0_grid.real, y0_grid.imag)
-    else:
-        y0_grid_np = y0_grid.to_numpy()
-        buses, gs, bs = aux._sum_by_group(eg_buses_ppc, y0_grid_np.real, y0_grid_np.imag)
+    buses, gs, bs = aux._sum_by_group(eg_buses_ppc, y0_grid.real, y0_grid.imag)
     ppc["bus"][buses, GS] = gs
     ppc["bus"][buses, BS] = bs
 

--- a/pandapower/pd2ppc_zero.py
+++ b/pandapower/pd2ppc_zero.py
@@ -6,6 +6,8 @@
 import math
 import numpy as np
 import copy
+import pandas as pd
+from packaging import version
 import pandapower.auxiliary as aux
 from pandapower.pd2ppc import _init_ppc
 from pandapower.build_bus import _build_bus_ppc
@@ -240,8 +242,12 @@ def _add_ext_grid_sc_impedance_zero(net, ppc):
         x0_grid = net.ext_grid["x0x_%s" % case] * x_grid
         r0_grid = net.ext_grid["r0x0_%s" % case] * x0_grid
     y0_grid = 1 / (r0_grid + x0_grid*1j)
-    y0_grid_np = y0_grid.to_numpy()
-    buses, gs, bs = aux._sum_by_group(eg_buses_ppc, y0_grid_np.real, y0_grid_np.imag)
+
+    if version.parse(pd.__version__) < version.parse("0.24"):
+        buses, gs, bs = aux._sum_by_group(eg_buses_ppc, y0_grid.real, y0_grid.imag)
+    else:
+        y0_grid_np = y0_grid.to_numpy()
+        buses, gs, bs = aux._sum_by_group(eg_buses_ppc, y0_grid_np.real, y0_grid_np.imag)
     ppc["bus"][buses, GS] = gs
     ppc["bus"][buses, BS] = bs
 

--- a/pandapower/toolbox.py
+++ b/pandapower/toolbox.py
@@ -1659,7 +1659,10 @@ def replace_ext_grid_by_gen(net, ext_grids=None):
     if net.res_ext_grid.shape[0]:
         to_add = net.res_ext_grid.loc[ext_grids]
         to_add.index = new_idx
-        net.res_gen = pd.concat([net.res_gen, to_add])
+        if version.parse(pd.__version__) < version.parse("0.23"):
+            net.res_gen = pd.concat([net.res_gen, to_add])
+        else:
+            net.res_gen = pd.concat([net.res_gen, to_add], sort=True)
         net.res_ext_grid.drop(ext_grids, inplace=True)
 
 
@@ -1710,7 +1713,10 @@ def replace_gen_by_ext_grid(net, gens=None):
     if net.res_gen.shape[0]:
         to_add = net.res_gen.loc[gens]
         to_add.index = new_idx
-        net.res_ext_grid = pd.concat([net.res_ext_grid, to_add])
+        if version.parse(pd.__version__) < version.parse("0.23"):
+            net.res_ext_grid = pd.concat([net.res_ext_grid, to_add])
+        else:
+            net.res_ext_grid = pd.concat([net.res_ext_grid, to_add], sort=True)
         net.res_gen.drop(gens, inplace=True)
 
 
@@ -1762,7 +1768,10 @@ def replace_gen_by_sgen(net, gens=None):
     if net.res_gen.shape[0]:
         to_add = net.res_gen.loc[gens]
         to_add.index = new_idx
-        net.res_sgen = pd.concat([net.res_sgen, to_add])
+        if version.parse(pd.__version__) < version.parse("0.23"):
+            net.res_sgen = pd.concat([net.res_sgen, to_add])
+        else:
+            net.res_sgen = pd.concat([net.res_sgen, to_add], sort=True)
         net.res_gen.drop(gens, inplace=True)
 
 
@@ -1815,7 +1824,10 @@ def replace_sgen_by_gen(net, sgens=None):
     if net.res_sgen.shape[0]:
         to_add = net.res_sgen.loc[sgens]
         to_add.index = new_idx
-        net.res_gen = pd.concat([net.res_gen, to_add])
+        if version.parse(pd.__version__) < version.parse("0.23"):
+            net.res_gen = pd.concat([net.res_gen, to_add])
+        else:
+            net.res_gen = pd.concat([net.res_gen, to_add], sort=True)
         net.res_sgen.drop(sgens, inplace=True)
 
 


### PR DESCRIPTION
Modfications to avoid deprecations mostly.
Does not handle:
- old format case files
- warnings from dependencies: I'm looking at you xlsx.py
- hard warnings about divide by zero and matrix singularity