### PR TITLE
integrate big data 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ pandapower/plotting/plotly/mapbox_token.txt
 pandapower/plotting/plotly/temp-plot.html
 pandapower/test/timeseries/run_timeseries_output/*
 pandapower/timeseries/logs/*
+*/data/*


### PR DESCRIPTION
in order to integrate big data in our repo directly, I suggest to have a folder called 'data', where you can put big data without integrating it into the git repo. For that this folder needs to be in .gitignore.

For Uni Kassel/Fraunhofer employees: We could put all big data concerning pandapower in one owncloud/teams folder and synchronize it with this data folder (big test grids, in future files of the load profile generator...). By that we have one centralized location for all big files concering pandapower.