### PR TITLE
fix(toolbox): merge asymmetric elements

### DIFF
--- a/pandapower/test/api/test_toolbox.py
+++ b/pandapower/test/api/test_toolbox.py
@@ -431,6 +431,18 @@ def test_merge_and_split_nets():
     assert np.allclose(net4.res_bus.vm_pu.values, net2.res_bus.vm_pu.values)
 
 
+def test_merge_asymmetric():
+    """Test that merging nets properly handles bus IDs for asymmetric elements
+    """
+    net1 = nw.ieee_european_lv_asymmetric()
+    net2 = nw.ieee_european_lv_asymmetric()
+    n_load_busses = len(net1.asymmetric_load.bus.unique())
+    n_sgen_busses = len(net1.asymmetric_sgen.bus.unique())
+    net3 = pp.merge_nets(net1, net2)
+    assert len(net3.asymmetric_load.bus.unique()) == 2 * n_load_busses
+    assert len(net3.asymmetric_sgen.bus.unique()) == 2 * n_sgen_busses
+
+
 def test_select_subnet():
     # This network has switches of type 'l' and 't'
     net = nw.create_cigre_network_mv()

--- a/pandapower/test/toolbox.py
+++ b/pandapower/test/toolbox.py
@@ -34,8 +34,9 @@ def assert_net_equal(a_net, b_net, **kwargs):
     """
     status = True
     namelist = ['bus', 'bus_geodata', 'load', 'sgen', 'ext_grid', 'line', 'shunt', 'line_geodata',
-                'trafo', 'switch', 'trafo3w', 'gen', 'ext_grid', 'res_line', 'res_bus', 'res_sgen',
-                'res_gen', 'res_shunt', 'res_load', 'res_ext_grid', 'res_trafo']
+                'trafo', 'switch', 'trafo3w', 'gen', 'ext_grid', 'asymmetric_load', 'asymmetric_sgen',
+                'res_line', 'res_bus', 'res_sgen', 'res_gen', 'res_shunt', 'res_load', 'res_ext_grid',
+                'res_trafo']
     for name in namelist:
         if name in a_net or name in b_net:
             if not (a_net[name] is None and b_net[name] is None):

--- a/pandapower/toolbox.py
+++ b/pandapower/toolbox.py
@@ -42,14 +42,14 @@ def element_bus_tuples(bus_elements=True, branch_elements=True, res_elements=Fal
     if bus_elements:
         ebts.update([("sgen", "bus"), ("load", "bus"), ("ext_grid", "bus"), ("gen", "bus"),
                      ("ward", "bus"), ("xward", "bus"), ("shunt", "bus"),
-                     ("storage", "bus")])
+                     ("storage", "bus"), ("asymmetric_load", "bus"), ("asymmetric_sgen", "bus")])
     if branch_elements:
         ebts.update([("line", "from_bus"), ("line", "to_bus"), ("impedance", "from_bus"),
                      ("switch", "bus"), ("impedance", "to_bus"), ("trafo", "hv_bus"),
                      ("trafo", "lv_bus"), ("trafo3w", "hv_bus"), ("trafo3w", "mv_bus"),
                      ("trafo3w", "lv_bus"), ("dcline", "from_bus"), ("dcline", "to_bus")])
     if res_elements:
-        elements_without_res = ["switch", "measurement"]
+        elements_without_res = ["switch", "measurement", "asymmetric_load", "asymmetric_sgen"]
         ebts.update(
             [("res_" + ebt[0], ebt[1]) for ebt in ebts if ebt[0] not in elements_without_res])
     return ebts
@@ -2324,7 +2324,8 @@ def get_connected_elements(net, element, buses, respect_switches=True, respect_i
         element_table = net.impedance
         connected_elements = set(net["impedance"].index[(net.impedance.from_bus.isin(buses)) |
                                                         (net.impedance.to_bus.isin(buses))])
-    elif element in ["gen", "ext_grid", "xward", "shunt", "ward", "sgen", "load", "storage"]:
+    elif element in ["gen", "ext_grid", "xward", "shunt", "ward", "sgen", "load", "storage",
+                     "asymmetric_load", "asymmetric_sgen"]:
         element_table = net[element]
         connected_elements = set(element_table.index[(element_table.bus.isin(buses))])
     elif element == "measurement":


### PR DESCRIPTION
Update bus IDs for net.asymmetric_load and net.asymmetric_sgen when merging nets.

I feel like this is a small piece of a larger refactor needed to support asymmetric elements in toolbox.py, so it's fine if you want to ignore this.