### PR TITLE
From mpc extra data

### DIFF
--- a/.github/workflows/github_test_action.yml
+++ b/.github/workflows/github_test_action.yml
@@ -36,6 +36,7 @@ jobs:
         pip install .["all"]
         if ${{ matrix.python-version == '3.7' }}; then python -m pip install pypower; fi
         if ${{ matrix.python-version != '3.6' }}; then python -m pip install numba; fi
+        if ${{ matrix.python-version == '3.9' }}; then python -m pip install lightsim2grid; fi
     - name: Install Julia
       if: ${{ matrix.python-version == '3.6' }}
       run: |

--- a/.github/workflows/github_test_action.yml
+++ b/.github/workflows/github_test_action.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/github_test_action.yml
+++ b/.github/workflows/github_test_action.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Change Log
 - [FIXED] revise to_ppc() and to_mpc() init behaviour
 - [CHANGED] import requirements / dependencies
 - [ADDED] distributed slack calculation to newton-raphson load flow; new column "slack_weights" for ext_grid, gen and xward; only 1 reference bus is allowed, any further reference buses are converted to PV buses internally
+- [CHANGED] improved the integration with the package lightim2grid (fast power flow backend written in C++), add the test coverage for using lightsim2grid
 
 [2.7.0]- 2021-07-15
 ----------------------

--- a/doc/powerflow/ac.rst
+++ b/doc/powerflow/ac.rst
@@ -15,3 +15,9 @@ pandapower uses PYPOWER to solve the power flow problem:
     If you are interested in the pypower casefile that pandapower is using for power flow, you can find it in net["_ppc"].
     However all necessary informations are written into the pandpower format net, so the pandapower user should not usually have to deal with pypower.
 
+If available, the librabry lightsim2grid is used as a backend for power flow simulation instead of the
+implementation in pandapower, leading to a boost in performance. The library lightsim2grid is implemented in C++ and
+can either be installed with pip install lightsim2grid, or built from source. More about the library and the
+installation guide can be found in the `documentation <https://lightsim2grid.readthedocs.io/en/latest/>`_ or
+its GitHub `repository <https://github.com/BDonnot/lightsim2grid>`_.
+

--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -46,7 +46,7 @@ except ImportError:
     from .pf.no_numba import jit
 
 try:
-    import lightsim2grid.newtonpf_new as newtonpf_ls
+    from lightsim2grid.newtonpf import newtonpf_new as newtonpf_ls
     lightsim2grid_available = True
 except ImportError:
     lightsim2grid_available = False

--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -46,6 +46,7 @@ except ImportError:
     from .pf.no_numba import jit
 
 try:
+    import lightsim2grid.newtonpf_new as newtonpf_ls
     lightsim2grid_available = True
 except ImportError:
     lightsim2grid_available = False

--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -46,15 +46,14 @@ except ImportError:
     from .pf.no_numba import jit
 
 try:
-    from lightsim2grid.newtonpf import newtonpf as newtonpf_ls
+    lightsim2grid_available = True
 except ImportError:
-    newtonpf_ls = None
+    lightsim2grid_available = False
 try:
     import pplog as logging
 except ImportError:
     import logging
 
-lightsim2grid_available = True if newtonpf_ls is not None else False
 logger = logging.getLogger(__name__)
 
 
@@ -736,33 +735,54 @@ def _check_if_numba_is_installed(numba):
     return numba
 
 
-def _deactive(msg):
-    logger.error(msg)
-    return False
+def _check_lightsim2grid_compatibility(net, lightsim2grid, voltage_dependend_loads, algorithm, enforce_q_lims,
+                                       distributed_slack):
+    """
+    Implement some checks to decide whether the package lightsim2grid can be used. The package implements a backend for
+     power flow calculation in C++ and provides a speed-up. If lightsim2grid is "auto" (default), we don't bombard the
+     user with messages. Otherwise, if lightsim2grid is True bus cannot be used, we inform the user abot it.
+    """
+    if not lightsim2grid:
+        return False  # early return :)
 
