### PR TITLE
fixed bugs in pandapower toolbox related to the implementation of trafo3w

### DIFF
--- a/pandapower/test/api/test_toolbox.py
+++ b/pandapower/test/api/test_toolbox.py
@@ -876,29 +876,30 @@ def test_get_connected_buses():
     bus4 = pp.create_bus(net, vn_kv=0.4)
     bus5 = pp.create_bus(net, vn_kv=20)
 
-    trafo0 = pp.create_transformer3w(net, hv_bus=bus0, mv_bus=bus1, lv_bus=bus2, name='trafo0',
-                                     std_type='63/25/38 MVA 110/20/10 kV')
+    trafo0 = pp.create_transformer3w(net, hv_bus=bus0, mv_bus=bus1, lv_bus=bus2, std_type='63/25/38 MVA 110/20/10 kV')
     trafo1 = pp.create_transformer(net, hv_bus=bus2, lv_bus=bus3, std_type='0.4 MVA 10/0.4 kV')
+    line1 = pp.create_line(net, from_bus=bus3, to_bus=bus4, length_km=20.1, std_type='24-AL1/4-ST1A 0.4')
 
-    line1 = pp.create_line(net, from_bus=bus3, to_bus=bus4, length_km=20.1,
-                           std_type='24-AL1/4-ST1A 0.4', name='line1')
-
-    # switch0=pp.create_switch(net, bus = bus0, element = trafo0, et = 't3') #~~~~~ not implementable
+    switch0a = pp.create_switch(net, bus=bus0, element=trafo0, et='t3')
+    switch0b = pp.create_switch(net, bus=bus2, element=trafo0, et='t3')
     switch1 = pp.create_switch(net, bus=bus1, element=bus5, et='b')
     switch2 = pp.create_switch(net, bus=bus2, element=trafo1, et='t')
     switch3 = pp.create_switch(net, bus=bus3, element=line1, et='l')
 
-    assert list(tb.get_connected_buses(net, [bus0])) == [bus1, bus2]  # trafo3w has not been implemented in the function
-    assert list(tb.get_connected_buses(net, [bus1])) == [bus0, bus2,
-                                                         bus5]  # trafo3w has not been implemented in the function
-    assert list(tb.get_connected_buses(net, [bus2])) == [bus0, bus1,
-                                                         bus3]  # trafo3w has not been implemented in the function
+    assert list(tb.get_connected_buses(net, [bus0])) == [bus1, bus2]
+    assert list(tb.get_connected_buses(net, [bus1])) == [bus0, bus2, bus5]
+    assert list(tb.get_connected_buses(net, [bus2])) == [bus0, bus1, bus3]
     assert list(tb.get_connected_buses(net, [bus3])) == [bus2, bus4]
     assert list(tb.get_connected_buses(net, [bus4])) == [bus3]
     assert list(tb.get_connected_buses(net, [bus5])) == [bus1]
-
     assert list(tb.get_connected_buses(net, [bus0, bus1])) == [bus2, bus5]
     assert list(tb.get_connected_buses(net, [bus2, bus3])) == [bus0, bus1, bus4]
+
+    net.switch.loc[[switch0b, switch1, switch2, switch3], 'closed'] = False
+    assert list(tb.get_connected_buses(net, [bus0])) == [bus1]
+    assert list(tb.get_connected_buses(net, [bus1])) == [bus0]
+    assert list(tb.get_connected_buses(net, [bus3])) == []
+    assert list(tb.get_connected_buses(net, [bus4])) == []
 
 
 def test_drop_elements_at_buses():
@@ -911,43 +912,39 @@ def test_drop_elements_at_buses():
     bus4 = pp.create_bus(net, vn_kv=0.4)
     bus5 = pp.create_bus(net, vn_kv=20)
 
+    pp.create_ext_grid(net, 0)
+
     trafo0 = pp.create_transformer3w(net, hv_bus=bus0, mv_bus=bus1, lv_bus=bus2, name='trafo0',
                                      std_type='63/25/38 MVA 110/20/10 kV')
     trafo1 = pp.create_transformer(net, hv_bus=bus2, lv_bus=bus3, std_type='0.4 MVA 10/0.4 kV')
 
     line1 = pp.create_line(net, from_bus=bus3, to_bus=bus4, length_km=20.1,
                            std_type='24-AL1/4-ST1A 0.4', name='line1')
