### PR TITLE
Bugfix deepcopy

### DIFF
--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -183,12 +183,13 @@ class ADict(dict, MutableMapping):
         for k, v in self.items():
             if isinstance(v, pd.DataFrame) and not set(v.columns).isdisjoint(deep_columns):
                 if k not in result:
-                    result[k] = pd.DataFrame(index=v.index, columns=v.columns).astype(v.dtypes)
+                    result[k] = pd.DataFrame(index=v.index, columns=v.columns)
                 for col in v.columns:
                     if col in deep_columns:
                         result[k][col] = v[col].apply(lambda x: copy.deepcopy(x, memo))
                     else:
                         result[k][col] = copy.deepcopy(v[col], memo)
+                _preserve_dtypes(result[k], v.dtypes)
             else:
                 setattr(result, k, copy.deepcopy(v, memo))
 

--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -183,7 +183,7 @@ class ADict(dict, MutableMapping):
         for k, v in self.items():
             if isinstance(v, pd.DataFrame) and not set(v.columns).isdisjoint(deep_columns):
                 if k not in result:
-                    result[k] = pd.DataFrame(index=v.index, columns=v.columns)
+                    result[k] = v.__class__(index=v.index, columns=v.columns)
                 for col in v.columns:
                     if col in deep_columns:
                         result[k][col] = v[col].apply(lambda x: copy.deepcopy(x, memo))

--- a/pandapower/test/api/test_file_io.py
+++ b/pandapower/test/api/test_file_io.py
@@ -74,6 +74,10 @@ def test_json(net_in, tempdir):
         pp.to_json(net_geo, filename)
         net_out = pp.from_json(filename)
         assert_net_equal(net_geo, net_out)
+        assert isinstance(net_out.line_geodata, gpd.GeoDataFrame)
+        assert isinstance(net_out.bus_geodata, gpd.GeoDataFrame)
+        assert isinstance(net_out.bus_geodata.geometry.iat[0], Point)
+        assert isinstance(net_out.line_geodata.geometry.iat[0], LineString)
     except (NameError, ImportError):
         pass
 


### PR DESCRIPTION
1) if net.bus_geodata or net.line_geodata are a GeoDataFrame, net.deepcopy() returned them as pd.DataFrame, because GeoDataFrame is a subclass of DataFrame, check "isinstance(v, pd.DataFrame)" was True.

2) after initializing a DataFrame with index and columns, the values in the DataFrame are np.nan. Casting with astype would lead to an error if np.nan could not safely be cast to a given type (e.g. int). This is fixed by using pandapower.auxiliary._preserve_dtypes

3) Added tests