### PR TITLE
switch engine to openpyxl in from_excel

### DIFF
--- a/pandapower/file_io.py
+++ b/pandapower/file_io.py
@@ -178,7 +178,7 @@ def from_excel(filename, convert=True):
     elif pd_version < version.parse("0.24"):
         xls = pd.ExcelFile(filename).parse(sheet_name=None)
     else:
-        xls = pd.ExcelFile(filename).parse(sheet_name=None, index_col=0)
+        xls = pd.ExcelFile(filename).parse(sheet_name=None, index_col=0, engine="openpyxl")
 
     try:
         net = io_utils.from_dict_of_dfs(xls)

--- a/pandapower/file_io.py
+++ b/pandapower/file_io.py
@@ -178,8 +178,8 @@ def from_excel(filename, convert=True):
     elif pd_version < version.parse("0.24"):
         xls = pd.ExcelFile(filename).parse(sheet_name=None)
     else:
-        xls = pd.ExcelFile(filename).parse(sheet_name=None, index_col=0, engine="openpyxl")
-
+        xls = pd.read_excel(filename, sheet_name=None, index_col=0, engine="openpyxl")
+        
     try:
         net = io_utils.from_dict_of_dfs(xls)
     except:

--- a/setup.py
+++ b/setup.py
@@ -47,9 +47,10 @@ setup(
                       "scipy",
                       "numpy>=0.11",
                       "packaging",
-					  "xlsxwriter",
-					  "xlrd",
-					  "cryptography"],
+                      "xlsxwriter",
+                      "xlrd",
+                      "openpyxl",
+                      "cryptography"],
     extras_require={
 		"docs": ["numpydoc", "sphinx", "sphinx_rtd_theme"],
 		"plotting": ["plotly", "matplotlib", "python-igraph"],


### PR DESCRIPTION
newer versions of xlrd (used in pandas) dropped support for anything other than .xls, and using an older version of xlrd is not recommended for security reasons.