### PR TITLE
new optional parameter additional_traces in simple_plotly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,16 @@ Change Log
 - [ADDED] plotting function for dclines (create_dcline_collection), also added in simple_plot
 - [ADDED] calculation of overhead line temperature in Newton-Raphson with two simplified methods (Frank et al. and Ngoko et al.)
 - [ADDED] group functionality
-- [FIXED] Bug with user_pf_options: _init_runpp_options in auxiliary.py ignored user_pf_options when performing sanity checks
 - [ADDED] File I/O: Can now save and load pandapower serializable objects to Excel, PostgreSQL
+- [ADDED] zero-sequence parameters for net.impedance
+- [ADDED] additional_traces (prepared by the user) can be passed to simple_plotly
+
 - [CHANGED] TDPF: rename r_theta to r_theta_kelvin_per_mw, add r_theta_kelvin_per_mw to net.res_line
 - [CHANGED] Compatibility with pandas 1.5, dropped "six" dependency
 - [CHANGED] from_ppc(): revision of indexing and naming of elements
 - [CHANGED] Complete revision of validate_from_ppc()
-- [ADDED] zero-sequence parameters for net.impedance
+
+- [FIXED] Bug with user_pf_options: _init_runpp_options in auxiliary.py ignored user_pf_options when performing sanity checks
 
 [2.10.1] - 2022-07-31
 -------------------------------

--- a/pandapower/plotting/plotly/simple_plotly.py
+++ b/pandapower/plotting/plotly/simple_plotly.py
@@ -74,15 +74,15 @@ def get_hoverinfo(net, element, precision=3, sub_index=None):
 def simple_plotly(net, respect_switches=True, use_line_geodata=None, on_map=False,
                   projection=None, map_style='basic', figsize=1, aspectratio='auto', line_width=1,
                   bus_size=10, ext_grid_size=20.0, bus_color="blue", line_color='grey',
-                  trafo_color='green',trafo3w_color='green', ext_grid_color="yellow",
-                  filename='temp-plot.html', auto_open=True, showlegend=True):
+                  trafo_color='green', trafo3w_color='green', ext_grid_color="yellow",
+                  filename='temp-plot.html', auto_open=True, showlegend=True,
+                  additional_traces=None):
     """
     Plots a pandapower network as simple as possible in plotly.
     If no geodata is available, artificial geodata is generated. For advanced plotting see the tutorial
 
     INPUT:
-        **net** - The pandapower format network. If none is provided, mv_oberrhein() will be
-            plotted as an example
+        **net** (pandapowerNet) - The pandapower format network.
 
     OPTIONAL:
         **respect_switches** (bool, True) - Respect switches when artificial geodata is created
@@ -132,6 +132,9 @@ def simple_plotly(net, respect_switches=True, use_line_geodata=None, on_map=Fals
 
         **showlegend** (bool, True) - If True, a legend will be shown
 
+        **additional_traces** (list, None) - List with additional, user-created traces that will
+            be appended to the simple_plotly traces before drawing all traces
+
     OUTPUT:
         **figure** (graph_objs._figure.Figure) figure object
     """
@@ -167,13 +170,17 @@ def simple_plotly(net, respect_switches=True, use_line_geodata=None, on_map=Fals
                                               filename=filename,
                                               auto_open=auto_open,
                                               showlegend=showlegend)
+    if additional_traces:
+        traces.extend(additional_traces)
 
     return draw_traces(traces, **settings)
 
+
 def _simple_plotly_generic(net, respect_separators, use_branch_geodata, on_map, projection, map_style,
                            figsize, aspectratio, branch_width, node_size, ext_grid_size, node_color,
-                           branch_color, trafo_color,trafo3w_color, ext_grid_color, node_element, branch_element,
-                           trans_element, trans3w_element, separator_element, branch_trace_func, node_trace_func,
+                           branch_color, trafo_color, trafo3w_color, ext_grid_color,
+                           node_element, branch_element, trans_element, trans3w_element,
+                           separator_element, branch_trace_func, node_trace_func,
                            hoverinfo_func, filename='temp-plot.html', auto_open=True,
                            showlegend=True):
     version_check()


### PR DESCRIPTION
Users can pass self-defined traces (e.g. bubbles for generation) that will be plotted on top of the simple plotly plot