### PR TITLE
runpp3ph: raise error for unsupported vector group in runpp_3ph

### DIFF
--- a/pandapower/pd2ppc_zero.py
+++ b/pandapower/pd2ppc_zero.py
@@ -178,6 +178,9 @@ def _add_trafo_sc_impedance_zero(net, ppc, trafo_df=None):
         # zero seq. transformer impedance
         tap_lv = np.square(vn_trafo_lv / vn_lv) * net.sn_mva
         if mode == 'pf_3ph':
+            if vector_group not in ["YNyn", "Dyn", "Yzn"]:
+                raise NotImplementedError("Calculation of 3-phase power flow is only implemented for the transformer "
+                                          "vector groups 'YNyn', 'Dyn', 'Yzn'")
             # =============================================================================
             #     Changing base from transformer base to Network base to get Zpu(Net)
             #     Zbase = (kV).squared/S_mva


### PR DESCRIPTION
Calculations of the zero-sequence impedances occur for more vector groups than are tested/implemented correctly for the 3ph power flow. Raise an error upon attempt to calculate runpp_3ph for unsoppiorted vector groups.

@gourab2009 @elodin 