### PR TITLE
Tdpf results r theta

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Change Log
 - [ADDED] calculation of overhead line temperature in Newton-Raphson with two simplified methods (Frank et al. and Ngoko et al.)
 - [ADDED] group functionality
 - [FIXED] Bug with user_pf_options: _init_runpp_options in auxiliary.py ignored user_pf_options when performing sanity checks
+- [CHANGED] TDPF: rename r_theta to r_theta_kelvin_per_mw, add r_theta_kelvin_per_mw to net.res_line
 
 [2.10.1] - 2022-07-31
 -------------------------------

--- a/doc/powerflow/ac.rst
+++ b/doc/powerflow/ac.rst
@@ -31,7 +31,7 @@ TDPF is implemented based on the following publications:
 Additional parameters in net.line are required. If missing, common assumptions are used to add the parameters to net.line.
 The column "tdpf" (bool) must be provided in net.line to designate which lines are relevant for TDPF.
 The parameter "outer_diameter_m" (float) must be provided if the weather model is used (pp.runpp parameter tdpf_update_r_theta=True).
-Otherwise, the parameter "r_theta" (float) must be specified. It can be calculated using the function "pandapower.pf.create_jacobian_tdpf.calc_r_theta_from_t_rise"
+Otherwise, the parameter "r_theta_kelvin_per_mw" (float) must be specified. It can be calculated using the function "pandapower.pf.create_jacobian_tdpf.calc_r_theta_from_t_rise"
 For consideration of thermal inertia, pp.runpp parameter "tdpf_delay_s" specifies the time after a step change of current.
 The parameter "mc_joule_per_m_k" describes the mass * thermal capacity of the conductor per unit length and it must be provided in net.line.
 

--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -805,7 +805,7 @@ def _check_tdpf_parameters(net, tdpf_update_r_theta, tdpf_delay_s):
     if len(tdpf_lines) == 0:
         logger.info("TDPF: no relevant lines found")
 
-    # required for simplified approach if r_theta is provided, can be filled with simplified values:
+    # required for simplified approach if r_theta_kelvin_per_mw is provided, can be filled with simplified values:
     default_values = {"temperature_degree_celsius": 20,  # starting temperature of lines
                       "reference_temperature_degree_celsius": 20,  # reference temperature for line.r_ohm_per_km
                       "air_temperature_degree_celsius": 35,  # temperature of air surrounding the conductors
@@ -820,8 +820,10 @@ def _check_tdpf_parameters(net, tdpf_update_r_theta, tdpf_delay_s):
                                "emissivity": 0.5})  # coefficient of solar emissivity
         required_columns.append("conductor_outer_diameter_m")  # outer diameter of the conductor
     else:
-        # make sure r_theta is provided (use the function pandapower.pf.create_jacobian_tdpf.calc_r_theta_from_t_rise)
-        required_columns.append("r_theta")  # if a simplified method for calculating the line temperature is used
+        # make sure r_theta_kelvin_per_mw is provided
+        # (use the function pandapower.pf.create_jacobian_tdpf.calc_r_theta_from_t_rise)
+        # is relevant if a simplified method for calculating the line temperature is used
+        required_columns.append("r_theta_kelvin_per_mw")
 
     if tdpf_delay_s:
         # for thermal inertia, mass * thermal capacity of the conductor per unit length:

--- a/pandapower/build_branch.py
+++ b/pandapower/build_branch.py
@@ -165,7 +165,7 @@ def _calc_line_parameter(net, ppc, elm="line", ppc_elm="branch"):
         branch[f:t, SOLAR_RADIATION_W_PER_SQ_M] = line.get("solar_radiation_w_per_sq_m", default=np.nan)
         branch[f:t, GAMMA] = line.get("solar_absorptivity", default=np.nan)
         branch[f:t, EPSILON] = line.get("emissivity", default=np.nan)
-        branch[f:t, R_THETA] = line.get("r_theta", default=np.nan)
+        branch[f:t, R_THETA] = line.get("r_theta_kelvin_per_mw", default=np.nan)
         branch[f:t, OUTER_DIAMETER_M] = line.get("conductor_outer_diameter_m", default=np.nan)
         branch[f:t, MC_JOULE_PER_M_K] = line.get("mc_joule_per_m_k", default=np.nan)
 

