### PR TITLE
pandapowerNet: create DataFrames at init; bugfix with StreamHandler

### DIFF
--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -237,6 +237,10 @@ class pandapowerNet(ADict):
             self.clear()
             self.update(**net.deepcopy())
 
+        for key in self:
+            if isinstance(self[key], list):
+                self[key] = pd.DataFrame(np.zeros(0, dtype=self[key]), index=pd.Index([], dtype=np.int64))
+
     def deepcopy(self):
         return copy.deepcopy(self)
 

--- a/pandapower/converter/powerfactory/logger_setup.py
+++ b/pandapower/converter/powerfactory/logger_setup.py
@@ -1,10 +1,11 @@
+from logging import StreamHandler
 try:
     import pandaplan.core.pplog as logging
 except ImportError:
     import logging
 
 
-class AppHandler(logging.StreamHandler):
+class AppHandler(StreamHandler):
     def __init__(self, app, freeze_app_between_messages=False):
         super().__init__()
         self.app = app

--- a/pandapower/create.py
+++ b/pandapower/create.py
@@ -514,9 +514,6 @@ def create_empty_network(name="", f_hz=50., sn_mva=1, add_stdtypes=True):
     net._empty_res_sgen_3ph = net._empty_res_sgen
     net._empty_res_storage_3ph = net._empty_res_storage
 
-    for s in net:
-        if isinstance(net[s], list):
-            net[s] = pd.DataFrame(zeros(0, dtype=net[s]), index=pd.Index([], dtype=np.int64))
     if add_stdtypes:
         add_basic_std_types(net)
     else:


### PR DESCRIPTION
DataFrames used to be created in the function create_empty_network, but it is more convenient and more reasonable to do it in the constructor