### PR TITLE
add __dir__ to assist IDEs finding attributes of network object

### DIFF
--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -73,6 +73,9 @@ class ADict(dict, MutableMapping):
     def __getstate__(self):
         return self.copy(), self._allow_invalid_attributes
 
+    def __dir__(self):
+        return list(six.iterkeys(self))
+
     def __setstate__(self, state):
         mapping, allow_invalid_attributes = state
         self.update(mapping)


### PR DESCRIPTION
IDEs can not easily autocomplete attributes of the pandapowerNet/ADict since attributes are modified dynamically. With this change IDEs that use ``__dir__`` to list attributes will be able to offer autocomplete at runtime. This works in pycharm in the debug console, for example. Doesn't help with static analysis of code, for that a stub file would probably be the way to go. 

Before:
<img width="592" alt="Screen Shot 2020-04-14 at 8 41 24 am" src="https://user-images.githubusercontent.com/33386122/79168140-797b3580-7e2c-11ea-9c8a-d2615298c2be.png">

After:
<img width="609" alt="Screen Shot 2020-04-14 at 8 41 53 am" src="https://user-images.githubusercontent.com/33386122/79168174-90ba2300-7e2c-11ea-9ea8-df7b34301e2e.png">
