### PR TITLE
control.ConstControl: added self.modify_values to ConstControl 

### DIFF
--- a/pandapower/control/controller/const_control.py
+++ b/pandapower/control/controller/const_control.py
@@ -138,6 +138,7 @@ class ConstControl(Controller):
         self.values = self.data_source.get_time_step_value(time_step=time,
                                                            profile_name=self.profile_name,
                                                            scale_factor=self.scale_factor)
+        self.modify_values()
         # self.write_to_net()
 
     def initialize_control(self, net):
@@ -162,6 +163,17 @@ class ConstControl(Controller):
         if self.values is not None:
             self.write_to_net(net)
         self.applied = True
+
+    def modify_values(self):
+        """
+        This function is applied to self.values after retrieving them from the data_source.
+        Use-case: setting min/max constraints for OPF depending on the time series values of a variable, or as a
+        postprocessing step to ensure that the values are within an allowed range.
+        This method can be overloaded in a class that inherits from ConstControl to use this functionality,
+        see test_const_control.py for reference.
+        Example: self.values = np.clip(self.values, 0, 10)
+        """
+        pass
 
     def _write_to_single_index(self, net):
         net[self.element].at[self.element_index, self.variable] = self.values

--- a/pandapower/control/controller/trafo_control.py
+++ b/pandapower/control/controller/trafo_control.py
@@ -58,7 +58,7 @@ class TrafoController(Controller):
         self.controlled_bus = net[self.trafotable].at[tid, side + "_bus"]
         if self.controlled_bus in net.ext_grid.loc[net.ext_grid.in_service, 'bus'].values:
             logger.warning("Controlled Bus is Slack Bus - deactivating controller")
-            self.set_active(False)
+            self.set_active(net, False)
         elif self.controlled_bus in net.ext_grid.loc[
             ~net.ext_grid.in_service, 'bus'].values:
             logger.warning("Controlled Bus is Slack Bus with slack out of service - "

--- a/pandapower/test/control/test_const_control.py
+++ b/pandapower/test/control/test_const_control.py
@@ -5,6 +5,7 @@
 
 import pytest
 import pandas as pd
+import numpy as np
 
 import pandapower as pp
 import pandapower.networks as nw
@@ -15,16 +16,40 @@ import logging as log
 logger = log.getLogger(__name__)
 
 
+class ModifiedConstControl(pp.control.ConstControl):
+    def modify_values(self):
+        self.values = np.square(self.values)
+
+
 def test_write():
     net = nw.simple_four_bus_system()
     ds = pp.timeseries.DFData(pd.DataFrame(data=[[0., 1., 2.], [2., 3., 4.]]))
     c1 = pp.control.ConstControl(net, 'sgen', 'p_mw', element_index=[0, 1], profile_name=[0, 1], data_source=ds)
     pp.create_sgen(net, 0, 0)
-    c2 = pp.control.ConstControl(net, 'sgen', 'p_mw', element_index=[2], profile_name=[2], data_source=ds)
-    c1.time_step(net, 0)
-    c1.control_step(net)
-    c2.time_step(net, 0)
-    c2.control_step(net)
+    c2 = pp.control.ConstControl(net, 'sgen', 'p_mw', element_index=[2], profile_name=[2], data_source=ds,
+                                 scale_factor=0.5)
+    for t in range(2):
+        c1.time_step(net, t)
+        c1.control_step(net)
+        c2.time_step(net, t)
+        c2.control_step(net)
+        assert np.all(net.sgen.p_mw.values == ds.df.loc[t].values * np.array([1, 1, 0.5]))
+
+
+def test_modified_values():
+    net = nw.simple_four_bus_system()
+    ds = pp.timeseries.DFData(pd.DataFrame(data=[[0., 1., 2.], [2., 3., 4.]]))
+    c1 = ModifiedConstControl(net, 'sgen', 'p_mw', element_index=[0, 1], profile_name=[0, 1], data_source=ds,
+                              scale_factor=0.5)
+    pp.create_sgen(net, 0, 0)
+    c2 = ModifiedConstControl(net, 'sgen', 'p_mw', element_index=[2], profile_name=[2], data_source=ds,
+                              scale_factor=0.25)
+    for t in range(2):
+        c1.time_step(net, t)
+        c1.control_step(net)
+        c2.time_step(net, t)
+        c2.control_step(net)
+        assert np.all(net.sgen.p_mw.values == np.square(ds.df.loc[t].values * np.array([0.5, 0.5, 0.25])))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Purpose: to be able to inherit from ConstControl and override self.modify_values for a custom post-processing step of the timeseries values

Possible use-cases:

* Setting of OPF limits depending on the actual value of a time step

e.g. loads are used as a flexibility option, and their consumption can be increased by 15 %. If some loads are negative (e.g. representing demand-side management loads, or EV charging), their injection can be reduced by 15 %. Then, the method modify_values can be overloaded:

```python
class ModifiedConstControl(pp.control.ConstControl):
    def modify_values(self):
        self.values[self.values>0] *= 1.15
        self.values[self.values<0] *= 0.85
```

* Postprocessing - e.g. ensuring that the values are within certain limits:

```python
class ModifiedConstControl(pp.control.ConstControl):
    def modify_values(self):
        self.values = np.clip(self.values, 0, 10)
```