### PR TITLE
do not preserve dtype of column "name" anymore

### DIFF
--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -243,9 +243,9 @@ class pandapowerNet(ADict):
         return r
 
 
-def _preserve_dtypes(df, dtypes):
+def _preserve_dtypes(df, dtypes, preserve_name_dtype=False):
     for item, dtype in list(dtypes.iteritems()):
-        if df.dtypes.at[item] != dtype:
+        if df.dtypes.at[item] != dtype and preserve_name_dtype or item != "name":
             try:
                 df[item] = df[item].astype(dtype)
             except ValueError:

--- a/pandapower/diagnostic.py
+++ b/pandapower/diagnostic.py
@@ -324,7 +324,7 @@ def no_ext_grid(net):
 
     """
 
-    if not len(net.ext_grid) + sum(net.gen.slack) > 0:
+    if net.ext_grid.in_service.sum() + (net.gen.slack & net.gen.in_service).sum() == 0:
         return True
 
 
@@ -722,7 +722,8 @@ def disconnected_elements(net):
     for section in sections:
         section_dict = {}
 
-        if not section & set(net.ext_grid.bus).union(net.gen.bus[net.gen.slack]) and any(
+        if not section & set(net.ext_grid.bus[net.ext_grid.in_service]).union(
+                net.gen.bus[net.gen.slack & net.gen.in_service]) and any(
                 net.bus.in_service.loc[section]):
             section_buses = list(net.bus[net.bus.index.isin(section)
                                          & (net.bus.in_service == True)].index)

--- a/pandapower/toolbox.py
+++ b/pandapower/toolbox.py
@@ -66,7 +66,7 @@ def pp_elements(bus=True, bus_elements=True, branch_elements=True, other_element
 
 
 def branch_element_bus_dict(include_switch=False):
-    """ """
+    """ Returns a dict with keys of branch elements and values of bus column names as list. """
     ebts = element_bus_tuples(bus_elements=False, branch_elements=True, res_elements=False)
     branch_elements = {ebt[0] for ebt in ebts}
     bebd = {elm: [] for elm in branch_elements}
@@ -693,7 +693,7 @@ def nets_equal(net1, net2, check_only_results=False, exclude_elms=None, **kwargs
                         not_equal.append(df_name)
 
     if len(not_equal) > 0:
-        logger.info("Networks do not match in DataFrame(s): %s" % (', '.join(not_equal)))
+        logger.error("Networks do not match in DataFrame(s): %s" % (', '.join(not_equal)))
 
     return eq
 


### PR DESCRIPTION
I remove the column "name" from preserve_dtypes by default because this leads to difficulties if one have a element table with integer names and want to create another element by giving a string name.

A simple example which leads to error without this PR:

import pandapower as pp
import pandapower.networks as pn
from copy import deepcopy
net = pn.case9()

# unintentionally change of the type
print(net.bus.dtypes["name"])
net.bus.name.loc[net.bus.vn_kv > 500] = "extra high voltage bus"
print(net.bus.dtypes["name"])

# now this leads to error
pp.create_bus(net, 345, name="additional_bus")

@FlorianShepherd @ascheidl Do you see any problem why not to change _preserve_dtype() behaviour in this way?