### PR TITLE
pandas req <1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ install:
 
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy scipy pandas=0 networkx numpydoc numba xlsxwriter xlrd
   - source activate test-environment
-  - pip install -e .
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
          conda uninstall numba --yes;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION pip numpy scipy pandas=0 networkx numpydoc numba xlsxwriter xlrd
   - source activate test-environment
+  - pip install -e .
   - if [[ "$TRAVIS_PYTHON_VERSION" == "3.6" ]]; then
          conda uninstall numba --yes;
     fi

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
 	long_description_content_type='text/x-rst',
     url='http://www.pandapower.org',
     license='BSD',
-    install_requires=["pandas>=0.17",
+    install_requires=["pandas>=0.17,<1.0.0",
                       "networkx",
                       "scipy",
                       "numpy>=0.11",


### PR DESCRIPTION
Changed pandas requirements in setup.py to reflect that pandapower doesn't work with pandas 1.

- pandas 1 causes short circuit tests to fail (looked like a pretty trivial fix though)
- pandas 1 has caused issues for other people #736 
- pandas 0 is specified in travis
