### PR TITLE
Update .travis.yml - remove python 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ env:
 
 matrix:
   include:
-    - python: 3.5
+    #- python: 3.5
     - python: 3.6
     - python: 3.7
     - python: 3.8


### PR DESCRIPTION
Python 3.5 fails with travisCI sometimes, and it is not clear why this happens.
GitHub Actions run through for python 3.5.