### PR TITLE
updated networkx dependency >=2.5 (see #1289)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     url='http://www.pandapower.org',
     license='BSD',
     install_requires=["pandas>=0.17",
-                      "networkx",
+                      "networkx>=2.5",
                       "scipy<=1.6.0",
                       "numpy>=0.11",
                       "packaging",


### PR DESCRIPTION
fixes #1289

networkx>=2.5 is required to run pandapower under python3.9 because fractions module is deprecated in python 3.9