### PR TITLE
add method __eq__ to JSONSerializableClass 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Change Log
 - [ADDED] parameter in_ka for rated switch current
 - [ADDED] current and loading result for switches
 - [FIXED] bug for disabled continous tap controllers
+- [ADDED] __eq__ method for JSONSerializableClass using deepdiff library, and adjusted pp.nets_equal to use it. Requires deepdiff
 
 [2.9.0]- 2022-03-23
 ----------------------

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -759,12 +759,13 @@ class JSONSerializableClass(object):
 
     def __eq__(self, other):
         """
-        isinstance: for an early return without calling DeepDiff
-        comparing class name instead of class directly allows more flexibility,
+        comparing class name and attributes instead of class object address directly.
+        This allows more flexibility,
         e.g. when the class definition is moved to a different module.
+        Checking isinstance(other, self.__class__) for an early return without calling DeepDiff.
         There is still a risk that the implementation details of the methods can differ
         if the classes are from different modules.
-        Comparison is based on comparing dictionaries of the classes.
+        The comparison is based on comparing dictionaries of the classes.
         To this end, the dictionary comparison library deepdiff is used for recursive comparison.
         """
         if not isinstance(other, self.__class__) or self.__class__.__name__ != other.__class__.__name__:

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -671,7 +671,16 @@ class JSONSerializableClass(object):
         return index
 
     def equals(self, other):
