### PR TITLE
JSON I/O: Raise an explicit error if a function is not defined

### DIFF
--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -445,6 +445,9 @@ class FromSerializableRegistry():
     @from_serializable.register(class_name='function')
     def function(self):
         module = importlib.import_module(self.module_name)
+        if not hasattr(module, self.obj):  # in case a function is a lambda or is not defined
+            raise UserWarning('Could not find the definition of the function %s in the module %s' %
+                              (self.obj, module.__name__))
         class_ = getattr(module, self.obj)  # works
         return class_
 


### PR DESCRIPTION
if an object attribute is a function that cannot be loaded, e.g. a lambda or if the function definition has been removed, raise a more clearly worded error for the user.