+    pp.create_sgen(net, 1, 0)
 
-    # switch0=pp.create_switch(net, bus = bus0, element = trafo0, et = 't3') #~~~~~ not implementable now
+    switch0a = pp.create_switch(net, bus=bus0, element=trafo0, et='t3')
+    switch0b = pp.create_switch(net, bus=bus1, element=trafo0, et='t3')
+    switch0c = pp.create_switch(net, bus=bus2, element=trafo0, et='t3')
     switch1 = pp.create_switch(net, bus=bus1, element=bus5, et='b')
-    switch2 = pp.create_switch(net, bus=bus2, element=trafo1, et='t')
-    switch3 = pp.create_switch(net, bus=bus3, element=line1, et='l')
+    switch2a = pp.create_switch(net, bus=bus2, element=trafo1, et='t')
+    switch2b = pp.create_switch(net, bus=bus3, element=trafo1, et='t')
+    switch3a = pp.create_switch(net, bus=bus3, element=line1, et='l')
+    switch3b = pp.create_switch(net, bus=bus4, element=line1, et='l')
     # bus id needs to be entered as iterable, not done in the function
-    tb.drop_elements_at_buses(net, [bus5])
-    assert len(net.switch) == 2
-    assert len(net.trafo) == 1
-    assert len(net.trafo3w) == 1
-    assert len(net.line) == 1
-    tb.drop_elements_at_buses(net, [bus4])
-    assert len(net.switch) == 1
-    assert len(net.line) == 0
-    assert len(net.trafo) == 1
-    assert len(net.trafo3w) == 1
-    tb.drop_elements_at_buses(net, [bus3])
-    assert len(net.switch) == 0
-    assert len(net.line) == 0
-    assert len(net.trafo) == 0
-    assert len(net.trafo3w) == 1
-    tb.drop_elements_at_buses(net, [bus2])
-    assert len(net.switch) == 0
-    assert len(net.line) == 0
-    assert len(net.trafo) == 0
-    assert len(net.trafo3w) == 0
-    tb.drop_elements_at_buses(net, [bus1])
-    assert len(net.switch) == 0
-    assert len(net.line) == 0
-    assert len(net.trafo) == 0
-    assert len(net.trafo3w) == 0
+
+    for b in net.bus.index.values:
+        net1 = net.deepcopy()
+        cd = tb.get_connected_elements_dict(net1, b, connected_buses=False)
+        swt3w = set(net1.switch.loc[net1.switch.element.isin(cd.get('trafo3w', [1000])) & (net1.switch.et=='t3')].index)
+        swt = set(net1.switch.loc[net1.switch.element.isin(cd.get('trafo', [1000])) & (net1.switch.et=='t')].index)
+        swl = set(net1.switch.loc[net1.switch.element.isin(cd.get('line', [1000])) & (net1.switch.et=='l')].index)
+        sw = swt3w | swt | swl
+        tb.drop_elements_at_buses(net1, [b])
+        assert b not in net1.switch.bus.values
+        assert b not in net1.switch.query("et=='b'").element.values
+        assert sw.isdisjoint(set(net1.switch.index))
+        for elm, id in cd.items():
+            assert len(net1[elm].loc[net1[elm].index.isin(id)]) == 0
 
 
 def test_impedance_line_replacement():

--- a/pandapower/toolbox.py
+++ b/pandapower/toolbox.py
@@ -1175,12 +1175,11 @@ def drop_trafos(net, trafos, table="trafo"):
     if table not in ('trafo', 'trafo3w'):
         raise UserWarning("parameter 'table' must be 'trafo' or 'trafo3w'")
     # drop any switches
-    num_switches = 0
-    if table == 'trafo':  # remove as soon as the trafo3w switches are implemented
-        i = net["switch"].index[(net["switch"]["element"].isin(trafos)) &
-                                (net["switch"]["et"] == "t")]
-        net["switch"].drop(i, inplace=True)
-        num_switches = len(i)
+    et = "t" if table == 'trafo' else "t3"
+    # remove any affected trafo or trafo3w switches
+    i = net["switch"].index[(net["switch"]["element"].isin(trafos)) & (net["switch"]["et"] == et)]
+    net["switch"].drop(i, inplace=True)
+    num_switches = len(i)
 
     # drop measurements
     drop_measurements_at_elements(net, table, idx=trafos)
