### PR TITLE
fixed assertion error with np.isclose

### DIFF
--- a/pandapower/test/opf/test_costs_pwl.py
+++ b/pandapower/test/opf/test_costs_pwl.py
@@ -126,7 +126,7 @@ def test_cost_piecewise_linear_sgen():
 
     assert net["OPF_converged"]
     assert net.res_sgen.p_mw.values[0] - net.sgen.min_p_mw.values[0] < 1e-2
-    assert net.res_cost == 2 * net.res_sgen.p_mw.values
+    assert np.isclose(net.res_cost, 2 * net.res_sgen.p_mw.values[0])
 
 
 def test_cost_piecewise_linear_load():


### PR DESCRIPTION
Fixes the error discussed in #884 using `np.isclose` instead of comparison `==`.
(also added an emptyline at end of file because github online editor apparently does this)