### PR TITLE
from_mpc.py: added the possibility to load additional variables

### DIFF
--- a/pandapower/converter/matpower/from_mpc.py
+++ b/pandapower/converter/matpower/from_mpc.py
@@ -51,6 +51,8 @@ def from_mpc(mpc_file, f_hz=50, casename_mpc_file='mpc', validate_conversion=Fal
     """
     ppc = _mpc2ppc(mpc_file, casename_mpc_file)
     net = from_ppc(ppc, f_hz, validate_conversion)
+    if len(ppc["mpc_additional_data"]) != 0:
+        net["mpc_additional_data"] = ppc["mpc_additional_data"]
 
     return net
 
@@ -93,6 +95,16 @@ def _copy_data_from_mpc_to_ppc(ppc, mpc, casename_mpc_file):
             ppc['gencost'] = mpc[casename_mpc_file].gencost
         except:
             logger.info('gencost is not in mpc')
+
+        additional_data = False
+        for k in mpc[casename_mpc_file]._fieldnames:
+            if k not in ppc:
+                additional_data = True
+                ppc.setdefault("mpc_additional_data", dict())[k] = getattr(mpc[casename_mpc_file], k)
+
+        if additional_data:
+            logger.info('added fields %s in mpc_additional_data' % list(ppc["mpc_additional_data"].keys()))
+
 
     else:
         logger.error('Matfile does not contain a valid mpc structure.')


### PR DESCRIPTION
Th MATPOWER case format allows specifying additional, optional varuables (e.g. bus names, type of energy carrier for generators, etc.).

This patch loads such variables in the optional net attribute "mpc_additional_data".

An INFO message if provided.

The user is then responsible for interpreting and further processing of such data.