-        # todo: can this be removed?
+        # todo: can this method be removed?
+        warn("JSONSerializableClass: the attribute 'equals' is deprecated "
+             "and will be removed in the future. Use the '__eq__' method instead, "
+             "by directly comparing the objects 'a == b'. "
+             "To check if two variables point to the same object, use 'a is b'", DeprecationWarning)
+
+        logger.warning("JSONSerializableClass: the attribute 'equals' is deprecated "
+                       "and will be removed in the future. Use the '__eq__' method instead, "
+                       "by directly comparing the objects 'a == b'. "
+                       "To check if two variables point to the same object, use 'a is b'")
 
         class UnequalityFound(Exception):
             pass

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -759,7 +759,7 @@ class JSONSerializableClass(object):
 
     def __eq__(self, other):
         """
-        isinstance: so that we know we can use to_json()
+        isinstance: for an early return without calling DeepDiff
         comparing class name instead of class directly allows more flexibility,
         e.g. when the class definition is moved to a different module.
         There is still a risk that the implementation details of the methods can differ
@@ -770,8 +770,8 @@ class JSONSerializableClass(object):
         if not isinstance(other, self.__class__) or self.__class__.__name__ != other.__class__.__name__:
             return False
         else:
-            d = DeepDiff(self, other, ignore_order=True, ignore_nan_inequality=True, significant_digits=6,
-                         ignore_private_variables=False)
+            d = DeepDiff(self.__dict__, other.__dict__, ignore_order=True, ignore_nan_inequality=True,
+                         significant_digits=6, math_epsilon=1e-6, ignore_private_variables=False)
             return len(d) == 0
 
 

--- a/pandapower/test/api/test_file_io.py
+++ b/pandapower/test/api/test_file_io.py
@@ -335,10 +335,10 @@ def test_deepcopy_controller():
     net2 = copy.deepcopy(net)
     ct1 = net.controller.object.iloc[0]
     ct2 = net2.controller.object.iloc[0]
-    assert ct1 != ct2
-    assert ct1.equals(ct2)
+    assert ct1 is not ct2
+    assert ct1 == ct2
     ct2.vm_set_pu = 1.02
-    assert not ct1.equals(ct2)
+    assert ct1 != ct2
 
 
 def test_elements_to_deserialize(tmp_path):

--- a/pandapower/test/api/test_toolbox.py
+++ b/pandapower/test/api/test_toolbox.py
@@ -172,9 +172,10 @@ def test_nets_equal():
     net2 = original.deepcopy()
     pp.control.ContinuousTapControl(net1, 0, 1.0)
     pp.control.ContinuousTapControl(net2, 0, 1.0)
-    c1 = net1.controller.object.at[0]
-    c2 = net2.controller.object[0]
+    c1 = net1.controller.at[0, "object"]
+    c2 = net2.controller.at[0, "object"]
     assert c1 == c2
+    assert c1 is not c2
     assert tb.nets_equal(net1, net2)
     c1.vm_set_pu = 1.01
     assert c1 != c2

--- a/pandapower/test/api/test_toolbox.py
+++ b/pandapower/test/api/test_toolbox.py
@@ -14,6 +14,7 @@ import pytest
 import pandapower as pp
 import pandapower.networks as nw
 import pandapower.toolbox as tb
+import pandapower.control
 from pandapower.test.toolbox import assert_net_equal
 
 
@@ -164,6 +165,21 @@ def test_nets_equal():
     net["load"]["p_mw"][net["load"].index[0]] += 0.0001
     assert tb.nets_equal(original, net, atol=0.1)
     assert tb.nets_equal(net, original, atol=0.1)
+
+    # check controllers
+    original.trafo.tap_side.fillna("hv", inplace=True)
+    net1 = original.deepcopy()
+    net2 = original.deepcopy()
+    pp.control.ContinuousTapControl(net1, 0, 1.0)
+    pp.control.ContinuousTapControl(net2, 0, 1.0)
+    c1 = net1.controller.object.at[0]
+    c2 = net2.controller.object[0]
+    assert c1 == c2
+    assert tb.nets_equal(net1, net2)
+    c1.vm_set_pu = 1.01
+    assert c1 != c2
+    assert tb.nets_equal(net1, net2, exclude_elms=["controller"])
+    assert not tb.nets_equal(net1, net2)
 
 
 def test_clear_result_tables():

--- a/pandapower/toolbox.py
+++ b/pandapower/toolbox.py
@@ -722,6 +722,9 @@ def nets_equal(net1, net2, check_only_results=False, check_without_results=False
 
     pandapower net keys starting with "_" are ignored. Same for the key "et" (elapsed time).
 
+    If the element tables contain JSONSerializableClass objects, they will also be compared:
+    attributes are compared but not the addresses of the objects.
+
     INPUT:
         **net1** (pandapower net)
 

--- a/pandapower/toolbox.py
+++ b/pandapower/toolbox.py
@@ -797,19 +797,8 @@ def _nets_equal_keys(net1, net2, check_only_results, check_without_results, excl
     for key in list(keys_to_check):
 
         if isinstance(net1[key], pd.DataFrame):
-            if not isinstance(net2[key], pd.DataFrame):
+            if not isinstance(net2[key], pd.DataFrame) or not dataframes_equal(net1[key], net2[key], **kwargs):
                 not_equal.append(key)
-            else:
-                if "object" in net1[key].columns and "object" in net2[key].columns and \
-                        isinstance(net1[key].object.dtype, object) and \
-                        isinstance(net1[key].object.dtype, object):
-                    logger.warning(f"net[{key}]['object'] cannot be compared.")
-                    if not dataframes_equal(net1[key][net1[key].columns.difference(["object"])],
-                                            net2[key][net2[key].columns.difference(["object"])],
-                                            **kwargs):
-                        not_equal.append(key)
-                elif not dataframes_equal(net1[key], net2[key], **kwargs):
-                    not_equal.append(key)
 
         elif isinstance(net1[key], np.ndarray):
             if not isinstance(net2[key], np.ndarray):

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,8 @@ setup(
                       "scipy",
                       "numpy>=0.11",
                       "packaging",
-                      "tqdm"],
+                      "tqdm",
+                      "deepdiff"],
     extras_require={
         "docs": ["numpydoc", "sphinx", "sphinx_rtd_theme"],
         "plotting": ["plotly", "matplotlib", "python-igraph", "geopandas"],


### PR DESCRIPTION
Objective: to allow comparison of pandapower objects (e.g. Controller, Characteristic). Updated pp.toolbox.nets_equal to consider pp objects.
