### PR TITLE
Not converging OPF tutorial

### DIFF
--- a/tutorials/opf_basic.ipynb
+++ b/tutorials/opf_basic.ipynb
@@ -82,26 +82,18 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "hp.pandapower.run - INFO: These elements have missing power constraint values, which are considered in OPF as +- 1000 TW: ['gen']\n",
-      "hp.pandapower.run - INFO: min_vm_pu is missing in bus table. In OPF these limits are considered as 0.0 pu.\n",
-      "hp.pandapower.run - INFO: max_vm_pu is missing in bus table. In OPF these limits are considered as 2.0 pu.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "pp.runopp(net)"
+    "pp.runopp(net, delta=1e-16)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "let's check the results:"
+    "This function runs an Optimal Power Flow using the PYPOWER OPF. To make sure that the PYPOWER OPF converges, we decrease the power tolerance `delta` (the default value is `delta=1e-10`). The power tolerance `delta` is a measure of the extent to which exceeding of minimum and maximum power limits is tolerated. That is, in above case, the limits considered by the OPF for the generators are `min_p_mw - delta` and `max_p_mw + delta` as lower and upper bound respectively on the active power. \n",
+    "\n",
+    "Let's check the results:"
    ]
   },
   {
@@ -264,19 +256,9 @@
    "cell_type": "code",
    "execution_count": 7,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "hp.pandapower.run - INFO: These elements have missing power constraint values, which are considered in OPF as +- 1000 TW: ['gen']\n",
-      "hp.pandapower.run - INFO: min_vm_pu is missing in bus table. In OPF these limits are considered as 0.0 pu.\n",
-      "hp.pandapower.run - INFO: max_vm_pu is missing in bus table. In OPF these limits are considered as 2.0 pu.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "pp.runopp(net)"
+    "pp.runopp(net, delta=1e-16)"
    ]
   },
   {
@@ -423,7 +405,7 @@
     {
      "data": {
       "text/plain": [
-       "1445.5955448589666"
+       "1445.5955448594827"
       ]
      },
      "execution_count": 10,
@@ -493,19 +475,9 @@
    "cell_type": "code",
    "execution_count": 13,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "hp.pandapower.run - INFO: These elements have missing power constraint values, which are considered in OPF as +- 1000 TW: ['gen']\n",
-      "hp.pandapower.run - INFO: min_vm_pu is missing in bus table. In OPF these limits are considered as 0.0 pu.\n",
-      "hp.pandapower.run - INFO: max_vm_pu is missing in bus table. In OPF these limits are considered as 2.0 pu.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "pp.runopp(net)"
+    "pp.runopp(net, delta=1e-16)"
    ]
   },
   {
@@ -678,7 +650,7 @@
     {
      "data": {
       "text/plain": [
-       "1619.1908981408608"
+       "1619.190898141058"
       ]
      },
      "execution_count": 17,
@@ -738,20 +710,10 @@
    "cell_type": "code",
    "execution_count": 19,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "hp.pandapower.run - INFO: These elements have missing power constraint values, which are considered in OPF as +- 1000 TW: ['gen']\n",
-      "hp.pandapower.run - INFO: min_vm_pu is missing in bus table. In OPF these limits are considered as 0.0 pu.\n",
-      "hp.pandapower.run - INFO: max_vm_pu is missing in bus table. In OPF these limits are considered as 2.0 pu.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "net.line[\"max_loading_percent\"] = 50\n",
-    "pp.runopp(net)"
+    "pp.runopp(net, delta=1e-16)"
    ]
   },
   {
@@ -932,7 +894,7 @@
     {
      "data": {
       "text/plain": [
-       "1638.0339026783777"
+       "1638.0339026783788"
       ]
      },
      "execution_count": 23,
@@ -1013,7 +975,7 @@
        "      <td>60.863554</td>\n",
        "      <td>-2.430957</td>\n",
        "      <td>14.999985</td>\n",
-       "      <td>4.490946e-22</td>\n",
+       "      <td>4.490949e-22</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>3</th>\n",
@@ -1022,7 +984,7 @@
        "      <td>-73.592614</td>\n",
        "      <td>-4.853496</td>\n",
        "      <td>12.000007</td>\n",
-       "      <td>1.781412e-21</td>\n",
+       "      <td>1.781411e-21</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1032,8 +994,8 @@
        "      vm_pu  va_degree       p_mw    q_mvar      lam_p         lam_q\n",
        "0  1.000000   0.000000 -49.787584  4.603451  10.000000 -1.410210e-21\n",
        "1  1.006024  -3.408832  60.000000  0.000000  13.095255 -5.409162e-02\n",
-       "2  0.993015  -5.815440  60.863554 -2.430957  14.999985  4.490946e-22\n",
-       "3  1.028887  -1.511326 -73.592614 -4.853496  12.000007  1.781412e-21"
+       "2  0.993015  -5.815440  60.863554 -2.430957  14.999985  4.490949e-22\n",
+       "3  1.028887  -1.511326 -73.592614 -4.853496  12.000007  1.781411e-21"
       ]
      },
      "execution_count": 24,
@@ -1056,19 +1018,11 @@
    "cell_type": "code",
    "execution_count": 25,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "hp.pandapower.run - INFO: These elements have missing power constraint values, which are considered in OPF as +- 1000 TW: ['gen']\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "net.bus[\"min_vm_pu\"] = 1.0\n",
     "net.bus[\"max_vm_pu\"] = 1.02\n",
-    "pp.runopp(net)"
+    "pp.runopp(net, delta=1e-16)"
    ]
   },
   {
@@ -1318,7 +1272,7 @@
     {
      "data": {
       "text/plain": [
-       "1642.2574101559044"
+       "1642.2574101559048"
       ]
      },
      "execution_count": 29,
@@ -1345,7 +1299,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pp.rundcopp(net)"
+    "pp.rundcopp(net, delta=1e-16)"
    ]
   },
   {
@@ -1357,7 +1311,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 31,
    "metadata": {},
    "outputs": [
     {
@@ -1393,7 +1347,7 @@
        "    <tr>\n",
        "      <th>0</th>\n",
        "      <td>NaN</td>\n",
-       "      <td>2.369698e-23</td>\n",
+       "      <td>0.000000</td>\n",
        "      <td>-50.000000</td>\n",
        "      <td>NaN</td>\n",
        "      <td>10.000000</td>\n",
@@ -1402,7 +1356,7 @@
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>NaN</td>\n",
-       "      <td>-3.436967e+00</td>\n",
+       "      <td>-3.436967</td>\n",
        "      <td>60.000000</td>\n",
        "      <td>NaN</td>\n",
        "      <td>13.090909</td>\n",
@@ -1411,7 +1365,7 @@
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>NaN</td>\n",
-       "      <td>-5.708566e+00</td>\n",
+       "      <td>-5.708566</td>\n",
        "      <td>61.488746</td>\n",
        "      <td>NaN</td>\n",
        "      <td>15.000000</td>\n",
@@ -1420,7 +1374,7 @@
        "    <tr>\n",
        "      <th>3</th>\n",
        "      <td>NaN</td>\n",
-       "      <td>-1.362340e+00</td>\n",
+       "      <td>-1.362340</td>\n",
        "      <td>-71.488747</td>\n",
        "      <td>NaN</td>\n",
        "      <td>12.000000</td>\n",
@@ -1431,14 +1385,14 @@
        "</div>"
       ],
       "text/plain": [
-       "   vm_pu     va_degree       p_mw  q_mvar      lam_p  lam_q\n",
-       "0    NaN  2.369698e-23 -50.000000     NaN  10.000000    0.0\n",
-       "1    NaN -3.436967e+00  60.000000     NaN  13.090909    0.0\n",
-       "2    NaN -5.708566e+00  61.488746     NaN  15.000000    0.0\n",
-       "3    NaN -1.362340e+00 -71.488747     NaN  12.000000    0.0"
+       "   vm_pu  va_degree       p_mw  q_mvar      lam_p  lam_q\n",
+       "0    NaN   0.000000 -50.000000     NaN  10.000000    0.0\n",
+       "1    NaN  -3.436967  60.000000     NaN  13.090909    0.0\n",
+       "2    NaN  -5.708566  61.488746     NaN  15.000000    0.0\n",
+       "3    NaN  -1.362340 -71.488747     NaN  12.000000    0.0"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 31,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1456,7 +1410,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [
     {
@@ -1569,7 +1523,7 @@
        "2        29.833747  "
       ]
      },
-     "execution_count": 33,
+     "execution_count": 32,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1580,7 +1534,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -1631,7 +1585,7 @@
        "      <td>0.131216</td>\n",
        "      <td>0.262432</td>\n",
        "      <td>1.0</td>\n",
-       "      <td>2.369698e-23</td>\n",
+       "      <td>0.0</td>\n",
        "      <td>1.0</td>\n",
        "      <td>-3.436967</td>\n",
        "      <td>50.0</td>\n",
@@ -1645,10 +1599,10 @@
        "0     50.0        0.0    -50.0        0.0    0.0      0.0  0.131216  0.262432   \n",
        "\n",
        "   vm_hv_pu  va_hv_degree  vm_lv_pu  va_lv_degree  loading_percent  \n",
-       "0       1.0  2.369698e-23       1.0     -3.436967             50.0  "
+       "0       1.0           0.0       1.0     -3.436967             50.0  "
       ]
      },
-     "execution_count": 34,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1666,7 +1620,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 34,
    "metadata": {},
    "outputs": [
     {
@@ -1701,9 +1655,9 @@
        "      <th>slack</th>\n",
        "      <th>in_service</th>\n",
        "      <th>type</th>\n",
+       "      <th>controllable</th>\n",
        "      <th>min_p_mw</th>\n",
        "      <th>max_p_mw</th>\n",
-       "      <th>controllable</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -1720,9 +1674,9 @@
        "      <td>False</td>\n",
        "      <td>True</td>\n",
        "      <td>None</td>\n",
+       "      <td>True</td>\n",
        "      <td>0.0</td>\n",
        "      <td>80.0</td>\n",
-       "      <td>True</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
@@ -1737,9 +1691,9 @@
        "      <td>False</td>\n",
        "      <td>True</td>\n",
        "      <td>None</td>\n",
+       "      <td>True</td>\n",
        "      <td>0.0</td>\n",
        "      <td>100.0</td>\n",
-       "      <td>True</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1750,12 +1704,12 @@
        "0  None    2   80.0   1.01     NaN         NaN         NaN      1.0  False   \n",
        "1  None    3  100.0   1.01     NaN         NaN         NaN      1.0  False   \n",
        "\n",
-       "   in_service  type  min_p_mw  max_p_mw  controllable  \n",
-       "0        True  None       0.0      80.0          True  \n",
-       "1        True  None       0.0     100.0          True  "
+       "   in_service  type  controllable  min_p_mw  max_p_mw  \n",
+       "0        True  None          True       0.0      80.0  \n",
+       "1        True  None          True       0.0     100.0  "
       ]
      },
-     "execution_count": 35,
+     "execution_count": 34,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1766,7 +1720,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -1821,7 +1775,7 @@
        "1  81.488747     NaN  -1.362340    1.0"
       ]
      },
