### PR TITLE
Fix for geo_data_to_latlong 

### DIFF
--- a/pandapower/plotting/plotly/mapbox_plot.py
+++ b/pandapower/plotting/plotly/mapbox_plot.py
@@ -68,6 +68,9 @@ def geo_data_to_latlong(net, projection):
                        'if geo-coordinates are not in lat/lon format an empty plot may appear...')
         return
 
+    if projection == 'epsg:4326':
+        return
+    
     wgs84 = Proj(init='epsg:4326')  # lat/long
 
     try:


### PR DESCRIPTION
geo_data_to_latlong return coords unchanged if they are already in the WGS84 or epsg4326 format