+    if not lightsim2grid_available:
+        if lightsim2grid != "auto":
+            logger.info("option 'lightsim2grid' is True but the module lightsim2grid could not be imported. "
+                        "Falling back to pandapower implementation.")
+        return False
+    if algorithm != 'nr':  # todo implement lightsim2grid dc power flow and gauss-seidel power flow
+        raise NotImplementedError(f"option 'lightsim2grid' is True but the algorithm {algorithm} not implemented.")
+    if voltage_dependend_loads:
+        if lightsim2grid != "auto":
+            logger.info("option 'lightsim2grid' is True and voltage-dependent loads detected. Falling back to "
+                        "pandapower implementation")
+        return False
+    #if enforce_q_lims:
+    # not valid: the way you enforce the q_limits in pandapower is to loop and perform successive calls to the
+    # newtonpf function, in this case using the lightsim2grid equivalent is perfectly fine. You CAN use
+    # lightsim2grid newtonpf function in this case.
+    #    logger.info("option 'lightsim2grid' is True and enforce_q_lims is True. Falling back to pandapower "
+    #                "implementation")
+    #    return False
+    if len(net.ext_grid) > 1 and not distributed_slack:
+        # lightsim2grid implements distributed_slack similarly to pandapower, but does not accept multiple slacks
+        # otherwise
+        if lightsim2grid != "auto":
+            logger.info("option 'lightsim2grid' is True and multiple ext_grids are found. Falling back to "
+                        "pandapower implementation.")
+        return False
+    # if np.any(net.gen.bus.isin(net.ext_grid.bus)):
+    #     #  not valid: actually it's even the exact opposite. In lightsim2grid, only the generators are considered
+    #     #  as slack buses. There is no concept of "ext_grid" in lightsim2grid. And by the way, this is not
+    #     #  relevant
+    #     #  when using the newtonpf function, ext_grid and generators with slack bus are handled before that when
+    #     #  defining the pv , pq and ref index vectors (used in newtonpf). You CAN use lightsim2grid newtonpf
+    #     #  function in this case.
+    #     logger.info("option 'lightsim2grid' is True and gen elements were found at slack buses. Falling back "
+    #                 "to pandapower implementation")
+    #     return False
 
-def _check_lightsim2grid_compatibility(net, lightsim2grid, voltage_dependend_loads, algorithm,
-                                       enforce_q_lims):
-    if lightsim2grid:
-        if not lightsim2grid_available:
-            return _deactive("option 'lightsim2grid' is True activates but module cannot be "
-                             "imported. lightsim2grid gets deactivet.")
-        if algorithm != 'nr':
-            raise ValueError("option 'lightsim2grid' is True activates but algorithm is not 'nr'.")
-        if voltage_dependend_loads:
-            return _deactive("option 'lightsim2grid' is True but voltage dependend loads are in "
-                             "your grid. lightsim2grid gets deactivet.")
-        if enforce_q_lims:
-            return _deactive("option 'lightsim2grid' is True and enforce_q_lims is True. This is "
-                             "not supported. lightsim2grid gets deactivet.")
-        if len(net.ext_grid) > 1:
-            return _deactive("option 'lightsim2grid' is True and multiple ext_grids are in the "
-                             "grid. lightsim2grid gets deactivet.")
-        if np.any(net.gen.bus.isin(net.ext_grid.bus)):
-            return _deactive("option 'lightsim2grid' is True and gens are at slack buses."
-                             "lightsim2grid gets deactivet.")
-
-    return lightsim2grid
+    return True
 
 
 # =============================================================================