@@ -1296,18 +1295,19 @@ def set_isolated_areas_out_of_service(net, respect_switches=True):
     for tr3w in net.trafo3w.index.values:
         tr3w_buses = net.trafo3w.loc[tr3w, ['hv_bus', 'mv_bus', 'lv_bus']].values
         if not all(net.bus.loc[tr3w_buses, 'in_service'].values):
-            net.trafo3w.loc[tr3w, 'in_service'] = False
+            net.trafo3w.at[tr3w, 'in_service'] = False
+        open_tr3w_switches = net.switch.loc[(net.switch.et == 't3') & ~net.switch.closed & (net.switch.element == tr3w)]
+        if len(open_tr3w_switches) == 3:
+            net.trafo3w.at[tr3w, 'in_service'] = False
 
-    for element in ["line", "trafo"]:
-        oos_elements = net.line[~net.line.in_service].index
-        oos_switches = net.switch[(net.switch.et == element[0]) &
-                                  (net.switch.element.isin(oos_elements))].index
+    for element, et in zip(["line", "trafo"], ["l", "t"]):
+        oos_elements = net[element].query("not in_service").index
+        oos_switches = net.switch[(net.switch.et == et) & net.switch.element.isin(oos_elements)].index
 
         closed_switches.update([i for i in oos_switches.values if not net.switch.at[i, 'closed']])
         net.switch.loc[oos_switches, "closed"] = True
 
-        for idx, bus in net.switch[
-            ~net.switch.closed & (net.switch.et == element[0])][["element", "bus"]].values:
+        for idx, bus in net.switch.loc[~net.switch.closed & (net.switch.et == et)][["element", "bus"]].values:
             if not net.bus.in_service.at[next_bus(net, bus, idx, element)]:
                 net[element].at[idx, "in_service"] = False
     if len(closed_switches) > 0:
@@ -2263,8 +2263,8 @@ def next_bus(net, bus, element_id, et='line', **kwargs):
         bc = ["from_bus", "to_bus"]
     elif et == 'trafo':
         bc = ["hv_bus", "lv_bus"]
-    elif et == "switch" and list(net[et].loc[element_id, ["et"]].values) == [
-        'b']:  # Raises error if switch is not a bus-bus switch
+    elif et == "switch" and list(net[et].loc[element_id, ["et"]].values) == ['b']:
+        # Raises error if switch is not a bus-bus switch
         bc = ["bus", "element"]
     else:
         raise Exception("unknown element type")
