### PR TITLE
Change order back to original state

### DIFF
--- a/pandapower/build_branch.py
+++ b/pandapower/build_branch.py
@@ -74,7 +74,7 @@ def _initialize_branch_lookup(net):
     start = 0
     end = 0
     net._pd2ppc_lookups["branch"] = {}
-    for element in ["line", "impedance", "trafo", "trafo3w", "xward"]:
+    for element in ["line", "trafo", "trafo3w", "impedance", "xward"]:
         if len(net[element]) > 0:
             if element == "trafo3w":
                 end = start + len(net[element]) * 3


### PR DESCRIPTION
The new branch lookup order is causing problems with the IEEOptTool converter. Change it back to its original state to avoid problems