@@ -968,7 +988,7 @@ def _init_runpp_options(net, algorithm, calculate_voltage_angles, init,
     # scipy spsolve options in NR power flow
     use_umfpack = kwargs.get("use_umfpack", True)
     permc_spec = kwargs.get("permc_spec", None)
-    lightsim2grid = kwargs.get("lightsim2grid", False)
+    lightsim2grid = kwargs.get("lightsim2grid", "auto")
 
     if "init" in overrule_options:
         init = overrule_options["init"]
@@ -982,8 +1002,8 @@ def _init_runpp_options(net, algorithm, calculate_voltage_angles, init,
                 or np.any(net["load"]["const_i_percent"].values)):
             voltage_depend_loads = False
 
-    lightsim2grid = _check_lightsim2grid_compatibility(net, lightsim2grid, voltage_depend_loads,
-                                                       algorithm, enforce_q_lims)
+    lightsim2grid = _check_lightsim2grid_compatibility(net, lightsim2grid, voltage_depend_loads, algorithm,
+                                                       enforce_q_lims, distributed_slack)
 
     ac = True
     mode = "pf"

--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -752,6 +752,8 @@ def _check_lightsim2grid_compatibility(net, lightsim2grid, voltage_dependend_loa
                         "Falling back to pandapower implementation.")
         return False
     if algorithm != 'nr':  # todo implement lightsim2grid dc power flow and gauss-seidel power flow
+        if lightsim2grid == "auto":
+            return False
         raise NotImplementedError(f"option 'lightsim2grid' is True but the algorithm {algorithm} not implemented.")
     if voltage_dependend_loads:
         if lightsim2grid != "auto":

--- a/pandapower/converter/matpower/from_mpc.py
+++ b/pandapower/converter/matpower/from_mpc.py
@@ -52,7 +52,8 @@ def from_mpc(mpc_file, f_hz=50, casename_mpc_file='mpc', validate_conversion=Fal
     ppc = _mpc2ppc(mpc_file, casename_mpc_file)
     net = from_ppc(ppc, f_hz, validate_conversion)
     if "mpc_additional_data" in ppc:
-        net["mpc_additional_data"] = ppc["mpc_additional_data"]
+        net._options.update(ppc["mpc_additional_data"])
+        logger.info('added fields %s in net._options' % list(ppc["mpc_additional_data"].keys()))
 
     return net
 
@@ -99,9 +100,6 @@ def _copy_data_from_mpc_to_ppc(ppc, mpc, casename_mpc_file):
         for k in mpc[casename_mpc_file]._fieldnames:
             if k not in ppc:
                 ppc.setdefault("mpc_additional_data", dict())[k] = getattr(mpc[casename_mpc_file], k)
-
-        if "mpc_additional_data" in ppc:
-            logger.info('added fields %s in mpc_additional_data' % list(ppc["mpc_additional_data"].keys()))
 
     else:
         logger.error('Matfile does not contain a valid mpc structure.')

--- a/pandapower/converter/pypower/from_ppc.py
+++ b/pandapower/converter/pypower/from_ppc.py
@@ -299,6 +299,9 @@ def from_ppc(ppc, f_hz=50, validate_conversion=False, **kwargs):
         if not validate_from_ppc(ppc, net, **kwargs):
             logger.error("Validation failed.")
 
+    net._options = {}
+    net._options["gen_lookup"] = gen_lookup
+
     return net
 
 

--- a/pandapower/pf/create_jacobian.py
+++ b/pandapower/pf/create_jacobian.py
@@ -67,8 +67,8 @@ def _create_J_without_numba(Ybus, V, ref, pvpq, pq, slack_weights, dist_slack):
             J10 = sparse(slack_weights[rows_pvpq].reshape(-1,1))
             J20 = sparse(zeros(shape=(len(pq), 1)))
             J = vstack([
-                hstack([J13, J11, J10]),
-                hstack([J23, J21, J20])
+                hstack([J10, J11, J12]),
+                hstack([J20, J21, J22])
             ], format="csr")
         else:
             J = vstack([

--- a/pandapower/pf/create_jacobian.py
+++ b/pandapower/pf/create_jacobian.py
@@ -64,11 +64,11 @@ def _create_J_without_numba(Ybus, V, ref, pvpq, pq, slack_weights, dist_slack):
         J21 = dS_dVa[array([pq]).T, cols_pvpq].imag
         J22 = dS_dVm[array([pq]).T, pq].imag
         if dist_slack:
-            J13 = sparse(slack_weights[rows_pvpq].reshape(-1,1))
-            J23 = sparse(zeros(shape=(len(pq), 1)))
+            J10 = sparse(slack_weights[rows_pvpq].reshape(-1,1))
+            J20 = sparse(zeros(shape=(len(pq), 1)))
             J = vstack([
-                hstack([J11, J12, J13]),
-                hstack([J21, J22, J23])
+                hstack([J13, J11, J10]),
+                hstack([J23, J21, J20])
             ], format="csr")
         else:
             J = vstack([

--- a/pandapower/pf/create_jacobian_numba.py
+++ b/pandapower/pf/create_jacobian_numba.py
@@ -231,6 +231,13 @@ def create_J_ds(dVm_x, dVa_x, Yp, Yj, pvpq_lookup, refpvpq, pvpq, pq, Jx, Jj, Jp
     for r in range(lrefpvpq):
         # nnzStar is necessary to calculate nonzeros per row
         nnzStart = nnz
+        # add slack weights to the first column
+        if slack_weights[refpvpq[r]] > 0:
+            Jx[nnz] = slack_weights[refpvpq[r]]
+            Jj[nnz] = 0
+            # if DEBUG:
+            #     JJ[r, 0] = Jx[nnz]
+            nnz += 1
         # iterate columns of J11 = dS_dVa.real at positions in pvpq
         # check entries in row pvpq[r] of dS_dV
         # r_start, r_end = Yp[refpvpq[r]], Yp[refpvpq[r] + 1]
@@ -250,7 +257,7 @@ def create_J_ds(dVm_x, dVa_x, Yp, Yj, pvpq_lookup, refpvpq, pvpq, pq, Jx, Jj, Jp
             if lookup_idx == bus_idx and not skip:# and lookup_idx in pvpq:  # too slow
                 # entry found
                 # equals entry of J11: J[r,cc] = dVa_x[c].real
-                col = cc - lref
+                col = cc
                 Jx[nnz] = dVa_x[c].real
                 Jj[nnz] = col
                 # if DEBUG:
@@ -258,20 +265,12 @@ def create_J_ds(dVm_x, dVa_x, Yp, Yj, pvpq_lookup, refpvpq, pvpq, pq, Jx, Jj, Jp
                 nnz += 1
                 # if entry is found in the "pq part" of pvpq = add entry of J12
                 if cc >= lrefpv:
-                    col = cc + lpq - lref
+                    col = cc + lpq
                     Jx[nnz] = dVm_x[c].real
                     Jj[nnz] = col
                     # if DEBUG:
                     #     JJ[r, col] = Jx[nnz]
                     nnz += 1
-
-        # add slack weights to the last column
-        if slack_weights[refpvpq[r]] > 0:
-            Jx[nnz] = slack_weights[refpvpq[r]]
-            Jj[nnz] = lpvpq + lpq
-            # if DEBUG:
-            #     JJ[r, lpvpq + lpq] = Jx[nnz]
-            nnz += 1
         # Jp: number of nonzeros per row = nnz - nnzStart (nnz at begging of loop - nnz at end of loop)
         Jp[r + 1] = nnz - nnzStart + Jp[r]
 
@@ -293,7 +292,7 @@ def create_J_ds(dVm_x, dVa_x, Yp, Yj, pvpq_lookup, refpvpq, pvpq, pq, Jx, Jj, Jp
             if lookup_idx == bus_idx and not skip:# and lookup_idx in pvpq:   # too slow
                 # entry found
                 # equals entry of J21: J[r + lpvpq, cc] = dVa_x[c].imag
-                col = cc - lref
+                col = cc
                 Jx[nnz] = dVa_x[c].imag
                 Jj[nnz] = col
                 # if DEBUG:
@@ -301,7 +300,7 @@ def create_J_ds(dVm_x, dVa_x, Yp, Yj, pvpq_lookup, refpvpq, pvpq, pq, Jx, Jj, Jp
                 nnz += 1
                 # if entry is found in the "pq part" of pvpq = Add entry of J22
                 if cc >= lrefpv:
-                    col = cc + lpq - lref
+                    col = cc + lpq
                     Jx[nnz] = dVm_x[c].imag
                     Jj[nnz] = col
                     # if DEBUG:

--- a/pandapower/pf/makeYbus_numba.py
+++ b/pandapower/pf/makeYbus_numba.py
@@ -166,4 +166,7 @@ def makeYbus(baseMVA, bus, branch):
     Yx, Yj, Yp, nnz = gen_Ybus(Yf_x, Yt_x, Ysh, col_Y, f, t, np.argsort(f), np.argsort(t), nb, nl,
                                np.arange(nl, dtype=np.int64))
     Ybus = csr_matrix((np.resize(Yx, nnz), np.resize(Yj, nnz), Yp), (nb, nb))
+    for Y in (Ybus, Yf, Yt):
+        Y.sort_indices()
+        Y.eliminate_zeros()
     return Ybus, Yf, Yt

--- a/pandapower/pf/run_newton_raphson_pf.py
+++ b/pandapower/pf/run_newton_raphson_pf.py
@@ -26,11 +26,9 @@ except ImportError:
     pass
 
 try:
-    from lightsim2grid.newtonpf import newtonpf as newton_ls
-    lightsim2grid_available = True
+    from lightsim2grid.newtonpf import newtonpf_new as newton_ls
 except ImportError:
     newton_ls = None
-    lightsim2grid_available = False
 
 
 def _run_newton_raphson_pf(ppci, options):
@@ -151,8 +149,8 @@ def _run_ac_pf_without_qlims_enforced(ppci, options):
 
 
     # run the newton power flow
-    if lightsim2grid_available:
-        V, success, iterations, J, Vm_it, Va_it = newton_ls(Ybus, Sbus, V0, pv, pq, ppci, options)
+    if options["lightsim2grid"]:
+        V, success, iterations, J, Vm_it, Va_it = newton_ls(Ybus, Sbus, V0, ref, pv, pq, ppci, options)
     else:
         V, success, iterations, J, Vm_it, Va_it = newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppci, options)
 

--- a/pandapower/pf/run_newton_raphson_pf.py
+++ b/pandapower/pf/run_newton_raphson_pf.py
@@ -26,7 +26,7 @@ except ImportError:
     pass
 
 try:
-    from lightsim2grid.newtonpf import newtonpf_new as newton_ls, newtonpf_old as newton_ls_old
+    from lightsim2grid.newtonpf import newtonpf_new as newton_ls
 except ImportError:
     newton_ls = None
 
@@ -149,9 +149,7 @@ def _run_ac_pf_without_qlims_enforced(ppci, options):
 
 
     # run the newton power flow
-    if options["lightsim2grid"] and not options["distributed_slack"]:
-        V, success, iterations, J, Vm_it, Va_it = newton_ls_old(Ybus.tocsc(), Sbus, V0, pv, pq, ppci, options)
-    elif options["lightsim2grid"]:
+    if options["lightsim2grid"]:
         V, success, iterations, J, Vm_it, Va_it = newton_ls(Ybus.tocsc(), Sbus, V0, ref, pv, pq, ppci, options)
     else:
         V, success, iterations, J, Vm_it, Va_it = newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppci, options)

--- a/pandapower/pf/run_newton_raphson_pf.py
+++ b/pandapower/pf/run_newton_raphson_pf.py
@@ -22,8 +22,9 @@ from pandapower.pypower.pfsoln import pfsoln as pfsoln_pypower
 try:
     from pandapower.pf.makeYbus_numba import makeYbus as makeYbus_numba
     from pandapower.pf.pfsoln_numba import pfsoln as pfsoln_numba, pf_solution_single_slack
+    numba_installed = True
 except ImportError:
-    pass
+    numba_installed = False
 
 try:
     from lightsim2grid.newtonpf import newtonpf_new as newton_ls
@@ -106,7 +107,7 @@ def _get_numba_functions(ppci, options):
     """
     pfsoln from pypower maybe slow in some cases. This function chooses the fastest for the given pf calculation
     """
-    if options["numba"]:
+    if options["numba"] and numba_installed:
         makeYbus = makeYbus_numba
         shunt_in_net = any(ppci["bus"][:, BS]) or any(ppci["bus"][:, GS])
         # faster pfsoln function if only one slack is in the grid and no gens

--- a/pandapower/pf/run_newton_raphson_pf.py
+++ b/pandapower/pf/run_newton_raphson_pf.py
@@ -149,11 +149,10 @@ def _run_ac_pf_without_qlims_enforced(ppci, options):
 
 
     # run the newton power flow
-    _ = np_sum(np_abs(Ybus))
     if options["lightsim2grid"] and not options["distributed_slack"]:
-        V, success, iterations, J, Vm_it, Va_it = newton_ls_old(Ybus, Sbus, V0, pv, pq, ppci, options)
+        V, success, iterations, J, Vm_it, Va_it = newton_ls_old(Ybus.tocsc(), Sbus, V0, pv, pq, ppci, options)
     elif options["lightsim2grid"]:
-        V, success, iterations, J, Vm_it, Va_it = newton_ls(Ybus, Sbus, V0, ref, pv, pq, ppci, options)
+        V, success, iterations, J, Vm_it, Va_it = newton_ls(Ybus.tocsc(), Sbus, V0, ref, pv, pq, ppci, options)
     else:
         V, success, iterations, J, Vm_it, Va_it = newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppci, options)
 

--- a/pandapower/pf/run_newton_raphson_pf.py
+++ b/pandapower/pf/run_newton_raphson_pf.py
@@ -27,9 +27,9 @@ except ImportError:
 
 try:
     from lightsim2grid.newtonpf import newtonpf as newton_ls
-
     lightsim2grid_available = True
 except ImportError:
+    newton_ls = None
     lightsim2grid_available = False
 
 

--- a/pandapower/pf/run_newton_raphson_pf.py
+++ b/pandapower/pf/run_newton_raphson_pf.py
@@ -26,7 +26,7 @@ except ImportError:
     pass
 
 try:
-    from lightsim2grid.newtonpf import newtonpf_new as newton_ls
+    from lightsim2grid.newtonpf import newtonpf_new as newton_ls, newtonpf_old as newton_ls_old
 except ImportError:
     newton_ls = None
 
@@ -149,7 +149,9 @@ def _run_ac_pf_without_qlims_enforced(ppci, options):
 
 
     # run the newton power flow
-    if options["lightsim2grid"]:
+    if options["lightsim2grid"] and not options["distributed_slack"]:
+        V, success, iterations, J, Vm_it, Va_it = newton_ls_old(Ybus, Sbus, V0, pv, pq, ppci, options)
+    elif options["lightsim2grid"]:
         V, success, iterations, J, Vm_it, Va_it = newton_ls(Ybus, Sbus, V0, ref, pv, pq, ppci, options)
     else:
         V, success, iterations, J, Vm_it, Va_it = newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppci, options)

--- a/pandapower/pf/run_newton_raphson_pf.py
+++ b/pandapower/pf/run_newton_raphson_pf.py
@@ -6,7 +6,7 @@
 
 from time import perf_counter
 
-from numpy import flatnonzero as find, r_, zeros, argmax, setdiff1d, union1d, any, int32
+from numpy import flatnonzero as find, r_, zeros, argmax, setdiff1d, union1d, any, int32, sum as np_sum, abs as np_abs
 
 from pandapower.pf.ppci_variables import _get_pf_variables_from_ppci, _store_results_from_pf_in_ppci
 from pandapower.pf.run_dc_pf import _run_dc_pf
@@ -149,6 +149,7 @@ def _run_ac_pf_without_qlims_enforced(ppci, options):
 
 
     # run the newton power flow
+    _ = np_sum(np_abs(Ybus))
     if options["lightsim2grid"] and not options["distributed_slack"]:
         V, success, iterations, J, Vm_it, Va_it = newton_ls_old(Ybus, Sbus, V0, pv, pq, ppci, options)
     elif options["lightsim2grid"]:

--- a/pandapower/pf/runpp_3ph.py
+++ b/pandapower/pf/runpp_3ph.py
@@ -407,7 +407,7 @@ def runpp_3ph(net, calculate_voltage_angles=True, init="auto",
     _add_pf_options(net, tolerance_mva=tolerance_mva, trafo_loading=trafo_loading,
                     numba=numba, ac=ac, algorithm="nr", max_iteration=max_iteration,\
                     only_v_results=only_v_results,v_debug=v_debug, use_umfpack=use_umfpack,
-                    permc_spec=permc_spec)
+                    permc_spec=permc_spec, lightsim2grid=False)
     net._options.update(overrule_options)
     _check_bus_index_and_print_warning_if_high(net)
     _check_gen_index_and_print_warning_if_high(net)

--- a/pandapower/pypower/makeYbus.py
+++ b/pandapower/pypower/makeYbus.py
@@ -71,6 +71,8 @@ def makeYbus(baseMVA, bus, branch):
     ## build Ybus
     Ybus = Cf.T * Yf + Ct.T * Yt + \
            csr_matrix((Ysh, (range(nb), range(nb))), (nb, nb))
+    Ybus.sort_indices()
+    Ybus.eliminate_zeros()
 
     return Ybus, Yf, Yt
 

--- a/pandapower/pypower/newtonpf.py
+++ b/pandapower/pypower/newtonpf.py
@@ -97,14 +97,13 @@ def newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppci, options):
     nref = len(ref)
     npv = len(pv)
     npq = len(pq)
-    j1 = 0
-    j2 = npv  # j1:j2 - V angle of pv buses
+    j0 = 0
+    j1 = nref if dist_slack else 0
+    j2 = j1 + npv  # j1:j2 - V angle of pv buses
     j3 = j2
     j4 = j2 + npq  # j3:j4 - V angle of pq buses
     j5 = j4
     j6 = j4 + npq  # j5:j6 - V mag of pq buses
-    j7 = j6
-    j8 = j6 + nref # j7:j8 - slacks
 
     # make initial guess for the slack
     slack = (gen[:, PG].sum() - bus[:, PD].sum()) / baseMVA
@@ -124,13 +123,13 @@ def newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppci, options):
 
         dx = -1 * spsolve(J, F, permc_spec=permc_spec, use_umfpack=use_umfpack)
         # update voltage
+        if dist_slack:
+            slack = slack + dx[j0:j1]
         if npv and not iwamoto:
             Va[pv] = Va[pv] + dx[j1:j2]
         if npq and not iwamoto:
             Va[pq] = Va[pq] + dx[j3:j4]
             Vm[pq] = Vm[pq] + dx[j5:j6]
-        if dist_slack:
-            slack = slack + dx[j7:j8]
 
         # iwamoto multiplier to increase convergence
         if iwamoto:

--- a/pandapower/run.py
+++ b/pandapower/run.py
@@ -39,7 +39,7 @@ def set_user_pf_options(net, overwrite=False, **kwargs):
                            'recycle', 'voltage_depend_loads', 'consider_line_temperature', 'delta',
                            'trafo3w_losses', 'init_vm_pu', 'init_va_degree', 'init_results',
                            'tolerance_mva', 'trafo_loading', 'numba', 'ac', 'algorithm',
-                           'max_iteration', 'v_debug', 'run_control', 'distributed_slack']
+                           'max_iteration', 'v_debug', 'run_control', 'distributed_slack', 'lightsim2grid']
 
     if overwrite or 'user_pf_options' not in net.keys():
         net['user_pf_options'] = dict()
@@ -158,6 +158,8 @@ def runpp(net, algorithm='nr', calculate_voltage_angles="auto", init="auto",
 
 
         **KWARGS**:
+
+        **lightsim2grid** ((bool,str), "auto") - whether to use the package lightsim2grid for power flow backend
 
         **numba** (bool, True) - Activation of numba JIT compiler in the newton solver
 

--- a/pandapower/test/api/test_diagnostic.py
+++ b/pandapower/test/api/test_diagnostic.py
@@ -1004,7 +1004,8 @@ def test_deviation_from_std_type(test_net, diag_params, diag_errors, report_meth
             report_check = False
         assert report_check
 
-@pytest.mark.skipif(numba_installed==False, reason="requires numba")
+
+@pytest.mark.skipif(not numba_installed, reason="requires numba")
 def test_numba_comparison(test_net, diag_params, diag_errors, report_methods):
     net = copy.deepcopy(test_net)
     check_function = 'numba_comparison'
@@ -1013,7 +1014,7 @@ def test_numba_comparison(test_net, diag_params, diag_errors, report_methods):
     if check_result:
         diag_results = {check_function: check_result}
     else:
-        diag_results = {}
+        diag_results = {check_function: {}}
     for element_type in diag_results[check_function]:
         check_results = diag_results[check_function]
         for result_type in check_results[element_type]:

--- a/pandapower/test/api/test_toolbox.py
+++ b/pandapower/test/api/test_toolbox.py
@@ -162,8 +162,8 @@ def test_nets_equal():
 
     # not detecting alternated value if difference is beyond tolerance
     net["load"]["p_mw"][net["load"].index[0]] += 0.0001
-    assert tb.nets_equal(original, net, tol=0.1)
-    assert tb.nets_equal(net, original, tol=0.1)
+    assert tb.nets_equal(original, net, atol=0.1)
+    assert tb.nets_equal(net, original, atol=0.1)
 
 
 def test_clear_result_tables():

--- a/pandapower/test/converter/test_from_ppc.py
+++ b/pandapower/test/converter/test_from_ppc.py
@@ -53,7 +53,7 @@ def test_from_ppc():
     assert len(net_by_ppc.bus) == len(net_by_code.bus)
     assert len(net_by_ppc.trafo) == len(net_by_code.trafo)
     assert len(net_by_ppc.ext_grid) == len(net_by_code.ext_grid)
-    assert pp.nets_equal(net_by_ppc, net_by_code, check_only_results=True, tol=1.e-9)
+    assert pp.nets_equal(net_by_ppc, net_by_code, check_only_results=True, atol=1e-9)
 
 
 def test_validate_from_ppc():
@@ -110,12 +110,12 @@ def test_case9_conversion():
     # compare loadflow results
     pp.runpp(net)
     pp.runpp(net2)
-    assert pp.nets_equal(net, net2, check_only_results=True, tol=1e-10)
+    assert pp.nets_equal(net, net2, check_only_results=True, atol=1e-10)
 
     # compare optimal powerflow results
     pp.runopp(net, delta=1e-16)
     pp.runopp(net2, delta=1e-16)
-    assert pp.nets_equal(net, net2, check_only_results=True, tol=1e-10)
+    assert pp.nets_equal(net, net2, check_only_results=True, atol=1e-10)
 
 
 @pytest.mark.skipif(pypower_installed == False, reason="needs pypower installation")

--- a/pandapower/test/loadflow/test_recycle.py
+++ b/pandapower/test/loadflow/test_recycle.py
@@ -125,6 +125,7 @@ def test_recycle_trafo_bus_gen(recycle_net):
 
 def test_result_index_unsorted():
     net = pp.create_empty_network()
+    pp.set_user_pf_options(net, tolerance_mva=1e-9)
 
     b1 = pp.create_bus(net, vn_kv=0.4, index=4)
     b2 = pp.create_bus(net, vn_kv=0.4, index=2)
@@ -141,7 +142,7 @@ def test_result_index_unsorted():
     pp.runpp(net_recycle, recycle=dict(trafo=True, bus_pq=True, gen=True))
     pp.runpp(net)
 
-    assert nets_equal(net, net_recycle, tol=1e-12)
+    assert nets_equal(net, net_recycle, atol=1e-12)
 
 
 if __name__ == "__main__":

--- a/pandapower/test/loadflow/test_runpp.py
+++ b/pandapower/test/loadflow/test_runpp.py
@@ -80,9 +80,6 @@ def test_set_user_pf_options():
     assert net._options['tolerance_mva'] == 1e-2
     assert net._options['max_iteration'] == 20
 
-    # todo check if kwargs also work with user_pf_options
-
-
 
 def test_kwargs_with_user_options():
     net = example_simple()

--- a/pandapower/test/loadflow/test_runpp.py
+++ b/pandapower/test/loadflow/test_runpp.py
@@ -80,6 +80,9 @@ def test_set_user_pf_options():
     assert net._options['tolerance_mva'] == 1e-2
     assert net._options['max_iteration'] == 20
 
+    # todo check if kwargs also work with user_pf_options
+
+
 
 def test_kwargs_with_user_options():
     net = example_simple()

--- a/pandapower/test/loadflow/test_runpp.py
+++ b/pandapower/test/loadflow/test_runpp.py
@@ -813,10 +813,12 @@ def test_get_internal():
 
     pvpq = np.r_[pv, pq]
     dist_slack = False
+    slack_weights = np.zeros(shape=V.shape)
+    slack_weights[ref] = 1
 
-    J = _create_J_without_numba(Ybus, V, ref, pvpq, pq, slack_weights=None, dist_slack=False)
+    J = _create_J_without_numba(Ybus, V, ref, pvpq, pq, slack_weights=slack_weights, dist_slack=dist_slack)
 
-    assert sum(sum(abs(abs(J.toarray()) - abs(J_intern.toarray())))) < 0.05
+    assert np.allclose(J.toarray(), J_intern.toarray(), atol=1e-4, rtol=0)
     # get J for all other algorithms
 
 

--- a/setup.py
+++ b/setup.py
@@ -51,12 +51,12 @@ setup(
         "docs": ["numpydoc", "sphinx", "sphinx_rtd_theme"],
         "plotting": ["plotly", "matplotlib", "python-igraph", "geopandas"],  # "shapely", "pyproj" are depedencies of geopandas and so already available; "base64", "hashlib", "zlib" produce installing problems, so it is not include
         "test": ["pytest", "pytest-xdist"],
-        "performance": ["ortools"],
+        "performance": ["ortools", "lightsim2grid"],
         "fileio": ["xlsxwriter", "openpyxl", "cryptography", "geopandas"],  # "fiona" is a depedency of geopandas and so already available
         "all": ["numpydoc", "sphinx", "sphinx_rtd_theme",
                 "plotly", "matplotlib", "python-igraph", "geopandas",
                 "pytest", "pytest-xdist",
-                "ortools",
+                "ortools", "lightsim2grid",
                 "xlsxwriter", "openpyxl", "cryptography"
                 ]},  # "shapely", "pyproj", "fiona" are depedencies of geopandas and so already available
     # "hashlib", "zlib", "base64" produce installing problems, so it is not included


### PR DESCRIPTION
adding the extra data in a separate attribute is not very convenient, better add it to the net._options dict that gets overwritten at runpp. This way, the user can postprocess the additional data, if needed, and then the extra variables are discarded at power flow.