-     "execution_count": 36,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1839,16 +1793,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 36,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1605.533761110142"
+       "1605.5337611101422"
       ]
      },
-     "execution_count": 37,
+     "execution_count": 36,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1870,7 +1824,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [
     {
@@ -1907,7 +1861,7 @@
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>0</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>ext_grid</td>\n",
        "      <td>0.0</td>\n",
        "      <td>10.0</td>\n",
@@ -1918,7 +1872,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
-       "      <td>0.0</td>\n",
+       "      <td>0</td>\n",
        "      <td>gen</td>\n",
        "      <td>0.0</td>\n",
        "      <td>15.0</td>\n",
@@ -1929,7 +1883,7 @@
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
-       "      <td>1.0</td>\n",
+       "      <td>1</td>\n",
        "      <td>gen</td>\n",
        "      <td>0.0</td>\n",
        "      <td>12.0</td>\n",
@@ -1944,9 +1898,9 @@
       ],
       "text/plain": [
        "   element        et  cp0_eur  cp1_eur_per_mw  cp2_eur_per_mw2  cq0_eur  \\\n",
-       "0      0.0  ext_grid      0.0            10.0              0.0      0.0   \n",
-       "1      0.0       gen      0.0            15.0              0.0      0.0   \n",
-       "2      1.0       gen      0.0            12.0              0.0      0.0   \n",
+       "0        0  ext_grid      0.0            10.0              0.0      0.0   \n",
+       "1        0       gen      0.0            15.0              0.0      0.0   \n",
+       "2        1       gen      0.0            12.0              0.0      0.0   \n",
        "\n",
        "   cq1_eur_per_mvar  cq2_eur_per_mvar2  \n",
        "0               0.0                0.0  \n",
@@ -1954,7 +1908,7 @@
        "2               0.0                0.0  "
       ]
      },
