### PR TITLE
Bugfix in ConstControl and create_line with geodata

### DIFF
--- a/pandapower/control/controller/const_control.py
+++ b/pandapower/control/controller/const_control.py
@@ -82,9 +82,10 @@ class ConstControl(Controller):
         if isinstance(self.element_index, int):
             # use .at if element_index is integer for speedup
             self.write = "single_index"
-        elif self.net[self.element].index.equals(Index(self.element_index)):
-            # use : indexer if all elements are in index
-            self.write = "all_index"
+        # commenting this out for now, see issue 609
+        # elif self.net[self.element].index.equals(Index(self.element_index)):
+        #     # use : indexer if all elements are in index
+        #     self.write = "all_index"
         else:
             # use common .loc
             self.write = "loc"

--- a/pandapower/create.py
+++ b/pandapower/create.py
@@ -1434,7 +1434,8 @@ def create_line(net, from_bus, to_bus, length_km, std_type, name=None, index=Non
     _preserve_dtypes(net.line, dtypes)
 
     if geodata is not None:
-        net["line_geodata"].loc[index, "coords"] = geodata
+        net["line_geodata"].loc[index, "coords"] = None
+        net["line_geodata"].at[index, "coords"] = geodata
 
     if not isnan(max_loading_percent):
         if "max_loading_percent" not in net.line.columns:
@@ -1544,7 +1545,8 @@ def create_line_from_parameters(net, from_bus, to_bus, length_km, r_ohm_per_km, 
     _preserve_dtypes(net.line, dtypes)
 
     if geodata is not None:
-        net["line_geodata"].loc[index, "coords"] = geodata
+        net["line_geodata"].loc[index, "coords"] = None
+        net["line_geodata"].at[index, "coords"] = geodata
 
     if not isnan(max_loading_percent):
         if "max_loading_percent" not in net.line.columns:

--- a/pandapower/test/control/test_const_control.py
+++ b/pandapower/test/control/test_const_control.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2016-2020 by University of Kassel and Fraunhofer Institute for Energy Economics
+# and Energy System Technology (IEE), Kassel. All rights reserved.
+
+import pytest
+import pandas as pd
+
+import pandapower as pp
+import pandapower.networks as nw
+import pandapower.control
+import pandapower.timeseries
+import logging as log
+
+logger = log.getLogger(__name__)
+
+
+def test_write():
+    net = nw.simple_four_bus_system()
+    ds = pp.timeseries.DFData(pd.DataFrame(data=[[0., 1., 2.], [2., 3., 4.]]))
+    c1 = pp.control.ConstControl(net, 'sgen', 'p_mw', element_index=[0, 1], profile_name=[0, 1], data_source=ds)
+    pp.create_sgen(net, 0, 0)
+    c2 = pp.control.ConstControl(net, 'sgen', 'p_mw', element_index=[2], profile_name=[2], data_source=ds)
+    c1.time_step(0)
+    c1.control_step()
+    c2.time_step(0)
+    c2.control_step()
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
Closing the issue #609 by disabling the option for write="all_index" in ConstControl

Closing #610 by first adding a row with .loc, and then setting geodata with .at.