### PR TITLE
adding continue_on_divergence and check_each_level 

### DIFF
--- a/pandapower/timeseries/run_time_series.py
+++ b/pandapower/timeseries/run_time_series.py
@@ -260,7 +260,7 @@ def init_time_series(net, time_steps, continue_on_divergence=False, verbose=True
 
     init_output_writer(net, time_steps)
     # as base take everything considered when preparing run_control
-    ts_variables = prepare_run_ctrl(net, None)
+    ts_variables = prepare_run_ctrl(net, None, **kwargs)
     # run function to be called in run_control - default is pp.runpp, but can be runopf or whatever you like
     ts_variables["run"] = run
     # recycle options, which define what can be recycled


### PR DESCRIPTION
as additional kwargs to run_control.py. This enables you to fire ctrl_repair if run_funct is not converging and that each level is checked for control convergence or not.