-     "execution_count": 38,
+     "execution_count": 37,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1972,7 +1926,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1988,7 +1942,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [
     {
@@ -2037,7 +1991,7 @@
        "1       0.0     100.0"
       ]
      },
-     "execution_count": 40,
+     "execution_count": 39,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2048,7 +2002,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -2091,7 +2045,7 @@
        "0   -1000.0    1000.0"
       ]
      },
-     "execution_count": 41,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2109,7 +2063,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 41,
    "metadata": {
     "scrolled": true
    },
@@ -2120,7 +2074,7 @@
        "2"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 41,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2140,7 +2094,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 42,
    "metadata": {},
    "outputs": [
     {
@@ -2195,7 +2149,7 @@
        "1  81.488747     NaN  -1.362340    1.0"
       ]
      },
-     "execution_count": 43,
+     "execution_count": 42,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2206,16 +2160,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 43,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1605.533761110142"
+       "1605.5337611101422"
       ]
      },
-     "execution_count": 44,
+     "execution_count": 43,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2233,16 +2187,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 44,
    "metadata": {},
    "outputs": [],
    "source": [
-    "pp.rundcopp(net)"
+    "pp.rundcopp(net, delta=1e-16)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 45,
    "metadata": {},
    "outputs": [
     {
@@ -2297,7 +2251,7 @@
        "1  81.488747     NaN  -1.362340    1.0"
       ]
      },
-     "execution_count": 46,
+     "execution_count": 45,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2308,16 +2262,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 46,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "1605.533761110142"
+       "1605.5337611101422"
       ]
      },
