### PR TITLE
const_control.py: set order and level to -1 as default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Change Log
 - [ADDED] Efficient PTDF calculation on large grid
 - [ADDED] toolbox function replace_pq_elmtype()
 - [CHANGED] ConstControl can now also change attributes of other controllers, if the parameter "variable" is defined in the format "object.attribute" (e.g. "object.vm_set_pu")
+- [CHANGED] ConstControl is initialized with level=-1 and order=-1 by default to make sure that it runs before other controllers
 - [ADDED] Alternative constructor for DiscreteTapControl to use net.trafo.tap_step_percent to determine vm_lower_pu and vm_upper_pu based on vm_set_pu
 - [ADDED] Characteristic object that represents a piecewise-linear characteristic
 - [ADDED] CharacteristicControl that implements adjusting values in net based on some other input values in the grid

--- a/pandapower/control/controller/const_control.py
+++ b/pandapower/control/controller/const_control.py
@@ -57,7 +57,7 @@ class ConstControl(Controller):
     """
 
     def __init__(self, net, element, variable, element_index, profile_name=None, data_source=None,
-                 scale_factor=1.0, in_service=True, recycle=True, order=0, level=0,
+                 scale_factor=1.0, in_service=True, recycle=True, order=-1, level=-1,
                  drop_same_existing_ctrl=False, matching_params=None,
                  initial_run=False, **kwargs):
         # just calling init of the parent
@@ -136,7 +136,7 @@ class ConstControl(Controller):
             self._write_to_object_attribute(net)
         else:
             raise NotImplementedError("ConstControl: self.write must be one of "
-                                      "['single_index', 'all_index', 'loc']")
+                                      "['single_index', 'all_index', 'loc', 'object']")
 
     def time_step(self, net, time):
         """


### PR DESCRIPTION
set the order and level to -1 by default in order to make sure that ConstControl runs before other controllers