### PR TITLE
Including ext_grid in add_zero_impedance_parameters()

### DIFF
--- a/pandapower/std_types.py
+++ b/pandapower/std_types.py
@@ -19,11 +19,12 @@ def create_std_type(net, data, name, element="line", overwrite=True, check_requi
     """
     Creates type data in the type database. The parameters that are used for
     the loadflow have to be at least contained in data. These parameters are:
-        
+
         - c_nf_per_km, r_ohm_per_km, x_ohm_per_km and max_i_ka (for lines)
         - sn_mva, vn_hv_kv, vn_lv_kv, vk_percent, vkr_percent, pfe_kw, i0_percent, shift_degree* (for transformers)
-        - sn_hv_mva, sn_mv_mva, sn_lv_mva, vn_hv_kv, vn_mv_kv, vn_lv_kv, vk_hv_percent, vk_mv_percent, vk_lv_percent, vkr_hv_percent, vkr_mv_percent, vkr_lv_percent, pfe_kw, i0_percent, shift_mv_degree*, shift_lv_degree* (for 3-winding-transformers)
-    
+        - sn_hv_mva, sn_mv_mva, sn_lv_mva, vn_hv_kv, vn_mv_kv, vn_lv_kv, vk_hv_percent, vk_mv_percent, vk_lv_percent,
+            vkr_hv_percent, vkr_mv_percent, vkr_lv_percent, pfe_kw, i0_percent, shift_mv_degree*, shift_lv_degree* (for 3-winding-transformers)
+
     additional parameters can be added and later loaded into pandapower with the function
     "parameter_from_std_type".
 
@@ -67,8 +68,8 @@ def create_std_type(net, data, name, element="line", overwrite=True, check_requi
             "tap_step_degree": 0,
             "tap_step_percent": 2.5,
             "tap_phase_shifter": False,
-            "vk0_percent": 6, 
-            "vkr0_percent": 0.78125, 
+            "vk0_percent": 6,
+            "vkr0_percent": 0.78125,
             "mag0_percent": 100,
             "mag0_rx": 0.,
             "si0_hv_partial": 0.9,}, name='Unsymmetric_trafo_type', element="trafo")
@@ -160,6 +161,7 @@ def load_std_type(net, name, element="line"):
         return library[name]
     else:
         raise UserWarning("Unknown standard %s type %s" % (element, name))
+
 
 def check_entry_in_std_type(param, entry, else_val):
     return param[entry] if entry in param else else_val
@@ -318,13 +320,13 @@ def find_std_type_by_parameter(net, data, element="line", epsilon=0.):
 def add_zero_impedance_parameters(net):
     """
     Adds all parameters required for zero sequence impedance calculations.
-    
+
     INPUT:
         **net** - pandapower network
-        
+
         zero sequence parameters of lines and transformers in pandapower networks
-        are entered using std_type. 
-        
+        are entered using std_type.
+
         This function adds them to the pandas dataframe
 
 
@@ -764,36 +766,36 @@ def add_basic_std_types(net):
         # quad bundle conductor. The c values are estimated.
         "490-AL1/64-ST1A 220.0":
         {"c_nf_per_km": 10,
-             "r_ohm_per_km": 0.059,
-             "x_ohm_per_km": 0.285,
-             "max_i_ka": 0.96,
-             "type": "ol",
-             "q_mm2": 490,
-             "alpha": alpha_al},
+         "r_ohm_per_km": 0.059,
+         "x_ohm_per_km": 0.285,
+         "max_i_ka": 0.96,
+         "type": "ol",
+         "q_mm2": 490,
+         "alpha": alpha_al},
         "679-AL1/86-ST1A 220.0":
         {"c_nf_per_km": 11.7,
-             "r_ohm_per_km": 0.042,
-             "x_ohm_per_km": 0.275,
-             "max_i_ka": 1.150,
-             "type": "ol",
-             "q_mm2": 679,
-             "alpha": alpha_al},
+         "r_ohm_per_km": 0.042,
+         "x_ohm_per_km": 0.275,
+         "max_i_ka": 1.150,
+         "type": "ol",
+         "q_mm2": 679,
+         "alpha": alpha_al},
         "490-AL1/64-ST1A 380.0":
         {"c_nf_per_km": 11,
-             "r_ohm_per_km": 0.059,
-             "x_ohm_per_km": 0.253,
-             "max_i_ka": 0.96,
-             "type": "ol",
-             "q_mm2": 490,
-             "alpha": alpha_al},
+         "r_ohm_per_km": 0.059,
+         "x_ohm_per_km": 0.253,
+         "max_i_ka": 0.96,
+         "type": "ol",
+         "q_mm2": 490,
+         "alpha": alpha_al},
         "679-AL1/86-ST1A 380.0":
         {"c_nf_per_km": 14.6,
-             "r_ohm_per_km": 0.042,
-             "x_ohm_per_km": 0.25,
-             "max_i_ka": 1.150,
-             "type": "ol",
-             "q_mm2": 679,
-             "alpha": alpha_al}
+         "r_ohm_per_km": 0.042,
+         "x_ohm_per_km": 0.25,
+         "max_i_ka": 1.150,
+         "type": "ol",
+         "q_mm2": 679,
+         "alpha": alpha_al}
     }
     create_std_types(net, data=linetypes, element="line")
 

--- a/pandapower/std_types.py
+++ b/pandapower/std_types.py
@@ -344,6 +344,12 @@ def add_zero_impedance_parameters(net):
     parameter_from_std_type(net, "x0_ohm_per_km")
     parameter_from_std_type(net, "endtemp_degree")
 
+    # add zero seq. parameters for ext_grid
+    net.ext_grid['s_sc_max_mva'] = None
+    net.ext_grid['rx_max'] = None
+    net.ext_grid['x0x_max'] = None
+    net.ext_grid['r0x0_max'] = None
+
 
 def add_temperature_coefficient(net, fill=None):
     """

--- a/pandapower/std_types.py
+++ b/pandapower/std_types.py
@@ -344,11 +344,15 @@ def add_zero_impedance_parameters(net):
     parameter_from_std_type(net, "x0_ohm_per_km")
     parameter_from_std_type(net, "endtemp_degree")
 
-    # add zero seq. parameters for ext_grid
-    net.ext_grid['s_sc_max_mva'] = None
-    net.ext_grid['rx_max'] = None
-    net.ext_grid['x0x_max'] = None
-    net.ext_grid['r0x0_max'] = None
+    # add zero seq. parameters for ext_grid and apply standard values
+    if 's_sc_max_mva' not in net.ext_grid.columns:
+        net.ext_grid['s_sc_max_mva'] = 1000
+    if 'rx_max' not in net.ext_grid.columns:
+        net.ext_grid['rx_max'] = 0.1
+    if 'x0x_max' not in net.ext_grid.columns:
+        net.ext_grid['x0x_max'] = 1
+    if 'r0x0_max' not in net.ext_grid.columns:
+        net.ext_grid['r0x0_max'] = 0.1
 
 
 def add_temperature_coefficient(net, fill=None):


### PR DESCRIPTION
add_zero_impedance_parameters() did so far only add zero seq. parameters to elements with standard types (lines and trafos). This is confusing for users, because the function name implies that all relevant zero seq. params are added while the necessary params for the ext_grid are missing. 

Now the function also adds the ext_grid params and applys standard values. 