### PR TITLE
Optimization: Remove iterrows from select_subnet() to improve performance for larger grids.

### DIFF
--- a/pandapower/test/api/test_toolbox.py
+++ b/pandapower/test/api/test_toolbox.py
@@ -476,7 +476,7 @@ def test_select_subnet():
     subnet = pp.select_subnet(net2, buses | elements)
     assert net2.switch[net2.switch.et=='b'].index.isin(subnet.switch.index).all()
 
-    
+
 def test_overloaded_lines():
     net = pp.create_empty_network()
 

--- a/pandapower/test/api/test_toolbox.py
+++ b/pandapower/test/api/test_toolbox.py
@@ -430,6 +430,7 @@ def test_merge_and_split_nets():
     net4 = pp.select_subnet(net, net.bus.index[n1:], include_results=True)
     assert np.allclose(net4.res_bus.vm_pu.values, net2.res_bus.vm_pu.values)
 
+
 def test_select_subnet():
     # This network has switches of type 'l' and 't'
     net = nw.create_cigre_network_mv()
@@ -474,7 +475,7 @@ def test_select_subnet():
     elements = set(net2.switch[net2.switch.et=='b'].element)
     subnet = pp.select_subnet(net2, buses | elements)
     assert net2.switch[net2.switch.et=='b'].index.isin(subnet.switch.index).all()
-    
+
     
 def test_overloaded_lines():
     net = pp.create_empty_network()

--- a/pandapower/test/api/test_toolbox.py
+++ b/pandapower/test/api/test_toolbox.py
@@ -434,7 +434,7 @@ def test_merge_and_split_nets():
 def test_select_subnet():
     # This network has switches of type 'l' and 't'
     net = nw.create_cigre_network_mv()
-    
+
     # Do nothing
     same_net = pp.select_subnet(net, net.bus.index)
     assert pp.dataframes_equal(net.bus, same_net.bus)
@@ -452,7 +452,7 @@ def test_select_subnet():
     assert len(empty.trafo) == 0
     assert len(empty.switch) == 0
     assert len(empty.ext_grid) == 0
-    
+
     # Should keep all trafo ('t') switches when buses are included
     hv_buses = set(net.trafo.hv_bus)
     lv_buses = set(net.trafo.lv_bus)
@@ -466,10 +466,10 @@ def test_select_subnet():
     line_switch_buses = set(net.switch[net.switch.et=='l'].bus)
     subnet = pp.select_subnet(net, from_bus | to_bus | line_switch_buses)
     assert net.switch[net.switch.et=='l'].index.isin(subnet.switch.index).all()
-    
+
     # This network has switches of type 'b'
     net2 = nw.create_cigre_network_lv()
-    
+
     # Should keep all bus-to-bus ('b') switches when buses are included
     buses = set(net2.switch[net2.switch.et=='b'].bus)
     elements = set(net2.switch[net2.switch.et=='b'].element)

--- a/pandapower/toolbox.py
+++ b/pandapower/toolbox.py
@@ -1400,12 +1400,13 @@ def select_subnet(net, buses, include_switch_buses=False, include_results=False,
         p2["line_geodata"] = net["line_geodata"].loc[net["line_geodata"].index.isin(lines)]
 
     # switches
-    si = [i for i, s in net["switch"].iterrows()
-          if s["bus"] in buses and
-          ((s["et"] == "b" and s["element"] in p2["bus"].index) or
-           (s["et"] == "l" and s["element"] in p2["line"].index) or
-           (s["et"] == "t" and s["element"] in p2["trafo"].index))]
-    p2["switch"] = net["switch"].loc[si]
+    p2["switch"] = net.switch[
+        net.switch.bus.isin(p2.bus.index) & pd.concat([
+            net.switch[net.switch.et=='b'].element.isin(p2.bus.index),
+            net.switch[net.switch.et=='l'].element.isin(p2.line.index),
+            net.switch[net.switch.et=='t'].element.isin(p2.trafo.index),
+        ], sort=False)
+    ]
 
     return pandapowerNet(p2)
 


### PR DESCRIPTION
# Motivation

I was working on a large network, and select_subnet would take around 10-20 seconds to execute. I figured out that the bottleneck was the list comprehension with iterrows for the switches. (see the diff)

With this PR, execution time for select_subnet(net, buses) is reduced to around 100ms from 10-20 seconds.

Issue: https://github.com/e2nIEE/pandapower/issues/769