--- a/pandapower/pf/run_newton_raphson_pf.py
+++ b/pandapower/pf/run_newton_raphson_pf.py
@@ -158,13 +158,15 @@ def _run_ac_pf_without_qlims_enforced(ppci, options):
     if options["lightsim2grid"]:
         V, success, iterations, J, Vm_it, Va_it = newton_ls(Ybus.tocsc(), Sbus, V0, ref, pv, pq, ppci, options)
         T = None
+        r_theta_kelvin_per_mw = None
     else:
-        V, success, iterations, J, Vm_it, Va_it, T = newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppci, options, makeYbus)
+        V, success, iterations, J, Vm_it, Va_it, r_theta_kelvin_per_mw, T = newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppci, options, makeYbus)
 
     # keep "internal" variables in  memory / net["_ppc"]["internal"] -> needed for recycle.
     ppci = _store_internal(ppci, {"J": J, "Vm_it": Vm_it, "Va_it": Va_it, "bus": bus, "gen": gen, "branch": branch,
                                   "baseMVA": baseMVA, "V": V, "pv": pv, "pq": pq, "ref": ref, "Sbus": Sbus,
-                                  "ref_gens": ref_gens, "Ybus": Ybus, "Yf": Yf, "Yt": Yt, "T": T})
+                                  "ref_gens": ref_gens, "Ybus": Ybus, "Yf": Yf, "Yt": Yt,
+                                  "r_theta_kelvin_per_mw": r_theta_kelvin_per_mw, "T": T})
 
     return ppci, success, iterations
 

--- a/pandapower/pypower/idx_brch_tdpf.py
+++ b/pandapower/pypower/idx_brch_tdpf.py
@@ -20,7 +20,7 @@ WIND_ANGLE_DEGREE 			= start + 10  # Angle of attack, angle between wind directi
 SOLAR_RADIATION_W_PER_SQ_M 	= start + 11  # Solar radiation in W/m²
 GAMMA 						= start + 12  # absorption albedo, solar absorptivity
 EPSILON 					= start + 13  # radiative albedo, emissivity
-R_THETA 					= start + 14  # Thermal resistance R_Theta (Optional)
+R_THETA 					= start + 14  # Thermal resistance R_Theta in K/MW (Optional)
 OUTER_DIAMETER_M 			= start + 15  # outer diameter of the conductor
 MC_JOULE_PER_M_K 			= start + 16  # thermal inertia parameter of the conductor
 

--- a/pandapower/pypower/newtonpf.py
+++ b/pandapower/pypower/newtonpf.py
@@ -123,6 +123,7 @@ def newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppci, options, makeYbus=None):
 
     T_base = 100  # T in p.u. for better convergence
     T = 20 / T_base
+    r_theta_pu = 0
     if tdpf:
         if len(pq) > 0:
             pq_lookup = zeros(max(refpvpq) + 1, dtype=int)  # for TDPF
@@ -169,7 +170,8 @@ def newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppci, options, makeYbus=None):
         if tdpf_update_r_theta:
             r_theta_pu = calc_r_theta(t_air_pu, a0, a1, a2, i_square_pu, p_loss_pu)
         # initial guess for T:
-        T = calc_T_frank(p_loss_pu, t_air_pu, r_theta_pu, tdpf_delay_s, T0, tau)
+        # T = calc_T_frank(p_loss_pu, t_air_pu, r_theta_pu, tdpf_delay_s, T0, tau)
+        T = T0.copy()  # better for e.g. timeseries calculation
         F_t = zeros(len(branch))
         # F_t[tdpf_lines] = T - T0
         F = r_[F, F_t]
@@ -238,7 +240,7 @@ def newtonpf(Ybus, Sbus, V0, ref, pv, pq, ppci, options, makeYbus=None):
 
         converged = _check_for_convergence(F, tol)
 
