### PR TITLE
Partial computation of PTDF matrices in makePTDF.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Change Log
 - [ADDED] parameter in_ka for rated switch current
 - [ADDED] current and loading result for switches
 - [FIXED] bug for disabled continous tap controllers
+- [CHANGED] enable calculating PTDF for a subset of branches
 
 [2.9.0]- 2022-03-23
 ----------------------

--- a/pandapower/pypower/makePTDF.py
+++ b/pandapower/pypower/makePTDF.py
@@ -17,8 +17,8 @@ import numpy as np
 from numpy.linalg import solve
 from scipy.sparse.linalg import spsolve, factorized
 
-from pandapower.pypower.idx_bus import BUS_TYPE, REF, BUS_I
-from pandapower.pypower.makeBdc import makeBdc
+from .idx_bus import BUS_TYPE, REF, BUS_I
+from .makeBdc import makeBdc
 
 
 def makePTDF(baseMVA, bus, branch, slack=None,

--- a/pandapower/pypower/makePTDF.py
+++ b/pandapower/pypower/makePTDF.py
@@ -22,8 +22,7 @@ from .makeBdc import makeBdc
 
 
 def makePTDF(baseMVA, bus, branch, slack=None,
-             result_side=0, using_sparse_solver=False, branch_id=None, reduced=False
-             ):
+             result_side=0, using_sparse_solver=False, branch_id=None, reduced=False):
     """Builds the DC PTDF matrix for a given choice of slack.
     Returns the DC PTDF matrix for a given choice of slack. The matrix is
     C{nbr x nb}, where C{nbr} is the number of branches and C{nb} is the
@@ -39,7 +38,7 @@ def makePTDF(baseMVA, bus, branch, slack=None,
     @see: L{makeLODF}
     @author: Ray Zimmerman (PSERC Cornell)
     """
-    if reduced and not branch_id:
+    if reduced and branch_id is None:
         raise ValueError("'reduced=True' is only valid if branch_id is not None")
 
     ## use reference bus for slack by default

--- a/pandapower/pypower/makePTDF.py
+++ b/pandapower/pypower/makePTDF.py
@@ -17,29 +17,31 @@ import numpy as np
 from numpy.linalg import solve
 from scipy.sparse.linalg import spsolve, factorized
 
-from .idx_bus import BUS_TYPE, REF, BUS_I
-from .makeBdc import makeBdc
+from pandapower.pypower.idx_bus import BUS_TYPE, REF, BUS_I
+from pandapower.pypower.makeBdc import makeBdc
 
 
 def makePTDF(baseMVA, bus, branch, slack=None,
-             result_side=0, using_sparse_solver=False):
+             result_side=0, using_sparse_solver=False, branch_id=None, reduced=False
+             ):
     """Builds the DC PTDF matrix for a given choice of slack.
-
     Returns the DC PTDF matrix for a given choice of slack. The matrix is
     C{nbr x nb}, where C{nbr} is the number of branches and C{nb} is the
     number of buses. The C{slack} can be a scalar (single slack bus) or an
     C{nb x 1} column vector of weights specifying the proportion of the
     slack taken up at each bus. If the C{slack} is not specified the
     reference bus is used by default.
-
     For convenience, C{slack} can also be an C{nb x nb} matrix, where each
     column specifies how the slack should be handled for injections
     at that bus.
-
+    To restrict the PTDF computation to a subset of branches, supply a list of ppci branch indices in C{branch_id}.
+    If C{reduced==True}, the output is reduced to the branches given in C{branch_id}, otherwise the complement rows are set to NaN.
     @see: L{makeLODF}
-
     @author: Ray Zimmerman (PSERC Cornell)
     """
+    if reduced and not branch_id:
+        raise ValueError("'reduced=True' is only valid if branch_id is not None")
+
     ## use reference bus for slack by default
     if slack is None:
         slack = find(bus[:, BUS_TYPE] == REF)