-     "execution_count": 47,
+     "execution_count": 46,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2335,7 +2289,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 48,
+   "execution_count": 47,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2351,11 +2305,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 49,
+   "execution_count": 48,
    "metadata": {},
    "outputs": [],
    "source": [
-    "pp.rundcopp(net)"
+    "pp.rundcopp(net, delta=1e-16)"
    ]
   },
   {
@@ -2367,7 +2321,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 50,
+   "execution_count": 49,
    "metadata": {},
    "outputs": [
     {
@@ -2422,7 +2376,7 @@
        "1  69.999997     NaN  -1.641146    1.0"
       ]
      },
-     "execution_count": 50,
+     "execution_count": 49,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -2442,16 +2396,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 51,
+   "execution_count": 50,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "hp.pandapower.run - INFO: These elements have missing power constraint values, which are considered in OPF as +- 1000 TW: ['gen']\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -2460,9 +2407,9 @@
       "Python Interior Point Solver - PIPS, Version 1.0, 07-Feb-2011\n",
       "Converged!\n",
       "\n",
-      "Converged in 1.19 seconds\n",
+      "Converged in 1.91 seconds\n",
       "================================================================================\n",
-      "|     System Summary                                                           |\n",
+      "| PyPower (ppci) System Summary - these are not valid for pandapower DataFrames|\n",
       "================================================================================\n",
       "\n",
       "How many?                How much?              P (MW)            Q (MVAr)\n",
@@ -2554,9 +2501,9 @@
       "                                                             --------  --------\n",
       "                                                    Total:     1.649      6.34\n",
       "\n",
-      "Converged in 1.19 seconds\n",
+      "Converged in 1.91 seconds\n",
       "================================================================================\n",
-      "|     System Summary                                                           |\n",
+      "| PyPower (ppci) System Summary - these are not valid for pandapower DataFrames|\n",
       "================================================================================\n",
       "\n",
       "How many?                How much?              P (MW)            Q (MVAr)\n",
@@ -2651,8 +2598,15 @@
     }
    ],
    "source": [
-    "pp.runopp(net, verbose=True)"
+    "pp.runopp(net, verbose=True, delta=1e-16)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
@@ -2673,7 +2627,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.6"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
As reported in #733 and #748 since version 2.2.0 the basic OPF tutorial is not converging anymore. This was fixed by reducing the power tolerance `delta=1e-16` in `runopp()`. 
