### PR TITLE
Enable warm start for 3ph loadflow

### DIFF
--- a/pandapower/build_bus.py
+++ b/pandapower/build_bus.py
@@ -10,7 +10,7 @@ from itertools import chain
 import numpy as np
 import pandas as pd
 
-from pandapower.auxiliary import _sum_by_group
+from pandapower.auxiliary import _sum_by_group, phase_to_sequence
 from pandapower.pypower.idx_bus import BUS_I, BASE_KV, PD, QD, GS, BS, VMAX, VMIN, BUS_TYPE, NONE, VM, VA, \
     CID, CZD, bus_cols, REF
 
@@ -201,26 +201,39 @@ def create_bus_lookup(net, bus_index, bus_is_idx, gen_is_mask, eg_is_mask, numba
     return bus_lookup
 
 
-def get_voltage_init_vector(net, init_v, mode):
+def get_voltage_init_vector(net, init_v, mode, sequence=None):
     if isinstance(init_v, str):
         if init_v == "results":
+            res_table = "res_bus" if sequence is None else "res_bus_3ph"
+
             # init voltage possible if bus results are available
-            if "res_bus" in net and net.res_bus.index.equals(net.bus.index):
-                # init bus voltages from results if the sorting is correct
-                res_table = "res_bus"
-            else:
+            if res_table not in net or not net[res_table].index.equals(net.bus.index):
                 # cannot init from results, since sorting of results is different from element table
                 # TO BE REVIEWED! Why there was no raise before this commit?
-                raise UserWarning("Init from results not possible. Index of res_bus do not match with bus. "
-                            "You should sort res_bus before calling runpp.")
-                return None
+                raise UserWarning("Init from results not possible. Index of %s do not match with bus. "
+                                  "You should sort res_bus before calling runpp." % res_table)
 
-            if mode == "magnitude":
-                return net[res_table]["vm_pu"].values.copy()
-            elif mode == "angle":
-                return net[res_table]["va_degree"].values.copy()
+            if res_table == "res_bus_3ph":
+                vm = net.res_bus_3ph[["vm_a_pu", "vm_b_pu", "vm_c_pu"]].values.T
+                va = net.res_bus_3ph[["va_a_degree", "va_b_degree", "va_c_degree"]].values.T
+
+                voltage_vector = phase_to_sequence(vm * np.exp(1j * np.pi * va / 180.))[sequence, :]
+
+                print(sequence, voltage_vector)
+
+                if mode == "magnitude":
+                    return np.abs(voltage_vector)
+                elif mode == "angle":
+                    return np.angle(voltage_vector) * 180 / np.pi
+                else:
+                    raise UserWarning(str(mode)+" for initialization not available!")
             else:
-                raise UserWarning(str(mode)+" for initialization not available!")
+                if mode == "magnitude":
+                    return net[res_table]["vm_pu"].values.copy()
+                elif mode == "angle":
+                    return net[res_table]["va_degree"].values.copy()
+                else:
+                    raise UserWarning(str(mode)+" for initialization not available!")
         if init_v == "flat":
             if mode == "magnitude":
                 net["_options"]["init_vm_pu"] = 0.
@@ -236,7 +249,7 @@ def get_voltage_init_vector(net, init_v, mode):
             raise UserWarning("Voltage starting vector indices do not match bus indices")
 
 
-def _build_bus_ppc(net, ppc):
+def _build_bus_ppc(net, ppc, sequence=None):
     """
     Generates the ppc["bus"] array and the lookup pandapower indices -> ppc indices
     """
@@ -302,11 +315,11 @@ def _build_bus_ppc(net, ppc):
     ppc["bus"][~in_service, BUS_TYPE] = NONE
     if mode != "nx":
         set_reference_buses(net, ppc, bus_lookup, mode)
-    vm_pu = get_voltage_init_vector(net, init_vm_pu, "magnitude")
+    vm_pu = get_voltage_init_vector(net, init_vm_pu, "magnitude", sequence=sequence)
     if vm_pu is not None:
         ppc["bus"][:n_bus, VM] = vm_pu
 
-    va_degree = get_voltage_init_vector(net, init_va_degree, "angle")
+    va_degree = get_voltage_init_vector(net, init_va_degree, "angle", sequence=sequence)
     if va_degree is not None:
         ppc["bus"][:n_bus, VA] = va_degree
 

--- a/pandapower/build_bus.py
+++ b/pandapower/build_bus.py
@@ -233,14 +233,10 @@ def get_voltage_init_vector(net, init_v, mode, sequence=None):
                 else:
                     raise UserWarning(str(mode)+" for initialization not available!")
         if init_v == "flat":
-            if mode == "magnitude":
-                net["_options"]["init_vm_pu"] = 0.
-            else:
-                net["_options"]["init_va_degree"] = 0.
             return None
-    elif isinstance(init_v, (float, np.ndarray, list)):
+    elif isinstance(init_v, (float, np.ndarray, list)) and sequence is None or sequence == 1:
         return init_v
-    elif isinstance(init_v, pd.Series):
+    elif isinstance(init_v, pd.Series) and sequence is None or sequence == 1:
         if init_v.index.equals(net.bus.index):
             return init_v.loc[net.bus.index]
         else:

--- a/pandapower/build_bus.py
+++ b/pandapower/build_bus.py
@@ -291,6 +291,10 @@ def _build_bus_ppc(net, ppc, sequence=None):
     ppc["bus"] = np.zeros(shape=(n_bus_ppc, bus_cols), dtype=float)
     ppc["bus"][:, :15] = np.array([0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 1, 2, 0, 0., 0.])  # changes of
     # voltage limits (2 and 0) must be considered in check_opf_data
+
+    if sequence is not None and sequence != 1:
+        ppc["bus"][:, VM] = 0.
+
     if mode == "sc":
         from pandapower.shortcircuit.idx_bus import bus_cols_sc
         bus_sc = np.empty(shape=(n_bus_ppc, bus_cols_sc), dtype=float)

--- a/pandapower/build_bus.py
+++ b/pandapower/build_bus.py
@@ -219,8 +219,6 @@ def get_voltage_init_vector(net, init_v, mode, sequence=None):
 
                 voltage_vector = phase_to_sequence(vm * np.exp(1j * np.pi * va / 180.))[sequence, :]
 
-                print(sequence, voltage_vector)
-
                 if mode == "magnitude":
                     return np.abs(voltage_vector)
                 elif mode == "angle":

--- a/pandapower/build_gen.py
+++ b/pandapower/build_gen.py
@@ -103,9 +103,10 @@ def _build_pp_ext_grid(net, ppc, f, t):
     ppc["gen"][f:t, VG] = net["ext_grid"]["vm_pu"].values[eg_is]
 
     # set bus values for external grid buses
-    if calculate_voltage_angles:
-        ppc["bus"][eg_buses, VA] = net["ext_grid"]["va_degree"].values[eg_is]
-    ppc["bus"][eg_buses, VM] = net["ext_grid"]["vm_pu"].values[eg_is]
+    if ppc.get("sequence", 1) == 1:
+        if calculate_voltage_angles:
+            ppc["bus"][eg_buses, VA] = net["ext_grid"]["va_degree"].values[eg_is]
+        ppc["bus"][eg_buses, VM] = net["ext_grid"]["vm_pu"].values[eg_is]
     if net._options["mode"] == "opf":
         add_q_constraints(net, "ext_grid", eg_is, ppc, f, t, delta)
         add_p_constraints(net, "ext_grid", eg_is, ppc, f, t, delta)

--- a/pandapower/pd2ppc.py
+++ b/pandapower/pd2ppc.py
@@ -69,7 +69,7 @@ def _pd2ppc(net, sequence=None):
     ppc = _init_ppc(net, mode=mode, sequence=sequence)
 
     # generate ppc['bus'] and the bus lookup
-    _build_bus_ppc(net, ppc)
+    _build_bus_ppc(net, ppc, sequence=sequence)
     if sequence == 0:
         from pandapower.pd2ppc_zero import _add_ext_grid_sc_impedance_zero, _build_branch_ppc_zero
         # Adds external grid impedance for 3ph and sc calculations in ppc0

--- a/pandapower/pd2ppc.py
+++ b/pandapower/pd2ppc.py
@@ -18,6 +18,40 @@ from pandapower.pypower.idx_gen import GEN_BUS, GEN_STATUS
 from pandapower.pypower.run_userfcn import run_userfcn
 
 
+def _pd2ppc_recycle(net, sequence, recycle):
+    key = "_ppc" if sequence is None else "_ppc%d" % sequence
+    if not recycle or not net.get(key, None):
+        return _pd2ppc(net, sequence=sequence)
+
+    ppc = net[key]
+    ppc["success"] = False
+    ppc["iterations"] = 0.
+    ppc["et"] = 0.
+
+    if "bus_pq" in recycle and recycle["bus_pq"]:
+        # update pq values in bus
+        _calc_pq_elements_and_add_on_ppc(net, ppc, sequence=sequence)
+
+    # if "trafo" in recycle and recycle["trafo"]:
+    #     # update trafo in branch and Ybus
+    #     lookup = net._pd2ppc_lookups["branch"]
+    #     if "trafo" in lookup:
+    #         _calc_trafo_parameter(net, ppc)
+    #     if "trafo3w" in lookup:
+    #         _calc_trafo3w_parameter(net, ppc)
+
+    if "gen" in recycle and recycle["gen"]:
+        # updates the ppc["gen"] part
+        _build_gen_ppc(net, ppc)
+        ppc["gen"] = np.nan_to_num(ppc["gen"])
+
+    ppci = _ppc2ppci(ppc, net)
+    ppci["internal"] = net[key]["internal"]
+    net[key] = ppc
+
+    return ppc, ppci
+
+
 def _pd2ppc(net, sequence=None):
     """
     Converter Flow:

--- a/pandapower/pf/runpp_3ph.py
+++ b/pandapower/pf/runpp_3ph.py
@@ -12,7 +12,7 @@ from numpy import flatnonzero as find, pi, exp
 from pandapower import LoadflowNotConverged
 from pandapower.pypower.pfsoln import pfsoln
 from pandapower.pypower.idx_gen import PG, QG
-from pandapower.pd2ppc import _pd2ppc
+from pandapower.pd2ppc import _pd2ppc_recycle
 from pandapower.pypower.makeYbus import makeYbus
 from pandapower.pypower.idx_bus import GS, BS, PD , QD
 from pandapower.auxiliary import _sum_by_group, _check_if_numba_is_installed,\
@@ -340,14 +340,12 @@ def runpp_3ph(net, calculate_voltage_angles=True, init="auto",
 
         **recycle** (dict, none)
 
-        (Not tested with 3 Phase load flow) - Reuse of internal powerflow variables for
+        - Reuse of internal powerflow variables for
         time series calculation
 
             Contains a dict with the following parameters:
-            _is_elements: If True in service elements are not filtered again
-            and are taken from the last result in net["_is_elements"]
-            ppc: If True the ppc is taken from net["_ppc"] and gets updated
-            instead of reconstructed entirely
+            bus_pq: If True PQ values of buses are updated
+            gen: If True Sbus and the gen table in the ppc are recalculated
             Ybus: If True the admittance matrix (Ybus, Yf, Yt) is taken from
             ppc["internal"] and not reconstructed
 
@@ -411,14 +409,12 @@ def runpp_3ph(net, calculate_voltage_angles=True, init="auto",
 
     neglect_open_switch_branches = kwargs.get("neglect_open_switch_branches", False)
     only_v_results = kwargs.get("only_v_results", False)
-    if (recycle is not None and recycle is not False):
-        raise ValueError("recycle is only available with Balanced Load Flow ")
     net._options = {}
     _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
                      trafo_model=trafo_model, check_connectivity=check_connectivity,
                      mode=mode, switch_rx_ratio=switch_rx_ratio,
                      init_vm_pu=init, init_va_degree=init,
-                     enforce_q_lims=enforce_q_lims, recycle=recycle,
+                     enforce_q_lims=enforce_q_lims, recycle=None,
                      voltage_depend_loads=False, delta=delta_q,\
                      neglect_open_switch_branches=neglect_open_switch_branches
                      )
@@ -432,13 +428,12 @@ def runpp_3ph(net, calculate_voltage_angles=True, init="auto",
     # =========================================================================
     # pd2ppc conversion
     # =========================================================================
-    net["_is_elements"] = None
-    _, ppci1 = _pd2ppc(net, 1)
+    _, ppci1 = _pd2ppc_recycle(net, 1, recycle=recycle)
 
-    _, ppci2 = _pd2ppc(net, 2)
+    _, ppci2 = _pd2ppc_recycle(net, 2, recycle=recycle)
     gs_eg, bs_eg = _add_ext_grid_sc_impedance(net, ppci2)
 
-    _, ppci0 = _pd2ppc(net, 0)
+    _, ppci0 = _pd2ppc_recycle(net, 0, recycle=recycle)
 
     _,       bus0, gen0, branch0,      _,      _,      _, _, _,\
         v00, ref_gens = _get_pf_variables_from_ppci(ppci0)
@@ -465,13 +460,16 @@ def runpp_3ph(net, calculate_voltage_angles=True, init="auto",
     # Initial voltage values
     # =========================================================================
     nb = ppci1["bus"].shape[0]
-    v_012_it = np.concatenate(
-        (
-            np.array(np.zeros((1, nb), dtype=np.complex128)),
-            np.array(np.ones((1, nb), dtype=np.complex128)),
-            np.array(np.zeros((1, nb), dtype=np.complex128))
-        ),
-        axis=0)
+
+    # make sure flat start is always respected, even with other voltage data in recycled ppc
+    if init == "flat":
+        v_012_it = np.zeros((3, nb), dtype=np.complex128)
+        v_012_it[1, :] = 1.0
+    else:
+        v_012_it = np.concatenate(
+            [np.array(ppc["bus"][:, VM] * np.exp(1j * np.deg2rad(ppc["bus"][:, VA]))).reshape((1, nb))
+             for ppc in (ppci0, ppci1, ppci2)], axis=0).astype(np.complex128)
+
     # For Delta transformation:
     # Voltage changed from line-earth to line-line using V_T
     # s_abc/v_abc will now give line-line currents. This is converted to line-earth
@@ -553,6 +551,9 @@ def runpp_3ph(net, calculate_voltage_angles=True, init="auto",
     ppci0["bus"][ref, GS] -= gs_eg
     ppci0["bus"][ref, BS] -= bs_eg
     y_0_pu, y_0_f, y_0_t = makeYbus(ppci0["baseMVA"], ppci0["bus"], ppci0["branch"])
+    # revert the change, otherwise repeated calculation with recycled elements will fail
+    ppci0["bus"][ref, GS] += gs_eg
+    ppci0["bus"][ref, BS] += bs_eg
     # Bus, Branch, and Gen  power values
     bus0, gen0, branch0 = pfsoln(base_mva, bus0, gen0, branch0, y_0_pu, y_0_f, y_0_t, v_012_it[0, :].flatten(),
                                  sl_bus, ref_gens)
@@ -563,15 +564,6 @@ def runpp_3ph(net, calculate_voltage_angles=True, init="auto",
     ppci0 = _store_results_from_pf_in_ppci(ppci0, bus0, gen0, branch0)
     ppci1 = _store_results_from_pf_in_ppci(ppci1, bus1, gen1, branch1)
     ppci2 = _store_results_from_pf_in_ppci(ppci2, bus2, gen2, branch2)
-    ppci0["internal"]["Ybus"] = y_0_pu
-    ppci1["internal"]["Ybus"] = y_1_pu
-    ppci2["internal"]["Ybus"] = y_2_pu
-    ppci0["internal"]["Yf"] = y_0_f
-    ppci1["internal"]["Yf"] = y_1_f
-    ppci2["internal"]["Yf"] = y_2_f
-    ppci0["internal"]["Yt"] = y_0_t
-    ppci1["internal"]["Yt"] = y_1_t
-    ppci2["internal"]["Yt"] = y_2_t
     i_012_res = _current_from_voltage_results(y_0_pu, y_1_pu, v_012_it)
     s_012_res = S_from_VI_elementwise(v_012_it, i_012_res) * ppci1["baseMVA"]
     eg_is_mask = net["_is_elements"]['ext_grid']
@@ -611,11 +603,13 @@ def runpp_3ph(net, calculate_voltage_angles=True, init="auto",
 
     _clean_up(net)
 
+
 def _current_from_voltage_results(y_0_pu, y_1_pu, v_012_pu):
     I012_pu = combine_X012(I0_from_V012(v_012_pu, y_0_pu),
                             I1_from_V012(v_012_pu, y_1_pu),
                             I2_from_V012(v_012_pu, y_1_pu))
     return I012_pu
+
 
 def _get_y_bus(ppci0, ppci1, ppci2, recycle):
     if recycle and recycle["Ybus"] and ppci0["internal"]["Ybus"].size and \

--- a/pandapower/pf/runpp_3ph.py
+++ b/pandapower/pf/runpp_3ph.py
@@ -8,7 +8,6 @@
 """
 from time import time
 import numpy as np
-from numpy import flatnonzero as find, pi, exp
 from pandapower import LoadflowNotConverged
 from pandapower.pypower.pfsoln import pfsoln
 from pandapower.pypower.idx_gen import PG, QG
@@ -27,7 +26,7 @@ from pandapower.build_bus import _add_ext_grid_sc_impedance
 from pandapower.pypower.bustypes import bustypes
 from pandapower.run import _passed_runpp_parameters
 from pandapower.pypower.idx_bus import VM, VA
-from pandapower.pypower.idx_gen import GEN_BUS, GEN_STATUS, VG
+from pandapower.pypower.idx_gen import GEN_BUS
 from pandapower.results import _copy_results_ppci_to_ppc, _extract_results_3ph,\
     init_results
 try:
@@ -430,7 +429,7 @@ def runpp_3ph(net, calculate_voltage_angles=True, init="auto",
     _, ppci0 = _pd2ppc_recycle(net, 0, recycle=recycle)
 
     _,        bus0, gen0, branch0,      _,      _,      _ = _get_pf_variables_from_ppci(ppci0)
-    base_mva, bus1, gen1, branch1, sl_bus, pv_bus, pq_bus = _get_pf_variables_from_ppci(ppci1)
+    base_mva, bus1, gen1, branch1, sl_bus,      _, pq_bus = _get_pf_variables_from_ppci(ppci1)
     _,        bus2, gen2, branch2,      _,      _,      _ = _get_pf_variables_from_ppci(ppci2)
 
     # initialize the results after the conversion to ppc is done, otherwise init=results does not work
@@ -445,8 +444,8 @@ def runpp_3ph(net, calculate_voltage_angles=True, init="auto",
     # Construct Sequence Frame Bus admittance matrices Ybus
     # =========================================================================
 
-    ppci0, ppci1, ppci2, y_0_pu, y_1_pu, y_2_pu, y_0_f, y_1_f, y_2_f,\
-        y_0_t, y_1_t, y_2_t = _get_y_bus(ppci0, ppci1, ppci2, recycle)
+    ppci0, ppci1, ppci2, y_0_pu, y_1_pu, y_2_pu, y_0_f, y_1_f, _,\
+        y_0_t, y_1_t, _ = _get_y_bus(ppci0, ppci1, ppci2, recycle)
     # =========================================================================
     # Initial voltage values
     # =========================================================================

--- a/pandapower/pf/runpp_3ph.py
+++ b/pandapower/pf/runpp_3ph.py
@@ -400,7 +400,7 @@ def runpp_3ph(net, calculate_voltage_angles=True, init="auto",
     use_umfpack = kwargs.get("use_umfpack", True)
     permc_spec = kwargs.get("permc_spec", None)
     calculate_voltage_angles = True
-    if init == "results" and len(net.res_bus) == 0:
+    if init == "results" and net.res_bus_3ph.empty:
         init = "auto"
     if init == "auto":
         init = "dc" if calculate_voltage_angles else "flat"
@@ -429,7 +429,6 @@ def runpp_3ph(net, calculate_voltage_angles=True, init="auto",
     net._options.update(overrule_options)
     _check_bus_index_and_print_warning_if_high(net)
     _check_gen_index_and_print_warning_if_high(net)
-    init_results(net, "pf_3ph")
     # =========================================================================
     # pd2ppc conversion
     # =========================================================================
@@ -447,6 +446,9 @@ def runpp_3ph(net, calculate_voltage_angles=True, init="auto",
         v01, ref_gens = _get_pf_variables_from_ppci(ppci1)
     _,       bus2, gen2, branch2,      _,      _,      _, _, _, \
         v02, ref_gens = _get_pf_variables_from_ppci(ppci2)
+
+    # initialize the results after the conversion to ppc is done, otherwise init=results does not work
+    init_results(net, "pf_3ph")
 
 # =============================================================================
 #     P Q values aggragated and summed up for each bus to make s_abc matrix

--- a/pandapower/test/loadflow/test_runpp_3ph.py
+++ b/pandapower/test/loadflow/test_runpp_3ph.py
@@ -113,7 +113,8 @@ def test_out_serv_load(net):
     check_it(net)
 
 
-def test_4bus_network():
+@pytest.mark.parametrize("init", ["auto", "results", "flat", "dc"])
+def test_4bus_network(init):
     v_base = 110                     # 110kV Base Voltage
     mva_base = 100                      # 100 MVA
     net = pp.create_empty_network(sn_mva=mva_base)
@@ -149,7 +150,8 @@ def test_4bus_network():
                               p_c_mw=10, q_c_mvar=5)
     pp.create_asymmetric_load(net, busp, p_a_mw=50, q_a_mvar=20, p_b_mw=60, q_b_mvar=20,
                               p_c_mw=10, q_c_mvar=5)
-    runpp_3ph_with_consistency_checks(net)
+    runpp_3ph_with_consistency_checks(net, init=init)
+    runpp_3ph_with_consistency_checks(net, init=init)
     assert net['converged']
 
     bus_pp = np.abs(net.res_bus_3ph[['vm_a_pu', 'vm_b_pu', 'vm_c_pu']]

--- a/pandapower/test/loadflow/test_runpp_3ph.py
+++ b/pandapower/test/loadflow/test_runpp_3ph.py
@@ -114,7 +114,8 @@ def test_out_serv_load(net):
 
 
 @pytest.mark.parametrize("init", ["auto", "results", "flat", "dc"])
-def test_4bus_network(init):
+@pytest.mark.parametrize("recycle", [None, {"bus_pq": True, "Ybus": True}, {"bus_pq": True, "Ybus": False}])
+def test_4bus_network(init, recycle):
     v_base = 110                     # 110kV Base Voltage
     mva_base = 100                      # 100 MVA
     net = pp.create_empty_network(sn_mva=mva_base)
@@ -150,8 +151,8 @@ def test_4bus_network(init):
                               p_c_mw=10, q_c_mvar=5)
     pp.create_asymmetric_load(net, busp, p_a_mw=50, q_a_mvar=20, p_b_mw=60, q_b_mvar=20,
                               p_c_mw=10, q_c_mvar=5)
-    runpp_3ph_with_consistency_checks(net, init=init)
-    runpp_3ph_with_consistency_checks(net, init=init)
+    runpp_3ph_with_consistency_checks(net, init=init, recycle=recycle)
+    runpp_3ph_with_consistency_checks(net, init=init, recycle=recycle)
     assert net['converged']
 
     bus_pp = np.abs(net.res_bus_3ph[['vm_a_pu', 'vm_b_pu', 'vm_c_pu']]


### PR DESCRIPTION
This pull request will add a missing feature of initializing the state of the 3ph loadflow based on previous results.

Changes:
* Check existance of res_bus_3ph instead of res_bus
* Pass-through the sequence-parameter to get_voltage_init_vector
* Calculate the appropriate init vector for each sequence number

The calculation is slightly faster with these optimizations. Any remarks are highly appreciated.