@@ -2367,8 +2367,8 @@ def get_connected_buses(net, buses, consider=("l", "s", "t", "t3", "i"), respect
                                                             will be respected
                                                             False: in_service status will be
                                                             ignored
-        **consider** (iterable, ("l", "s", "t"))    - Determines, which types of connections will
-                                                      be will be considered.
+        **consider** (iterable, ("l", "s", "t", "t3", "i"))    - Determines, which types of connections will
+                                                      be considered.
                                                       l: lines
                                                       s: switches
                                                       t: trafos
@@ -2384,16 +2384,12 @@ def get_connected_buses(net, buses, consider=("l", "s", "t", "t3", "i"), respect
     cb = set()
     if "l" in consider:
         in_service_constr = net.line.in_service if respect_in_service else True
-        opened_lines = set(net.switch.loc[(~net.switch.closed) & (net.switch.et == "l")
-                                          ].element.unique()) if respect_switches else {}
-        connected_fb_lines = set(net.line.index[
-                                     (net.line.from_bus.isin(buses)) & ~net.line.index.isin(
-                                         opened_lines) &
-                                     (in_service_constr)])
-        connected_tb_lines = set(net.line.index[
-                                     (net.line.to_bus.isin(buses)) & ~net.line.index.isin(
-                                         opened_lines) &
-                                     (in_service_constr)])
+        opened_lines = set(net.switch.loc[(~net.switch.closed) &
+                                          (net.switch.et == "l")].element.unique()) if respect_switches else set()
+        connected_fb_lines = set(net.line.index[(net.line.from_bus.isin(buses)) &
+                                                ~net.line.index.isin(opened_lines) & in_service_constr])
+        connected_tb_lines = set(net.line.index[(net.line.to_bus.isin(buses)) &
+                                                ~net.line.index.isin(opened_lines) & in_service_constr])
         cb |= set(net.line[net.line.index.isin(connected_tb_lines)].from_bus)
         cb |= set(net.line[net.line.index.isin(connected_fb_lines)].to_bus)
 
@@ -2405,32 +2401,48 @@ def get_connected_buses(net, buses, consider=("l", "s", "t", "t3", "i"), respect
 
     if "t" in consider:
         in_service_constr = net.trafo.in_service if respect_in_service else True
-        opened_trafos = set(net.switch.loc[(~net.switch.closed) & (net.switch.et == "t")
-                                           ].element.unique()) if respect_switches else {}
-        connected_hvb_trafos = set(net.trafo.index[
-                                       (net.trafo.hv_bus.isin(buses)) & ~net.trafo.index.isin(
-                                           opened_trafos) &
-                                       (in_service_constr)])
-        connected_lvb_trafos = set(net.trafo.index[
-                                       (net.trafo.lv_bus.isin(buses)) & ~net.trafo.index.isin(
-                                           opened_trafos) &
-                                       (in_service_constr)])
+        opened_trafos = set(net.switch.loc[(~net.switch.closed) &
+                                           (net.switch.et == "t")].element.unique()) if respect_switches else set()
+        connected_hvb_trafos = set(net.trafo.index[(net.trafo.hv_bus.isin(buses)) &
+                                                   ~net.trafo.index.isin(opened_trafos) & in_service_constr])
+        connected_lvb_trafos = set(net.trafo.index[(net.trafo.lv_bus.isin(buses)) &
+                                                   ~net.trafo.index.isin(opened_trafos) & in_service_constr])
         cb |= set(net.trafo.loc[connected_lvb_trafos].hv_bus.values)
         cb |= set(net.trafo.loc[connected_hvb_trafos].lv_bus.values)
 
     # Gives the lv mv and hv buses of a 3 winding transformer
     if "t3" in consider:
-        ct3 = get_connected_elements(net, "trafo3w", buses, respect_switches, respect_in_service)
-        cb |= set(net.trafo3w.loc[ct3].hv_bus.values)
-        cb |= set(net.trafo3w.loc[ct3].mv_bus.values)
-        cb |= set(net.trafo3w.loc[ct3].lv_bus.values)
+        in_service_constr3w = net.trafo3w.in_service if respect_in_service else True
+        if respect_switches:
+            opened_buses_hv = set(net.switch.loc[~net.switch.closed & (net.switch.et == "t3") &
+                                                 net.switch.bus.isin(net.trafo3w.hv_bus)].bus.unique())
+            opened_buses_mv = set(net.switch.loc[~net.switch.closed & (net.switch.et == "t3") &
+                                                 net.switch.bus.isin(net.trafo3w.mv_bus)].bus.unique())
+            opened_buses_lv = set(net.switch.loc[~net.switch.closed & (net.switch.et == "t3") &
+                                                 net.switch.bus.isin(net.trafo3w.lv_bus)].bus.unique())
+        else:
+            opened_buses_hv = opened_buses_mv = opened_buses_lv = set()
+
+        hvb_trafos3w = set(net.trafo3w.index[net.trafo3w.hv_bus.isin(buses) &
+                                             ~net.trafo3w.hv_bus.isin(opened_buses_hv) & in_service_constr3w])
+        mvb_trafos3w = set(net.trafo3w.index[net.trafo3w.mv_bus.isin(buses) &
+                                             ~net.trafo3w.mv_bus.isin(opened_buses_mv) & in_service_constr3w])
+        lvb_trafos3w = set(net.trafo3w.index[net.trafo3w.lv_bus.isin(buses) &
+                                             ~net.trafo3w.lv_bus.isin(opened_buses_lv) & in_service_constr3w])
+
+        cb |= (set(net.trafo3w.loc[hvb_trafos3w].mv_bus) | set(net.trafo3w.loc[hvb_trafos3w].lv_bus) -
+               opened_buses_mv - opened_buses_lv)
+        cb |= (set(net.trafo3w.loc[mvb_trafos3w].hv_bus) | set(net.trafo3w.loc[mvb_trafos3w].lv_bus) -
+               opened_buses_hv - opened_buses_lv)
+        cb |= (set(net.trafo3w.loc[lvb_trafos3w].hv_bus) | set(net.trafo3w.loc[lvb_trafos3w].mv_bus) -
+               opened_buses_hv - opened_buses_mv)
 
     if "i" in consider:
         in_service_constr = net.impedance.in_service if respect_in_service else True
         connected_fb_impedances = set(net.impedance.index[
-                                          (net.impedance.from_bus.isin(buses)) & (in_service_constr)])
+                                          (net.impedance.from_bus.isin(buses)) & in_service_constr])
         connected_tb_impedances = set(net.impedance.index[
-                                          (net.impedance.to_bus.isin(buses)) & (in_service_constr)])
+                                          (net.impedance.to_bus.isin(buses)) & in_service_constr])
         cb |= set(net.impedance[net.impedance.index.isin(connected_tb_impedances)].from_bus)
         cb |= set(net.impedance[net.impedance.index.isin(connected_fb_impedances)].to_bus)
 
