### PR TITLE
omitting certain tables when loading a json

### DIFF
--- a/pandapower/file_io.py
+++ b/pandapower/file_io.py
@@ -224,7 +224,7 @@ def _from_excel_old(xls):
 
 
 def from_json(filename, convert=True, encryption_key=None, elements_to_deserialize=None,
-              keep_serialized_elements=True, add_basic_std_types=False):
+              keep_serialized_elements=True, add_basic_std_types=False, omit_tables=[]):
     """
     Load a pandapower network from a JSON file.
     The index of the returned network is not necessarily in the same order as the original network.
@@ -267,11 +267,11 @@ def from_json(filename, convert=True, encryption_key=None, elements_to_deseriali
     return from_json_string(json_string, convert=convert, encryption_key=encryption_key,
                             elements_to_deserialize=elements_to_deserialize,
                             keep_serialized_elements=keep_serialized_elements,
-                            add_basic_std_types=add_basic_std_types)
+                            add_basic_std_types=add_basic_std_types, omit_tables=omit_tables)
 
 
 def from_json_string(json_string, convert=False, encryption_key=None, elements_to_deserialize=None,
-                     keep_serialized_elements=True, add_basic_std_types=False):
+                     keep_serialized_elements=True, add_basic_std_types=False, omit_tables=[]):
     """
     Load a pandapower network from a JSON string.
     The index of the returned network is not necessarily in the same order as the original network.
@@ -306,9 +306,9 @@ def from_json_string(json_string, convert=False, encryption_key=None, elements_t
         json_string = io_utils.decrypt_string(json_string, encryption_key)
 
     if elements_to_deserialize is None:
-        net = json.loads(json_string, cls=io_utils.PPJSONDecoder)
+        net = json.loads(json_string, cls=io_utils.PPJSONDecoder, omit_tables=omit_tables)
     else:
-        net = json.loads(json_string, cls=io_utils.PPJSONDecoder, deserialize_pandas=False)
+        net = json.loads(json_string, cls=io_utils.PPJSONDecoder, deserialize_pandas=False, omit_tables=omit_tables)
         net_dummy = create_empty_network()
         if ('version' not in net.keys()) | (version.parse(net.version) < version.parse('2.1.0')):
             raise UserWarning('table selection is only possible for nets above version 2.0.1. '

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -548,15 +548,20 @@ class PPJSONDecoder(json.JSONDecoder):
         # net = pandapowerNet.__new__(pandapowerNet)
         #        net = create_empty_network()
         deserialize_pandas = kwargs.pop('deserialize_pandas', True)
+        omit_tables = kwargs.pop('omit_tables', [])
         super_kwargs = {"object_hook": partial(pp_hook,
                                                deserialize_pandas=deserialize_pandas,
+                                               omit_tables=omit_tables,
                                                registry_class=FromSerializableRegistry)}
         super_kwargs.update(kwargs)
         super().__init__(**super_kwargs)
 
 
-def pp_hook(d, deserialize_pandas=True, registry_class=FromSerializableRegistry):
+def pp_hook(d, deserialize_pandas=True, omit_tables=[], registry_class=FromSerializableRegistry):
     try:
+        for ot in omit_tables:
+            if ot in d:
+                del d[ot]
         if '_module' in d and '_class' in d:
             if 'pandas' in d['_module'] and not deserialize_pandas:
                 return json.dumps(d)

--- a/pandapower/test/api/test_file_io.py
+++ b/pandapower/test/api/test_file_io.py
@@ -19,6 +19,7 @@ from pandapower import pp_dir
 from pandapower.io_utils import PPJSONEncoder, PPJSONDecoder
 from pandapower.test.toolbox import assert_net_equal, create_test_network, create_test_network2
 from pandapower.timeseries import DFData
+from pandapower.toolbox import nets_equal
 
 try:
     import geopandas as gpd
@@ -425,6 +426,19 @@ def test_json_io_with_characteristics(net_in):
     assert isinstance(net_out.characteristic.object.at[c2.index], pp.control.SplineCharacteristic)
     assert np.isclose(net_out.characteristic.object.at[c1.index](0.5), c1(0.5), rtol=0, atol=1e-12)
     assert np.isclose(net_out.characteristic.object.at[c2.index](2.5), c2(2.5), rtol=0, atol=1e-12)
+
+
+def test_omitting_tables_from_json(net_in):
+    net = copy.deepcopy(net_in)
+    control.ConstControl(net, 'load', 'p_mw', 0)
+    json_string = pp.to_json(net)
+    net1 = pp.from_json_string(json_string, omit_tables=['controller'])
+    net2 = pp.from_json_string(json_string)
+
+    assert(nets_equal(net, net2))
+    assert(not nets_equal(net, net1))
+    net.controller.drop(0, inplace=True)
+    assert(nets_equal(net, net1))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
If you want to omit some tables to be loaded, you can pass a list to the variable omit_tables. If the tables are in the net, they are not loaded but omitted.