### PR TITLE
io_utils: bugfix for functions as attributes of classes

### DIFF
--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -442,7 +442,7 @@ class FromSerializableRegistry():
         # class_ = getattr(module, obj) # doesn't work
         return self.obj
 
-    @from_serializable.register(class_name='function', module_name='pandapower.run')
+    @from_serializable.register(class_name='function')
     def function(self):
         module = importlib.import_module(self.module_name)
         class_ = getattr(module, self.obj)  # works


### PR DESCRIPTION
fixed a bug in the function io_utils:

removed the default "module" parameter from @from_serializable.register(class_name='function')