-    return V, converged, i, J, Vm_it, Va_it, T * T_base
+    return V, converged, i, J, Vm_it, Va_it, r_theta_pu / baseMVA * T_base, T * T_base
 
 
 def _evaluate_Fx(Ybus, V, Sbus, ref, pv, pq, slack_weights=None, dist_slack=False, slack=None):

--- a/pandapower/results_branch.py
+++ b/pandapower/results_branch.py
@@ -148,6 +148,7 @@ def _get_line_results(net, ppc, i_ft, suffix=None):
 
         if net["_options"].get("tdpf", False):
             tpdf_lines = line_df.in_service & line_df.tdpf
+            res_line_df.loc[tpdf_lines, "r_theta_kelvin_per_mw"] = ppc["internal"]["r_theta_kelvin_per_mw"]
             no_tdpf_t = line_df.loc[~tpdf_lines].get("temperature_degree_celsius", default=20.)
             res_line_df.loc[tpdf_lines, "temperature_degree_celsius"] = ppc["internal"]["T"]
             res_line_df.loc[~tpdf_lines, "temperature_degree_celsius"] = no_tdpf_t

--- a/pandapower/run.py
+++ b/pandapower/run.py
@@ -37,10 +37,10 @@ def set_user_pf_options(net, overwrite=False, **kwargs):
     standard_parameters = ['calculate_voltage_angles', 'trafo_model', 'check_connectivity', 'mode',
                            'copy_constraints_to_ppc', 'switch_rx_ratio', 'enforce_q_lims',
                            'recycle', 'voltage_depend_loads', 'consider_line_temperature', 'delta',
-                           'trafo3w_losses', 'init_vm_pu', 'init_va_degree', 'init_results',
+                           'trafo3w_losses', 'init', 'init_vm_pu', 'init_va_degree', 'init_results',
                            'tolerance_mva', 'trafo_loading', 'numba', 'ac', 'algorithm',
                            'max_iteration', 'v_debug', 'run_control', 'distributed_slack', 'lightsim2grid',
-                           'tdpf', 'tdpf_delay_s']
+                           'tdpf', 'tdpf_delay_s', 'tdpf_update_r_theta']
 
     if overwrite or 'user_pf_options' not in net.keys():
         net['user_pf_options'] = dict()

--- a/tutorials/temperature_dependent_power_flow.ipynb
+++ b/tutorials/temperature_dependent_power_flow.ipynb
@@ -400,7 +400,7 @@
     "* solar emissivity and solar absorptivity (0.5)\n",
     "* thermal coefficient of resistivity (4.03e-3)\n",
     "\n",
