### PR TITLE
Update io_utils.py

### DIFF
--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -480,7 +480,7 @@ class FromSerializableRegistry():
                 return df
 
     if GEOPANDAS_INSTALLED:
-        @from_serializable.register(class_name='GeoDataFrame')
+        @from_serializable.register(class_name='GeoDataFrame', module_name='geopandas.geodataframe')
         def GeoDataFrame(self):
             df = geopandas.GeoDataFrame.from_features(fiona.Collection(self.obj),
                                                       crs=self.d['crs']).astype(self.d['dtype'])


### PR DESCRIPTION
Missed module_name='geopandas.geodataframe': With py3.8 and newest versions of pandas & co, it won't read json files with geodataframe, without this module_name attached.