### PR TITLE
drop Python 3.6

### DIFF
--- a/.github/workflows/github_test_action.yml
+++ b/.github/workflows/github_test_action.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2
@@ -35,9 +35,9 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install .["all"]
         if ${{ matrix.python-version == '3.7' }}; then python -m pip install pypower; fi
-        if ${{ matrix.python-version != '3.6' }}; then python -m pip install numba; fi
+        if ${{ matrix.python-version != '3.7' }}; then python -m pip install numba; fi
     - name: Install Julia
-      if: ${{ matrix.python-version == '3.6' }}
+      if: ${{ matrix.python-version == '3.7' }}
       run: |
         ./.install_julia.sh 1.5
         pip install julia
@@ -65,7 +65,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.7', '3.8', '3.9']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
drop 3.6 from github actions

adjust some conditional tests to use 3.7 instead of 3.6