-    "The parameters are specified in the net.line element table. If any parameters are missing, they will be substitutet by default assumptions. The parameter \"tdpf\" is always required. If the option to not update $R_\\Theta$ is used, then \"r_theta\" is required. Otherwise, \"conductor_outer_diameter_m\" is required. Furthermore, if thermal inertia is considered by setting the option \"tdpf_delay_s\", the parameter \"mc_joule_per_m_k\" is required."
+    "The parameters are specified in the net.line element table. If any parameters are missing, they will be substitutet by default assumptions. The parameter \"tdpf\" is always required. If the option to not update $R_\\Theta$ is used, then \"r_theta_kelvin_per_mw\" is required. Otherwise, \"conductor_outer_diameter_m\" is required. Furthermore, if thermal inertia is considered by setting the option \"tdpf_delay_s\", the parameter \"mc_joule_per_m_k\" is required."
    ]
   },
   {
@@ -411,8 +411,8 @@
     {
      "data": {
       "text/plain": [
-       "array([46.05926996, 53.12154882, 49.93833344, 47.29144877, 99.9890416 ,\n",
-       "       91.40392366])"
+       "array([ 46.06044226,  53.12839992,  49.94224359,  47.29338662,\n",
+       "       100.09505835,  91.48530994])"
       ]
      },
      "execution_count": 6,
@@ -422,7 +422,7 @@
    ],
    "source": [
     "t_air_pu = 35\n",
-    "alpha_pu = 4e-3\n",
+    "alpha_pu = 4.03e-3\n",
     "r_ref = net.line.r_ohm_per_km.values / 1e3\n",
     "a0, a1, a2, tau = calc_a0_a1_a2_tau(t_air_pu, 80, 20, r_ref, 30.6e-3,\n",
     "                                    1490, 0.6, 45, 900, alpha_pu, 0.5, 0.5)\n",
@@ -453,7 +453,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Alternatively, the thermal resistance can be approximated using an assumption for the rated temperature rise, as described in Frank et al. To this end, the air temperature $T_{air}$ and the temperature rise are added to calculate the line temperature. The temperature rise is calculated by multiplying the thermal resistance $R_\\Theta$ and the active power losses $P_{Loss}$."
+    "Alternatively, the thermal resistance can be approximated using an assumption for the rated temperature rise, as described in Frank et al. To this end, the air temperature $T_{air}$ and the temperature rise are added to calculate the line temperature. The temperature rise is calculated by multiplying the thermal resistance $R_\\Theta$ and the active power losses $P_{Loss}$. The thermal resistance is included in the line results table."
    ]
   },
   {
@@ -464,8 +464,8 @@
     {
      "data": {
       "text/plain": [
-       "array([46.05926996, 53.12154882, 49.93833344, 47.29144877, 99.9890416 ,\n",
-       "       91.40392366])"
+       "array([ 46.06044226,  53.12839992,  49.94224359,  47.29338662,\n",
+       "       100.09505835,  91.48530994])"
       ]
      },
      "execution_count": 7,
@@ -484,8 +484,8 @@
     "Va = np.angle(net._ppc[\"internal\"][\"V\"])\n",
     "i_square_pu, p_loss_pu = calc_i_square_p_loss(branch, tdpf_lines, g, b, Vm, Va)\n",
     "#i_square_pu = np.square(net.res_line.i_ka.values*1e3)\n",
-    "r_theta = calc_r_theta(t_air_pu, a0, a1, a2, np.square(net.res_line.i_ka.values*1e3), p_loss_pu)\n",
-    "calc_T_frank(p_loss_pu, t_air_pu, r_theta, None, None, None)"
+    "r_theta_pu = calc_r_theta(t_air_pu, a0, a1, a2, np.square(net.res_line.i_ka.values*1e3), p_loss_pu)\n",
+    "calc_T_frank(p_loss_pu, t_air_pu, r_theta_pu, None, None, None)"
    ]
   },
   {
@@ -496,8 +496,8 @@
     {
      "data": {
       "text/plain": [
-       "array([35.01438349, 35.05681755, 35.03790295, 35.02191228, 35.30425606,\n",
-       "       35.26252383])"
+       "array([36.43834877, 40.68175543, 38.79029548, 37.19122826, 65.42560553,\n",
+       "       61.25238291])"
       ]
      },
      "execution_count": 8,
@@ -507,8 +507,8 @@
    ],
    "source": [
     "# using an approximation for the rated temperature rise:\n",
-    "r_theta = calc_r_theta_from_t_rise(net, 25)\n",
-    "calc_T_frank(p_loss_pu, t_air_pu, r_theta.values, None, None, None)"
+    "r_theta_kelvin_per_mw = calc_r_theta_from_t_rise(net, 25)\n",
+    "calc_T_frank(p_loss_pu, t_air_pu, r_theta_kelvin_per_mw.values * net.sn_mva / 1, None, None, None)"
    ]
   },
   {
@@ -575,6 +575,7 @@
        "      <th>va_to_degree</th>\n",
        "      <th>loading_percent</th>\n",
        "      <th>r_ohm_per_km</th>\n",
+       "      <th>r_theta_kelvin_per_mw</th>\n",
        "      <th>temperature_degree_celsius</th>\n",
        "    </tr>\n",
        "  </thead>\n",
@@ -596,6 +597,7 @@
        "      <td>3.324106</td>\n",
        "      <td>25.648576</td>\n",
        "      <td>0.065172</td>\n",
+       "      <td>37.924674</td>\n",
        "      <td>46.151857</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -615,6 +617,7 @@
        "      <td>0.000000</td>\n",
        "      <td>50.764815</td>\n",
        "      <td>0.066887</td>\n",
+       "      <td>15.579987</td>\n",
        "      <td>53.419294</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -634,6 +637,7 @@
        "      <td>5.550365</td>\n",
        "      <td>41.478734</td>\n",
        "      <td>0.066113</td>\n",
+       "      <td>24.328248</td>\n",
        "      <td>50.138432</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -653,13 +657,14 @@
        "      <td>2.284085</td>\n",
        "      <td>31.031951</td>\n",
        "      <td>0.065440</td>\n",
+       "      <td>56.856682</td>\n",
        "      <td>47.287124</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
        "      <td>209.539677</td>\n",
        "      <td>-151.708806</td>\n",
-       "      <td>-203.578074</td>\n",
+       "      <td>-203.578073</td>\n",
        "      <td>179.827572</td>\n",
        "      <td>5.961603</td>\n",
        "      <td>28.118767</td>\n",
@@ -672,13 +677,14 @@
        "      <td>0.000000</td>\n",
        "      <td>117.863704</td>\n",
        "      <td>0.078446</td>\n",
-       "      <td>102.396571</td>\n",
+       "      <td>11.305108</td>\n",
+       "      <td>102.396570</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
        "      <td>-112.343080</td>\n",
        "      <td>225.658937</td>\n",
-       "      <td>115.473610</td>\n",
+       "      <td>115.473611</td>\n",
        "      <td>-210.478384</td>\n",
        "      <td>3.130530</td>\n",
        "      <td>15.180553</td>\n",
@@ -691,6 +697,7 @@
        "      <td>2.284085</td>\n",
        "      <td>109.380148</td>\n",
        "      <td>0.076301</td>\n",
+       "      <td>18.626449</td>\n",
        "      <td>93.310661</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -703,8 +710,8 @@
        "1   98.854296   -57.860539  -97.672056   64.400365  1.182241   6.539826   \n",
        "2  -89.838066    13.737926   90.460324  -10.255459  0.622257   3.482468   \n",
        "3   65.689717   -17.546813  -65.473610   18.768694  0.216107   1.221881   \n",
-       "4  209.539677  -151.708806 -203.578074  179.827572  5.961603  28.118767   \n",
-       "5 -112.343080   225.658937  115.473610 -210.478384  3.130530  15.180553   \n",
+       "4  209.539677  -151.708806 -203.578073  179.827572  5.961603  28.118767   \n",
+       "5 -112.343080   225.658937  115.473611 -210.478384  3.130530  15.180553   \n",
        "\n",
        "   i_from_ka   i_to_ka      i_ka  vm_from_pu  va_from_degree  vm_to_pu  \\\n",
        "0   0.246226  0.246226  0.246226    1.028013        3.058060  0.998271   \n",
@@ -714,13 +721,21 @@
        "4   1.131492  1.131492  1.131492    1.000000        5.550365  1.050000   \n",
        "5   1.050049  1.050049  1.050049    1.050000        0.000000  1.000000   \n",
        "\n",
-       "   va_to_degree  loading_percent  r_ohm_per_km  temperature_degree_celsius  \n",
-       "0      3.324106        25.648576      0.065172                   46.151857  \n",
-       "1      0.000000        50.764815      0.066887                   53.419294  \n",
-       "2      5.550365        41.478734      0.066113                   50.138432  \n",
-       "3      2.284085        31.031951      0.065440                   47.287124  \n",
-       "4      0.000000       117.863704      0.078446                  102.396571  \n",
-       "5      2.284085       109.380148      0.076301                   93.310661  "
+       "   va_to_degree  loading_percent  r_ohm_per_km  r_theta_kelvin_per_mw  \\\n",
+       "0      3.324106        25.648576      0.065172              37.924674   \n",
+       "1      0.000000        50.764815      0.066887              15.579987   \n",
+       "2      5.550365        41.478734      0.066113              24.328248   \n",
+       "3      2.284085        31.031951      0.065440              56.856682   \n",
+       "4      0.000000       117.863704      0.078446              11.305108   \n",
+       "5      2.284085       109.380148      0.076301              18.626449   \n",
+       "\n",
+       "   temperature_degree_celsius  \n",
+       "0                   46.151857  \n",
+       "1                   53.419294  \n",
+       "2                   50.138432  \n",
+       "3                   47.287124  \n",
+       "4                  102.396570  \n",
+       "5                   93.310661  "
       ]
      },
      "execution_count": 10,
