### PR TITLE
fix typo in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016-2021 by University of Kassel and Fraunhofer Institute for for Energy Economics
+Copyright (c) 2016-2021 by University of Kassel and Fraunhofer Institute for Energy Economics
 and Energy System Technology (IEE) Kassel and individual contributors (see AUTHORS file for details).
 All rights reserved.
 


### PR DESCRIPTION
Small spelling mistake, I am sure it is supposed to be "Fraunhofer Institute for Energy Economics" and not "Fraunhofer Institute for for Energy Economics".