### PR TITLE
3ph input diagnostic

### DIFF
--- a/pandapower/create.py
+++ b/pandapower/create.py
@@ -1905,7 +1905,7 @@ def create_line_from_parameters(net, from_bus, to_bus, length_km, r_ohm_per_km, 
                                 max_loading_percent=nan, alpha=nan,
                                 temperature_degree_celsius=nan, r0_ohm_per_km=nan,
                                 x0_ohm_per_km=nan, c0_nf_per_km=nan, g0_us_per_km=0,
-                                endtemp_degree=nan, **kwargs):
+                                endtemp_degree=nan, std_type=None, **kwargs):
     """
     Creates a line element in net["line"] from line parameters.
 
@@ -1976,7 +1976,7 @@ def create_line_from_parameters(net, from_bus, to_bus, length_km, r_ohm_per_km, 
 
     v = {
         "name": name, "length_km": length_km, "from_bus": from_bus,
-        "to_bus": to_bus, "in_service": bool(in_service), "std_type": None,
+        "to_bus": to_bus, "in_service": bool(in_service), "std_type": std_type,
         "df": df, "r_ohm_per_km": r_ohm_per_km, "x_ohm_per_km": x_ohm_per_km,
         "c_nf_per_km": c_nf_per_km, "max_i_ka": max_i_ka, "parallel": parallel, "type": type,
         "g_us_per_km": g_us_per_km

--- a/pandapower/diagnostic_reports.py
+++ b/pandapower/diagnostic_reports.py
@@ -37,7 +37,8 @@ def diagnostic_report(net, diag_results, diag_errors, diag_params, compact_repor
         "wrong_reference_system": diag_report.report_wrong_reference_system,
         "deviation_from_std_type": diag_report.report_deviation_from_std_type,
         "numba_comparison": diag_report.report_numba_comparison,
-        "parallel_switches": diag_report.report_parallel_switches
+        "parallel_switches": diag_report.report_parallel_switches,
+        "unsupported_elements_active": diag_report.report_unsupported_elements_active
     }
 
     logger.warning("\n\n_____________ PANDAPOWER DIAGNOSTIC TOOL _____________ \n")
@@ -667,3 +668,31 @@ class DiagnosticReports:
             logger.warning(self.diag_errors["missing_bus_indices"])
         else:
             logger.info("PASSED: No missing bus indices found.")
+
+
+    def report_unsupported_elements_active(self):
+        if "unsupported_elements_active" in self.diag_results:
+            if '3ph' in self.diag_results["unsupported_elements_active"]["mode"]:
+                if len(self.diag_results["unsupported_elements_active"]) > 1:
+                    # message header
+                    if self.compact_report:
+                        logger.warning("unsupported_elements_active:")
+                    else:
+                        logger.warning("Checking for unsupported elements...")
+                    logger.warning("")
+
+                    # message body
+                    diag_result = self.diag_results["unsupported_elements_active"]
+                    for active_element in diag_result:
+                        if active_element == "active_gens":
+                            logger.warning("Active 'gen' found. Gens are not supported for 3 phase powerflow. Please put them out of service.")
+                        elif not active_element == "mode":
+                            logger.warning("%s found" % active_element)
+
+                        # message summary
+                    if not self.compact_report:
+                        logger.warning("")
+                        logger.warning("SUMMARY: %s occurences of unsupported elements found."
+                                       % (len(diag_result) - 1))
+                else:
+                    logger.info("PASSED: No unsupported elements found.")


### PR DESCRIPTION
Added checks to the diagnostic functionality to see, if given net has the necessary parameters to do 3 phase loadflow calculations.

Only checks this, when the net is clearly made for 3ph calculation (i.e. asymmetric load present)

Also checks for elements, that are not yet supported for some calculation mode and would disrupt it therefore (for 3_ph: gens)

Added the test-cases for verification.