@@ -740,8 +755,8 @@
     {
      "data": {
       "text/plain": [
-       "array([ 46.15185728,  53.41929414,  50.13843149,  47.28712425,\n",
-       "       102.39657035,  93.31066069])"
+       "array([ 46.15308366,  53.42645102,  50.1425085 ,  47.28905922,\n",
+       "       102.50991728,  93.39730687])"
       ]
      },
      "execution_count": 11,
@@ -761,8 +776,8 @@
     {
      "data": {
       "text/plain": [
-       "array([46.05926996, 53.12154882, 49.93833344, 47.29144877, 99.9890416 ,\n",
-       "       91.40392366])"
+       "array([ 46.06044226,  53.12839992,  49.94224359,  47.29338662,\n",
+       "       100.09505835,  91.48530994])"
       ]
      },
      "execution_count": 12,
@@ -849,6 +864,7 @@
        "      <th>va_to_degree</th>\n",
        "      <th>loading_percent</th>\n",
        "      <th>r_ohm_per_km</th>\n",
+       "      <th>r_theta_kelvin_per_mw</th>\n",
        "      <th>temperature_degree_celsius</th>\n",
        "    </tr>\n",
        "  </thead>\n",
@@ -857,7 +873,7 @@
        "      <th>0</th>\n",
        "      <td>2.169795</td>\n",
        "      <td>56.988937</td>\n",
-       "      <td>-1.903740</td>\n",
+       "      <td>-1.903741</td>\n",
        "      <td>-55.366515</td>\n",
        "      <td>0.266055</td>\n",
        "      <td>1.622422</td>\n",
@@ -870,13 +886,14 @@
        "      <td>3.212388</td>\n",
        "      <td>25.284924</td>\n",
        "      <td>0.060675</td>\n",
+       "      <td>41.657558</td>\n",
        "      <td>27.096882</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1</th>\n",
        "      <td>97.830205</td>\n",
        "      <td>-56.988937</td>\n",
-       "      <td>-96.773740</td>\n",
+       "      <td>-96.773739</td>\n",
        "      <td>63.383200</td>\n",
        "      <td>1.056465</td>\n",
        "      <td>6.394263</td>\n",
@@ -889,13 +906,14 @@
        "      <td>0.000000</td>\n",
        "      <td>50.196674</td>\n",
        "      <td>0.061132</td>\n",
+       "      <td>17.225095</td>\n",
        "      <td>29.032648</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>2</th>\n",
        "      <td>-88.984503</td>\n",
        "      <td>12.221760</td>\n",
-       "      <td>89.544641</td>\n",
+       "      <td>89.544640</td>\n",
        "      <td>-8.820053</td>\n",
        "      <td>0.560137</td>\n",
        "      <td>3.401707</td>\n",
@@ -908,6 +926,7 @@
        "      <td>5.407436</td>\n",
        "      <td>40.994956</td>\n",
        "      <td>0.060926</td>\n",
+       "      <td>26.756068</td>\n",
        "      <td>28.159076</td>\n",
        "    </tr>\n",
        "    <tr>\n",
@@ -927,13 +946,14 @@
        "      <td>2.174414</td>\n",
        "      <td>31.040639</td>\n",
        "      <td>0.060752</td>\n",
+       "      <td>61.219320</td>\n",
        "      <td>27.425004</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>4</th>\n",
-       "      <td>210.455361</td>\n",
+       "      <td>210.455359</td>\n",
        "      <td>-144.382347</td>\n",
-       "      <td>-205.708173</td>\n",
+       "      <td>-205.708171</td>\n",
        "      <td>171.751230</td>\n",
        "      <td>4.747188</td>\n",
        "      <td>27.368883</td>\n",
@@ -946,13 +966,14 @@
        "      <td>0.000000</td>\n",
        "      <td>116.281463</td>\n",
        "      <td>0.064177</td>\n",
-       "      <td>41.937485</td>\n",
+       "      <td>13.824373</td>\n",
+       "      <td>41.937483</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>5</th>\n",
-       "      <td>-113.143652</td>\n",
+       "      <td>-113.143651</td>\n",
        "      <td>221.648526</td>\n",
-       "      <td>115.687504</td>\n",
+       "      <td>115.687503</td>\n",
        "      <td>-206.853411</td>\n",
        "      <td>2.543852</td>\n",
        "      <td>14.795116</td>\n",
@@ -965,6 +986,7 @@
        "      <td>2.174414</td>\n",
        "      <td>107.982627</td>\n",
        "      <td>0.063617</td>\n",
+       "      <td>22.370305</td>\n",
        "      <td>39.564852</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -973,12 +995,12 @@
       ],
       "text/plain": [
        "    p_from_mw  q_from_mvar     p_to_mw   q_to_mvar     pl_mw    ql_mvar  \\\n",
-       "0    2.169795    56.988937   -1.903740  -55.366515  0.266055   1.622422   \n",
-       "1   97.830205   -56.988937  -96.773740   63.383200  1.056465   6.394263   \n",
-       "2  -88.984503    12.221760   89.544641   -8.820053  0.560137   3.401707   \n",
+       "0    2.169795    56.988937   -1.903741  -55.366515  0.266055   1.622422   \n",
+       "1   97.830205   -56.988937  -96.773739   63.383200  1.056465   6.394263   \n",
+       "2  -88.984503    12.221760   89.544640   -8.820053  0.560137   3.401707   \n",
        "3   65.888243   -16.855245  -65.687504   18.077810  0.200740   1.222565   \n",
-       "4  210.455361  -144.382347 -205.708173  171.751230  4.747188  27.368883   \n",
-       "5 -113.143652   221.648526  115.687504 -206.853411  2.543852  14.795116   \n",
+       "4  210.455359  -144.382347 -205.708171  171.751230  4.747188  27.368883   \n",
+       "5 -113.143651   221.648526  115.687503 -206.853411  2.543852  14.795116   \n",
        "\n",
        "   i_from_ka   i_to_ka      i_ka  vm_from_pu  va_from_degree  vm_to_pu  \\\n",
        "0   0.242735  0.242735  0.242735    1.027632        3.001264  0.998243   \n",
@@ -988,13 +1010,21 @@
        "4   1.116302  1.116302  1.116302    1.000000        5.407436  1.050000   \n",
        "5   1.036633  1.036633  1.036633    1.050000        0.000000  1.000000   \n",
        "\n",
-       "   va_to_degree  loading_percent  r_ohm_per_km  temperature_degree_celsius  \n",
-       "0      3.212388        25.284924      0.060675                   27.096882  \n",
-       "1      0.000000        50.196674      0.061132                   29.032648  \n",
-       "2      5.407436        40.994956      0.060926                   28.159076  \n",
-       "3      2.174414        31.040639      0.060752                   27.425004  \n",
-       "4      0.000000       116.281463      0.064177                   41.937485  \n",
-       "5      2.174414       107.982627      0.063617                   39.564852  "
+       "   va_to_degree  loading_percent  r_ohm_per_km  r_theta_kelvin_per_mw  \\\n",
+       "0      3.212388        25.284924      0.060675              41.657558   \n",
+       "1      0.000000        50.196674      0.061132              17.225095   \n",
+       "2      5.407436        40.994956      0.060926              26.756068   \n",
+       "3      2.174414        31.040639      0.060752              61.219320   \n",
+       "4      0.000000       116.281463      0.064177              13.824373   \n",
+       "5      2.174414       107.982627      0.063617              22.370305   \n",
+       "\n",
+       "   temperature_degree_celsius  \n",
+       "0                   27.096882  \n",
+       "1                   29.032648  \n",
+       "2                   28.159076  \n",
+       "3                   27.425004  \n",
+       "4                   41.937483  \n",
+       "5                   39.564852  "
       ]
      },
      "execution_count": 15,


### PR DESCRIPTION
TDPF: renaming r_theta to r_theta_pu and r_theta_kelvin_per_mw clarifies the code and makes it easier to avoid an error

init T from T0 

include r_theta_kelvin_per_mw in net.res_line