@@ -60,7 +62,10 @@ def makePTDF(baseMVA, bus, branch, slack=None,
     if any(bus[:, BUS_I] != arange(nb)):
         stderr.write('makePTDF: buses must be numbered consecutively')
 
-    H = zeros((nbr, nb))
+    if reduced:
+        H = zeros((len(branch_id), nb))
+    else:
+        H = zeros((nbr, nb))
     # compute PTDF for single slack_bus
     if using_sparse_solver:
         Bbus, Bf, _, _ = makeBdc(bus, branch, return_csr=False)
@@ -68,8 +73,13 @@ def makePTDF(baseMVA, bus, branch, slack=None,
         Bbus = Bbus.real
         if result_side == 1:
             Bf *= -1
-
-        if Bf.shape[0] < 2000:
+        if branch_id is not None:
+            Bf = Bf.real.toarray()
+            if reduced:
+                H[:, noslack] = spsolve(Bbus[ix_(noslack, noref)].T, Bf[ix_(branch_id, noref)].T).T
+            else:
+                H[ix_(branch_id, noslack)] = spsolve(Bbus[ix_(noslack, noref)].T, Bf[ix_(branch_id, noref)].T).T
+        elif Bf.shape[0] < 2000:
             Bf = Bf.real.toarray()
             H[:, noslack] = spsolve(Bbus[ix_(noslack, noref)].T, Bf[:, noref].T).T
         else:
@@ -82,7 +92,13 @@ def makePTDF(baseMVA, bus, branch, slack=None,
         Bbus, Bf = np.real(Bbus.toarray()), np.real(Bf.toarray())
         if result_side == 1:
             Bf *= -1
-        H[:, noslack] = solve(Bbus[ix_(noslack, noref)].T, Bf[:, noref].T).T
+        if branch_id is not None:
+            if reduced:
+                H[:, noslack] = solve(Bbus[ix_(noslack, noref)].T, Bf[ix_(branch_id, noref)].T).T
+            else:
+                H[ix_(branch_id, noslack)] = solve(Bbus[ix_(noslack, noref)].T, Bf[ix_(branch_id, noref)].T).T
+        else:
+            H[:, noslack] = solve(Bbus[ix_(noslack, noref)].T, Bf[:, noref].T).T
 
     ## distribute slack, if requested
     if not isscalar(slack):

--- a/pandapower/test/loadflow/test_PTDF_LODF.py
+++ b/pandapower/test/loadflow/test_PTDF_LODF.py
@@ -28,6 +28,12 @@ def test_PTDF():
                  result_side=1, using_sparse_solver=False)
     ptdf_sparse = makePTDF(ppci["baseMVA"], ppci["bus"], ppci["branch"],
                            using_sparse_solver=True)
+    ptdf_reduced = makePTDF(ppci["baseMVA"], ppci["bus"], ppci["branch"], 
+                            using_sparse_solver=False, 
+                            branch_id=list(range(15)), reduced=True)
+    ptdf_reduced_sparse = makePTDF(ppci["baseMVA"], ppci["bus"], ppci["branch"], 
+                                   using_sparse_solver=True, 
+                                   branch_id=list(range(15)), reduced=True)
 
     if not np.allclose(ptdf, ptdf_sparse):
         raise AssertionError("Sparse PTDF has differenct result against dense PTDF")
@@ -35,6 +41,10 @@ def test_PTDF():
         raise AssertionError("PTDF has wrong dimension")
     if not np.all(~np.isnan(ptdf)):
         raise AssertionError("PTDF has NaN value")
+    if not ptdf_reduced.shape == (15, ppci["bus"].shape[0]):
+        raise AssertionError("Reduced PTDF has wrong dimension")
+    if not ptdf_reduced_sparse.shape == (15,ppci["bus"].shape[0]):
+        raise AssertionError("Sparse reduced PTDF has wrong dimension"
 
 def test_PTDF_large():
     net = nw.case9241pegase()

--- a/pandapower/test/loadflow/test_PTDF_LODF.py
+++ b/pandapower/test/loadflow/test_PTDF_LODF.py
@@ -44,7 +44,7 @@ def test_PTDF():
     if not ptdf_reduced.shape == (15, ppci["bus"].shape[0]):
         raise AssertionError("Reduced PTDF has wrong dimension")
     if not ptdf_reduced_sparse.shape == (15,ppci["bus"].shape[0]):
-        raise AssertionError("Sparse reduced PTDF has wrong dimension"
+        raise AssertionError("Sparse reduced PTDF has wrong dimension")
 
 def test_PTDF_large():
     net = nw.case9241pegase()


### PR DESCRIPTION
This PR adds the functionality to restrict the PTDF computation to a subset of branches by adjusting the equation set to be solved.
As a consequence, computation time and resources are significantly decreased when only a subset of a grid model is of interest.

The ppci indices of the branches to be kept (positive list) is given in the optional keyword argument `branch_id`. Additionally, it is possible to reduce the size of the output matrix to these branches by setting `reduced=True`.