@@ -2483,7 +2495,7 @@ def get_connected_buses_at_element(net, element, et, respect_in_service=False):
     return cb
 
 
-def get_connected_switches(net, buses, consider=('b', 'l', 't'), status="all"):
+def get_connected_switches(net, buses, consider=('b', 'l', 't', 't3'), status="all"):
     """
     Returns switches connected to given buses.
 
@@ -2493,11 +2505,12 @@ def get_connected_switches(net, buses, consider=('b', 'l', 't'), status="all"):
         **buses** (single integer or iterable of ints)
 
     OPTIONAL:
-        **consider** (iterable, ("l", "s", "t"))    - Determines, which types of connections
+        **consider** (iterable, ("l", "s", "t", "t3))    - Determines, which types of connections
                                                       will be considered.
                                                       l: lines
                                                       b: bus-bus-switches
-                                                      t: trafos
+                                                      t: transformers
+                                                      t3: 3W transformers
 
         **status** (string, ("all", "closed", "open"))    - Determines, which switches will
                                                             be considered
@@ -2512,24 +2525,21 @@ def get_connected_switches(net, buses, consider=('b', 'l', 't'), status="all"):
         switch_selection = net.switch.closed
     elif status == "open":
         switch_selection = ~net.switch.closed
-    elif status == "all":
-        switch_selection = np.full(len(net.switch), True, dtype=bool)
     else:
-        logger.warning("Unknown switch status \"%s\" selected! "
-                       "Selecting all switches by default." % status)
+        switch_selection = np.full(len(net.switch), True, dtype=bool)
+        if status != "all":
+            logger.warning("Unknown switch status \"%s\" selected! "
+                           "Selecting all switches by default." % status)
 
     cs = set()
-    if 'b' in consider:
-        cs |= set(net['switch'].index[
-                      (net['switch']['bus'].isin(buses) | net['switch']['element'].isin(buses)) &
-                      (net['switch']['et'] == 'b') & switch_selection])
-    if 'l' in consider:
-        cs |= set(net['switch'].index[(net['switch']['bus'].isin(buses)) & (
-                net['switch']['et'] == 'l') & switch_selection])
-
-    if 't' in consider:
-        cs |= set(net['switch'].index[net['switch']['bus'].isin(buses) & (
-                net['switch']['et'] == 't') & switch_selection])
+    for et in consider:
+        if et == 'b':
+            cs |= set(net['switch'].index[
+                          (net['switch']['bus'].isin(buses) | net['switch']['element'].isin(buses)) &
+                          (net['switch']['et'] == 'b') & switch_selection])
+        else:
+            cs |= set(net['switch'].index[(net['switch']['bus'].isin(buses)) &
+                                          (net['switch']['et'] == et) & switch_selection])
 
     return cs
 


### PR DESCRIPTION
Fixed wrong consideration of trafo3w switches in pandapower toolbox.
Functions that were affected:

* drop_trafos
* set_isolated_areas_out_of_service
* get_connected_buses
* get_connected_switches

Also fixed the tests that did not catch the mistakes.