### PR TITLE
Feature/plotly extra traces

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,13 +6,16 @@ Change Log
 - [ADDED] plotting function for dclines (create_dcline_collection), also added in simple_plot
 - [ADDED] calculation of overhead line temperature in Newton-Raphson with two simplified methods (Frank et al. and Ngoko et al.)
 - [ADDED] group functionality
-- [FIXED] Bug with user_pf_options: _init_runpp_options in auxiliary.py ignored user_pf_options when performing sanity checks
 - [ADDED] File I/O: Can now save and load pandapower serializable objects to Excel, PostgreSQL
+- [ADDED] zero-sequence parameters for net.impedance
+- [ADDED] additional_traces (prepared by the user) can be passed to simple_plotly
+
 - [CHANGED] TDPF: rename r_theta to r_theta_kelvin_per_mw, add r_theta_kelvin_per_mw to net.res_line
 - [CHANGED] Compatibility with pandas 1.5, dropped "six" dependency
 - [CHANGED] from_ppc(): revision of indexing and naming of elements
 - [CHANGED] Complete revision of validate_from_ppc()
-- [ADDED] zero-sequence parameters for net.impedance
+
+- [FIXED] Bug with user_pf_options: _init_runpp_options in auxiliary.py ignored user_pf_options when performing sanity checks
 
 [2.10.1] - 2022-07-31
 -------------------------------

--- a/doc/plotting/plotly/built-in_plots.rst
+++ b/doc/plotting/plotly/built-in_plots.rst
@@ -8,7 +8,7 @@ In order to get idea about interactive plot features and possibilities see the `
 Simple Plotting
 =============================
 
-The function simple_plotly() can be used for a simple interactive plotting.
+The function :func:`simple_plotly()` can be used for a simple interactive plotting.
 
 .. _simple_plotly:
 
@@ -48,7 +48,7 @@ Example simple plot on a map::
 Network coloring according to voltage levels
 ===============================================
 
-The function vlevel_plotly() is used to plot a network colored and labeled according to voltage levels.
+The function :func:`vlevel_plotly()` is used to plot a network colored and labeled according to voltage levels.
 
 .. _vlevel_plotly:
 
@@ -70,7 +70,7 @@ Example plot with mv_oberrhein network from the pandapower.networks package::
 Power Flow results
 =============================
 
-The function pf_res_plotly() is used to plot a network according to power flow results where a colormap is used to represent line loading and voltage magnitudes. For advanced possibilities see the tutorials.
+The function :func:`pf_res_plotly()` is used to plot a network according to power flow results where a colormap is used to represent line loading and voltage magnitudes. For advanced possibilities see the tutorials.
 
 .. _pf_res_plotly:
 

--- a/doc/plotting/plotly/create_traces.rst
+++ b/doc/plotting/plotly/create_traces.rst
@@ -4,7 +4,7 @@ Create & Draw Traces
 
 
 Plotly traces can be created from pandapower networks with the following functions.
-The traces can be passed as `additional_traces` (list) to the `simple_plotly` function.
+The traces can be passed as :code:`additional_traces` (list) to the :func:`simple_plotly` function.
 
 ++++++++++
 Bus Traces
@@ -33,7 +33,7 @@ Draw Traces
 Markers with weighted size
 ++++++++++++++++++++++++++
 
-The function `create_weighted_marker_trace` can be used to create additional traces with markers
+The function :func:`create_weighted_marker_trace()` can be used to create additional traces with markers
 (patches) for one column in one component table.
 
 .. autofunction:: pandapower.plotting.plotly.traces.create_weighted_marker_trace

--- a/doc/plotting/plotly/create_traces.rst
+++ b/doc/plotting/plotly/create_traces.rst
@@ -4,27 +4,46 @@ Create & Draw Traces
 
 
 Plotly traces can be created from pandapower networks with the following functions.
+The traces can be passed as `additional_traces` (list) to the `simple_plotly` function.
 
 ++++++++++
 Bus Traces
 ++++++++++
 
-.. autofunction:: pandapower.plotting.plotly.create_bus_trace
+.. autofunction:: pandapower.plotting.plotly.traces.create_bus_trace
 
 
 +++++++++++++
 Branch Traces
 +++++++++++++
 
-.. autofunction:: pandapower.plotting.plotly.create_line_trace
+.. autofunction:: pandapower.plotting.plotly.traces.create_line_trace
 
-.. autofunction:: pandapower.plotting.plotly.create_trafo_trace
+.. autofunction:: pandapower.plotting.plotly.traces.create_trafo_trace
 
 
 +++++++++++
 Draw Traces
 +++++++++++
 
-.. autofunction:: pandapower.plotting.plotly.draw_traces
+.. autofunction:: pandapower.plotting.plotly.traces.draw_traces
 
 
+++++++++++++++++++++++++++
+Markers with weighted size
+++++++++++++++++++++++++++
+
+The function `create_weighted_marker_trace` can be used to create additional traces with markers
+(patches) for one column in one component table.
+
+.. autofunction:: pandapower.plotting.plotly.traces.create_weighted_marker_trace
+
+Example with load and sgen bubbles::
+
+    net = mv_oberrhein()
+    net.load.scaling, net.sgen.scaling = 1, 1
+    markers_load = create_weighted_marker_trace(net, elm_type="load", color="red",
+                                                marker_scaling=100)
+    markers_sgen = create_weighted_marker_trace(net, elm_type="sgen", color="green",
+                                                marker_scaling=100)
+    simple_plotly(net, bus_size=1, additional_traces=[markers_load, markers_sgen])

--- a/pandapower/plotting/plotly/pf_res_plotly.py
+++ b/pandapower/plotting/plotly/pf_res_plotly.py
@@ -38,13 +38,13 @@ def pf_res_plotly(net, cmap="Jet", use_line_geodata=None, on_map=False, projecti
             **cmap** (str, True) - name of the colormap
 
             **colors_dict** (dict, None) - by default 6 basic colors from default collor palette is used.
-                                                Otherwise, user can define a dictionary in the form: voltage_kv : color
+            Otherwise, user can define a dictionary in the form: voltage_kv : color
 
             **on_map** (bool, False) - enables using mapbox plot in plotly. If provided geodata are not
-                                                    real geo-coordinates in lon/lat form, on_map will be set to False.
+            real geo-coordinates in lon/lat form, on_map will be set to False.
 
             **projection** (String, None) - defines a projection from which network geo-data will be transformed to
-                                            lat-long. For each projection a string can be found at http://spatialreference.org/ref/epsg/
+            lat-long. For each projection a string can be found at http://spatialreference.org/ref/epsg/
 
             **map_style** (str, 'basic') - enables using mapbox plot in plotly
 
@@ -57,7 +57,7 @@ def pf_res_plotly(net, cmap="Jet", use_line_geodata=None, on_map=False, projecti
             **figsize** (float, 1) - aspectratio is multiplied by it in order to get final image size
 
             **aspectratio** (tuple, 'auto') - when 'auto' it preserves original aspect ratio of the network geodata
-                                                    any custom aspectration can be given as a tuple, e.g. (1.2, 1)
+            any custom aspectration can be given as a tuple, e.g. (1.2, 1)
 
             **line_width** (float, 1.0) - width of lines
 

--- a/pandapower/plotting/plotly/simple_plotly.py
+++ b/pandapower/plotting/plotly/simple_plotly.py
@@ -264,8 +264,11 @@ if __name__ == '__main__':
     # fig = simple_plotly(net, trafo3w_color='k')
     net = mv_oberrhein()
     net.load.scaling, net.sgen.scaling = 1, 1
+    # different markers and sizemodes as examples
     markers_load = create_weighted_marker_trace(net, elm_type="load", color="red",
+                                                patch_type="triangle-up", sizemode="area",
                                                 marker_scaling=100)
     markers_sgen = create_weighted_marker_trace(net, elm_type="sgen", color="green",
+                                                patch_type="circle-open", sizemode="diameter",
                                                 marker_scaling=100)
     simple_plotly(net, bus_size=1, additional_traces=[markers_load, markers_sgen])

--- a/pandapower/plotting/plotly/simple_plotly.py
+++ b/pandapower/plotting/plotly/simple_plotly.py
@@ -87,15 +87,14 @@ def simple_plotly(net, respect_switches=True, use_line_geodata=None, on_map=Fals
     OPTIONAL:
         **respect_switches** (bool, True) - Respect switches when artificial geodata is created
 
-        *use_line_geodata** (bool, True) - defines if lines patches are based on net.line_geodata of the lines (True)
-        or on net.bus_geodata of the connected buses (False)
+        **use_line_geodata** (bool, True) - defines if lines patches are based on
+        net.line_geodata of the lines (True) or on net.bus_geodata of the connected buses (False)
 
         **on_map** (bool, False) - enables using mapbox plot in plotly.
         If provided geodata are not real geo-coordinates in lon/lat form, on_map will be set to False.
 
         **projection** (String, None) - defines a projection from which network geo-data will be transformed to
         lat-long. For each projection a string can be found at http://spatialreference.org/ref/epsg/
-
 
         **map_style** (str, 'basic') - enables using mapbox plot in plotly
 

--- a/pandapower/plotting/plotly/simple_plotly.py
+++ b/pandapower/plotting/plotly/simple_plotly.py
@@ -171,7 +171,10 @@ def simple_plotly(net, respect_switches=True, use_line_geodata=None, on_map=Fals
                                               auto_open=auto_open,
                                               showlegend=showlegend)
     if additional_traces:
-        traces.extend(additional_traces)
+        if isinstance(additional_traces, dict):
+            traces.append(additional_traces)
+        else:
+            traces.extend(additional_traces)
 
     return draw_traces(traces, **settings)
 
@@ -255,7 +258,15 @@ def _simple_plotly_generic(net, respect_separators, use_branch_geodata, on_map, 
 
 if __name__ == '__main__':
     from pandapower import networks as nw
-    # net = nw.mv_oberrhein()
+    from pandapower.plotting.plotly.traces import create_weighted_marker_trace
     # simple_plotly(net)
-    net = nw.example_multivoltage()
-    fig = simple_plotly(net, trafo3w_color='k')
+    # net = nw.example_multivoltage()
+    # fig = simple_plotly(net, trafo3w_color='k')
+    net = nw.mv_oberrhein()
+    net.load.scaling = 1
+    net.sgen.scaling = 1
+    marker_trace_load = create_weighted_marker_trace(net, elm_type="load", column_to_plot="p_mw",
+                                                     color="red", marker_scaling=75)
+    marker_trace_sgen = create_weighted_marker_trace(net, elm_type="sgen", column_to_plot="p_mw",
+                                                     color="green", marker_scaling=75)
+    simple_plotly(net, bus_size=1, additional_traces=[marker_trace_load, marker_trace_sgen])

--- a/pandapower/plotting/plotly/simple_plotly.py
+++ b/pandapower/plotting/plotly/simple_plotly.py
@@ -88,13 +88,13 @@ def simple_plotly(net, respect_switches=True, use_line_geodata=None, on_map=Fals
         **respect_switches** (bool, True) - Respect switches when artificial geodata is created
 
         *use_line_geodata** (bool, True) - defines if lines patches are based on net.line_geodata of the lines (True)
-            or on net.bus_geodata of the connected buses (False)
+        or on net.bus_geodata of the connected buses (False)
 
         **on_map** (bool, False) - enables using mapbox plot in plotly.
-            If provided geodata are not real geo-coordinates in lon/lat form, on_map will be set to False.
+        If provided geodata are not real geo-coordinates in lon/lat form, on_map will be set to False.
 
         **projection** (String, None) - defines a projection from which network geo-data will be transformed to
-            lat-long. For each projection a string can be found at http://spatialreference.org/ref/epsg/
+        lat-long. For each projection a string can be found at http://spatialreference.org/ref/epsg/
 
 
         **map_style** (str, 'basic') - enables using mapbox plot in plotly
@@ -108,7 +108,7 @@ def simple_plotly(net, respect_switches=True, use_line_geodata=None, on_map=Fals
         **figsize** (float, 1) - aspectratio is multiplied by it in order to get final image size
 
         **aspectratio** (tuple, 'auto') - when 'auto' it preserves original aspect ratio of the network geodata;
-            any custom aspectration can be given as a tuple, e.g. (1.2, 1)
+        any custom aspectration can be given as a tuple, e.g. (1.2, 1)
 
         **line_width** (float, 1.0) - width of lines
 
@@ -133,7 +133,7 @@ def simple_plotly(net, respect_switches=True, use_line_geodata=None, on_map=Fals
         **showlegend** (bool, True) - If True, a legend will be shown
 
         **additional_traces** (list, None) - List with additional, user-created traces that will
-            be appended to the simple_plotly traces before drawing all traces
+        be appended to the simple_plotly traces before drawing all traces
 
     OUTPUT:
         **figure** (graph_objs._figure.Figure) figure object
@@ -258,15 +258,15 @@ def _simple_plotly_generic(net, respect_separators, use_branch_geodata, on_map, 
 
 if __name__ == '__main__':
     from pandapower import networks as nw
+    from pandapower.networks import mv_oberrhein
     from pandapower.plotting.plotly.traces import create_weighted_marker_trace
     # simple_plotly(net)
     # net = nw.example_multivoltage()
     # fig = simple_plotly(net, trafo3w_color='k')
-    net = nw.mv_oberrhein()
-    net.load.scaling = 1
-    net.sgen.scaling = 1
-    marker_trace_load = create_weighted_marker_trace(net, elm_type="load", column_to_plot="p_mw",
-                                                     color="red", marker_scaling=75)
-    marker_trace_sgen = create_weighted_marker_trace(net, elm_type="sgen", column_to_plot="p_mw",
-                                                     color="green", marker_scaling=75)
-    simple_plotly(net, bus_size=1, additional_traces=[marker_trace_load, marker_trace_sgen])
+    net = mv_oberrhein()
+    net.load.scaling, net.sgen.scaling = 1, 1
+    markers_load = create_weighted_marker_trace(net, elm_type="load", color="red",
+                                                marker_scaling=100)
+    markers_sgen = create_weighted_marker_trace(net, elm_type="sgen", color="green",
+                                                marker_scaling=100)
+    simple_plotly(net, bus_size=1, additional_traces=[markers_load, markers_sgen])

--- a/pandapower/plotting/plotly/simple_plotly.py
+++ b/pandapower/plotting/plotly/simple_plotly.py
@@ -74,15 +74,15 @@ def get_hoverinfo(net, element, precision=3, sub_index=None):
 def simple_plotly(net, respect_switches=True, use_line_geodata=None, on_map=False,
                   projection=None, map_style='basic', figsize=1, aspectratio='auto', line_width=1,
                   bus_size=10, ext_grid_size=20.0, bus_color="blue", line_color='grey',
-                  trafo_color='green',trafo3w_color='green', ext_grid_color="yellow",
-                  filename='temp-plot.html', auto_open=True, showlegend=True):
+                  trafo_color='green', trafo3w_color='green', ext_grid_color="yellow",
+                  filename='temp-plot.html', auto_open=True, showlegend=True,
+                  additional_traces=None):
     """
     Plots a pandapower network as simple as possible in plotly.
     If no geodata is available, artificial geodata is generated. For advanced plotting see the tutorial
 
     INPUT:
-        **net** - The pandapower format network. If none is provided, mv_oberrhein() will be
-            plotted as an example
+        **net** (pandapowerNet) - The pandapower format network.
 
     OPTIONAL:
         **respect_switches** (bool, True) - Respect switches when artificial geodata is created
@@ -132,6 +132,9 @@ def simple_plotly(net, respect_switches=True, use_line_geodata=None, on_map=Fals
 
         **showlegend** (bool, True) - If True, a legend will be shown
 
+        **additional_traces** (list, None) - List with additional, user-created traces that will
+            be appended to the simple_plotly traces before drawing all traces
+
     OUTPUT:
         **figure** (graph_objs._figure.Figure) figure object
     """
@@ -167,13 +170,17 @@ def simple_plotly(net, respect_switches=True, use_line_geodata=None, on_map=Fals
                                               filename=filename,
                                               auto_open=auto_open,
                                               showlegend=showlegend)
+    if additional_traces:
+        traces.extend(additional_traces)
 
     return draw_traces(traces, **settings)
 
+
 def _simple_plotly_generic(net, respect_separators, use_branch_geodata, on_map, projection, map_style,
                            figsize, aspectratio, branch_width, node_size, ext_grid_size, node_color,
-                           branch_color, trafo_color,trafo3w_color, ext_grid_color, node_element, branch_element,
-                           trans_element, trans3w_element, separator_element, branch_trace_func, node_trace_func,
+                           branch_color, trafo_color, trafo3w_color, ext_grid_color,
+                           node_element, branch_element, trans_element, trans3w_element,
+                           separator_element, branch_trace_func, node_trace_func,
                            hoverinfo_func, filename='temp-plot.html', auto_open=True,
                            showlegend=True):
     version_check()

--- a/pandapower/plotting/plotly/traces.py
+++ b/pandapower/plotting/plotly/traces.py
@@ -785,150 +785,6 @@ def create_trafo_trace(net, trafos=None, color='green', trafotype='2W', width=5,
     return trafo_traces
 
 
-def draw_traces(traces, on_map=False, map_style='basic', showlegend=True, figsize=1,
-                aspectratio='auto', filename='temp-plot.html', auto_open=True, **kwargs):
-    """
-    plots all the traces (which can be created using :func:`create_bus_trace`, :func:`create_line_trace`,
-    :func:`create_trafo_trace`)
-    to PLOTLY (see https://plot.ly/python/)
-
-    INPUT:
-        **traces** - list of dicts which correspond to plotly traces
-        generated using: `create_bus_trace`, `create_line_trace`, `create_trafo_trace`
-
-    OPTIONAL:
-        **on_map** (bool, False) - enables using mapbox plot in plotly
-
-        **map_style** (str, 'basic') - enables using mapbox plot in plotly
-
-            - 'streets'
-            - 'bright'
-            - 'light'
-            - 'dark'
-            - 'satellite'
-
-        **showlegend** (bool, 'True') - enables legend display
-
-        **figsize** (float, 1) - aspectratio is multiplied by it in order to get final image size
-
-        **aspectratio** (tuple, 'auto') - when 'auto' it preserves original aspect ratio of the
-        network geodata any custom aspectration can be given as a tuple, e.g. (1.2, 1)
-
-        **filename** (str, "temp-plot.html") - plots to a html file called filename
-
-        **auto_open** (bool, 'True') - automatically open plot in browser
-
-    OUTPUT:
-        **figure** (graph_objs._figure.Figure) figure object
-
-    """
-    if on_map:
-        try:
-            on_map = _on_map_test(traces[0]['x'][0], traces[0]['y'][0])
-        except:
-            logger.warning("Test if geo-data are in lat/long cannot be performed using geopy -> "
-                           "eventual plot errors are possible.")
-
-        if on_map is False:
-            logger.warning("Existing geodata are not real lat/lon geographical coordinates. -> "
-                           "plot on maps is not possible.\n"
-                           "Use geo_data_to_latlong(net, projection) to transform geodata from specific projection.")
-
-    if on_map:
-        # change traces for mapbox
-        # change trace_type to scattermapbox and rename x to lat and y to lon
-        for trace in traces:
-            trace['lat'] = trace.pop('y')
-            trace['lon'] = trace.pop('x')
-            trace['type'] = 'scattermapbox'
-            if "line" in trace and isinstance(trace["line"], Line):
-                # scattermapboxplot lines do not support dash for some reason, make it a red line instead
-                if "dash" in trace["line"]._props:
-                    _prps = dict(trace["line"]._props)
-                    _prps.pop("dash", None)
-                    _prps["color"] = "red"
-                    trace["line"] = scmLine(_prps)
-                else:
-                    trace["line"] = scmLine(dict(trace["line"]._props))
-            elif "marker" in trace and isinstance(trace["marker"], Marker):
-                trace["marker"] = scmMarker(trace["marker"]._props)
-
-    # setting Figure object
-    fig = Figure(data=traces,  # edge_trace
-                 layout=Layout(
-                     titlefont=dict(size=16),
-                     showlegend=showlegend,
-                     autosize=(aspectratio == 'auto'),
-                     hovermode='closest',
-                     margin=dict(b=5, l=5, r=5, t=5),
-                     # annotations=[dict(
-                     #     text="",
-                     #     showarrow=False,
-                     #     xref="paper", yref="paper",
-                     #     x=0.005, y=-0.002)],
-                     xaxis=XAxis(showgrid=False, zeroline=False, showticklabels=False),
-                     yaxis=YAxis(showgrid=False, zeroline=False, showticklabels=False),
-                     # legend=dict(x=0, y=1.0)
-                     ),
-                )
-    a = kwargs.get('annotation')
-    if a:
-        fig.add_annotation(a)
-
-    # check if geodata are real geographical lat/lon coordinates using geopy
-    if on_map:
-        try:
-            mapbox_access_token = _get_mapbox_token()
-        except Exception:
-            logger.exception('mapbox token required for map plots. '
-                             'Get Mapbox token by signing in to https://www.mapbox.com/.\n'
-                             'After getting a token, set it to pandapower using:\n'
-                             'pandapower.plotting.plotly.mapbox_plot.set_mapbox_token(\'<token>\')')
-            raise MapboxTokenMissing
-
-        fig['layout']['mapbox'] = dict(accesstoken=mapbox_access_token,
-                                       bearing=0,
-                                       center=dict(lat=pd.Series(traces[0]['lat']).dropna().mean(),
-                                                   lon=pd.Series(traces[0]['lon']).dropna().mean()),
-                                       style=map_style,
-                                       pitch=0,
-                                       zoom=11)
-
-    # default aspectratio: if on_map use auto, else use 'original'
-    aspectratio = 'original' if not on_map and aspectratio == 'auto' else aspectratio
-
-    if aspectratio != 'auto':
-        if aspectratio == 'original':
-            # TODO improve this workaround for getting original aspectratio
-            xs = []
-            ys = []
-            for trace in traces:
-                xs += trace['x']
-                ys += trace['y']
-            x_dropna = pd.Series(xs).dropna()
-            y_dropna = pd.Series(ys).dropna()
-            xrange = x_dropna.max() - x_dropna.min()
-            yrange = y_dropna.max() - y_dropna.min()
-            ratio = xrange / yrange
-            if ratio < 1:
-                aspectratio = (ratio, 1.)
-            else:
-                aspectratio = (1., 1 / ratio)
-
-        aspectratio = np.array(aspectratio) / max(aspectratio)
-        fig['layout']['width'], fig['layout']['height'] = ([ar * figsize * 700 for ar in aspectratio])
-
-    # check if called from ipynb or not in order to consider appropriate plot function
-    if _in_ipynb():
-        from plotly.offline import init_notebook_mode, iplot as plot
-        init_notebook_mode()
-        plot(fig, filename=filename)
-    else:
-        from plotly.offline import plot as plot
-        plot(fig, filename=filename, auto_open=auto_open)
-
-    return fig
-
 def create_weighted_marker_trace(net, elm_type="load", elm_ids=None, column_to_plot="p_mw",
                                  sizemode="area", color="red", patch_type="circle",
                                  marker_scaling=1., trace_name="", infofunc=None,
@@ -1027,3 +883,150 @@ def create_weighted_marker_trace(net, elm_type="load", elm_ids=None, column_to_p
                                   symbol=patch_type, sizemode=sizemode)
 
     return marker_trace
+
+
+def draw_traces(traces, on_map=False, map_style='basic', showlegend=True, figsize=1,
+                aspectratio='auto', filename='temp-plot.html', auto_open=True, **kwargs):
+    """
+    plots all the traces (which can be created using :func:`create_bus_trace`, :func:`create_line_trace`,
+    :func:`create_trafo_trace`)
+    to PLOTLY (see https://plot.ly/python/)
+
+    INPUT:
+        **traces** - list of dicts which correspond to plotly traces
+        generated using: `create_bus_trace`, `create_line_trace`, `create_trafo_trace`
+
+    OPTIONAL:
+        **on_map** (bool, False) - enables using mapbox plot in plotly
+
+        **map_style** (str, 'basic') - enables using mapbox plot in plotly
+
+            - 'streets'
+            - 'bright'
+            - 'light'
+            - 'dark'
+            - 'satellite'
+
+        **showlegend** (bool, 'True') - enables legend display
+
+        **figsize** (float, 1) - aspectratio is multiplied by it in order to get final image size
+
+        **aspectratio** (tuple, 'auto') - when 'auto' it preserves original aspect ratio of the
+        network geodata any custom aspectration can be given as a tuple, e.g. (1.2, 1)
+
+        **filename** (str, "temp-plot.html") - plots to a html file called filename
+
+        **auto_open** (bool, 'True') - automatically open plot in browser
+
+    OUTPUT:
+        **figure** (graph_objs._figure.Figure) figure object
+
+    """
+    if on_map:
+        try:
+            on_map = _on_map_test(traces[0]['x'][0], traces[0]['y'][0])
+        except:
+            logger.warning("Test if geo-data are in lat/long cannot be performed using geopy -> "
+                           "eventual plot errors are possible.")
+
+        if on_map is False:
+            logger.warning("Existing geodata are not real lat/lon geographical coordinates. -> "
+                           "plot on maps is not possible.\n"
+                           "Use geo_data_to_latlong(net, projection) to transform geodata from specific projection.")
+
+    if on_map:
+        # change traces for mapbox
+        # change trace_type to scattermapbox and rename x to lat and y to lon
+        for trace in traces:
+            if 'x' in trace.keys():
+                trace['lon'] = trace.pop('x')
+            if 'y' in trace.keys():
+                trace['lat'] = trace.pop('y')
+            trace['type'] = 'scattermapbox'
+            if "line" in trace and isinstance(trace["line"], Line):
+                # scattermapboxplot lines do not support dash for some reason, make it a red line instead
+                if "dash" in trace["line"]._props:
+                    _prps = dict(trace["line"]._props)
+                    _prps.pop("dash", None)
+                    _prps["color"] = "red"
+                    trace["line"] = scmLine(_prps)
+                else:
+                    trace["line"] = scmLine(dict(trace["line"]._props))
+            elif "marker" in trace and isinstance(trace["marker"], Marker):
+                trace["marker"] = scmMarker(trace["marker"]._props)
+
+    # setting Figure object
+    fig = Figure(data=traces,  # edge_trace
+                 layout=Layout(
+                     titlefont=dict(size=16),
+                     showlegend=showlegend,
+                     autosize=(aspectratio == 'auto'),
+                     hovermode='closest',
+                     margin=dict(b=5, l=5, r=5, t=5),
+                     # annotations=[dict(
+                     #     text="",
+                     #     showarrow=False,
+                     #     xref="paper", yref="paper",
+                     #     x=0.005, y=-0.002)],
+                     xaxis=XAxis(showgrid=False, zeroline=False, showticklabels=False),
+                     yaxis=YAxis(showgrid=False, zeroline=False, showticklabels=False),
+                     # legend=dict(x=0, y=1.0)
+                     ),
+                )
+    a = kwargs.get('annotation')
+    if a:
+        fig.add_annotation(a)
+
+    # check if geodata are real geographical lat/lon coordinates using geopy
+    if on_map:
+        try:
+            mapbox_access_token = _get_mapbox_token()
+        except Exception:
+            logger.exception('mapbox token required for map plots. '
+                             'Get Mapbox token by signing in to https://www.mapbox.com/.\n'
+                             'After getting a token, set it to pandapower using:\n'
+                             'pandapower.plotting.plotly.mapbox_plot.set_mapbox_token(\'<token>\')')
+            raise MapboxTokenMissing
+
+        fig['layout']['mapbox'] = dict(accesstoken=mapbox_access_token,
+                                       bearing=0,
+                                       center=dict(lat=pd.Series(traces[0]['lat']).dropna().mean(),
+                                                   lon=pd.Series(traces[0]['lon']).dropna().mean()),
+                                       style=map_style,
+                                       pitch=0,
+                                       zoom=kwargs.pop('zoomlevel', 11))
+
+    # default aspectratio: if on_map use auto, else use 'original'
+    aspectratio = 'original' if not on_map and aspectratio == 'auto' else aspectratio
+
+    if aspectratio != 'auto':
+        if aspectratio == 'original':
+            # TODO improve this workaround for getting original aspectratio
+            xs = []
+            ys = []
+            for trace in traces:
+                xs += trace.get('x') or trace['lon']
+                ys += trace.get('y') or trace['lat']
+            x_dropna = pd.Series(xs).dropna()
+            y_dropna = pd.Series(ys).dropna()
+            xrange = x_dropna.max() - x_dropna.min()
+            yrange = y_dropna.max() - y_dropna.min()
+            ratio = xrange / yrange
+            if ratio < 1:
+                aspectratio = (ratio, 1.)
+            else:
+                aspectratio = (1., 1 / ratio)
+
+        aspectratio = np.array(aspectratio) / max(aspectratio)
+        fig['layout']['width'], fig['layout']['height'] = ([ar * figsize * 700 for ar in aspectratio])
+
+    # check if called from ipynb or not in order to consider appropriate plot function
+    if _in_ipynb():
+        from plotly.offline import init_notebook_mode, iplot as plot
+        init_notebook_mode()
+        plot(fig, filename=filename)
+    else:
+        from plotly.offline import plot as plot
+        plot(fig, filename=filename, auto_open=auto_open)
+
+    return fig

--- a/pandapower/plotting/plotly/traces.py
+++ b/pandapower/plotting/plotly/traces.py
@@ -97,10 +97,10 @@ def create_edge_center_trace(line_trace, size=1, patch_type="circle", color="whi
                 - "circle" for a circle
                 - "square" for a rectangle
                 - "diamond" for a diamond
-                - much more pathc types at https://plot.ly/python/reference/#scatter-marker
+                - much more patch types at https://plot.ly/python/reference/#scatter-marker
 
         **infofunc** (pd.Series, None) - hoverinfo for each trace element. Indices should correspond
-            to the pandapower element indices
+        to the pandapower element indices
 
         **trace_name** (String, "buses") - name of the trace which will appear in the legend
 
@@ -153,19 +153,19 @@ def create_bus_trace(net, buses=None, size=5, patch_type="circle", color="blue",
                 - "circle" for a circle
                 - "square" for a rectangle
                 - "diamond" for a diamond
-                - much more pathc types at https://plot.ly/python/reference/#scatter-marker
+                - much more patch types at https://plot.ly/python/reference/#scatter-marker
 
         **infofunc** (pd.Series, None) - hoverinfo for bus elements. Indices should correspond to
-            the pandapower element indices
+        the pandapower element indices
 
         **trace_name** (String, "buses") - name of the trace which will appear in the legend
 
         **color** (String, "blue") - color of buses in the trace
 
         **cmap** (String, None) - name of a colormap which exists within plotly
-            (Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow,
-            Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis) alternatively a custom
-            discrete colormap can be used
+        (Greys, YlGnBu, Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow,
+        Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis) alternatively a custom
+        discrete colormap can be used. Append "_r" for inversion.
 
         **cmap_vals** (list, None) - values used for coloring using colormap
 
@@ -224,7 +224,7 @@ def _create_node_trace(net, nodes=None, size=5, patch_type='circle', color='blue
                 - "circle" for a circle
                 - "square" for a rectangle
                 - "diamond" for a diamond
-                - much more pathc types at https://plot.ly/python/reference/#scatter-marker
+                - much more patch types at https://plot.ly/python/reference/#scatter-marker
 
         **infofunc** (pd.Series, None) - hoverinfo for node elements. Indices should correspond to
                                          the node element indices
@@ -373,7 +373,7 @@ def create_line_trace(net, lines=None, use_line_geodata=True, respect_switches=F
 
 
         **infofunc** (pd.Series, None) - hoverinfo for line elements. Indices should correspond to
-            the pandapower element indices
+        the pandapower element indices
 
         **trace_name** (String, "lines") - name of the trace which will appear in the legend
 
@@ -385,6 +385,7 @@ def create_line_trace(net, lines=None, use_line_geodata=True, respect_switches=F
         **cmap** (String, None) - name of a colormap which exists within plotly if set to True default `Jet`
         colormap is used, alternative colormaps : Greys, YlGnBu, Greens, YlOrRd,
         Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot, Blackbody, Earth, Electric, Viridis
+        To revert the color map, append "_r" to the name.
 
         **cmap_vals** (list, None) - values used for coloring using colormap
 
@@ -438,7 +439,7 @@ def _create_branch_trace(net, branches=None, use_branch_geodata=True, respect_se
     were introduced to make it usable in other packages, e.g. for pipe networks.
 
    INPUT:
-       **net** (pandapowerNet) - The  network
+       **net** (pandapowerNet) - The network
 
    OPTIONAL:
        **branches** (list, None) - The branches for which the collections are created.
@@ -684,15 +685,15 @@ def create_trafo_trace(net, trafos=None, color='green', trafotype='2W', width=5,
         **width** (int, 5) - line width
 
         **infofunc** (pd.Series, None) - hoverinfo for trafo elements. Indices should correspond
-            to the pandapower element indices
+        to the pandapower element indices
 
         **trace_name** (String, "lines") - name of the trace which will appear in the legend
 
         **color** (String, "green") - color of lines in the trace
 
         **cmap** (bool, False) - name of a colormap which exists within plotly (Greys, YlGnBu,
-            Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot,
-            Blackbody, Earth, Electric, Viridis)
+        Greens, YlOrRd, Bluered, RdBu, Reds, Blues, Picnic, Rainbow, Portland, Jet, Hot,
+        Blackbody, Earth, Electric, Viridis)
 
         **cmap_vals** (list, None) - values used for coloring using colormap
 
@@ -811,7 +812,7 @@ def draw_traces(traces, on_map=False, map_style='basic', showlegend=True, figsiz
         **figsize** (float, 1) - aspectratio is multiplied by it in order to get final image size
 
         **aspectratio** (tuple, 'auto') - when 'auto' it preserves original aspect ratio of the
-            network geodata any custom aspectration can be given as a tuple, e.g. (1.2, 1)
+        network geodata any custom aspectration can be given as a tuple, e.g. (1.2, 1)
 
         **filename** (str, "temp-plot.html") - plots to a html file called filename
 
@@ -941,40 +942,40 @@ def create_weighted_marker_trace(net, elm_type="load", elm_ids=None, column_to_p
     mixed in one column! All values are treated as absolute values.
     If value = 0, no marker will be created.
 
-    Parameters
-    ----------
-    **net** (pandapipesNet): the pandapipes net of the plot
+    INPUT:
+        **net** (pandapipesNet) - the pandapipes net of the plot
 
-    **elm_type** (str, default "load"): the element table in the net that holds the values to plot
+    OPTIONAL:
+        **elm_type** (str, default "load") - the element table in the net that holds the values
+        to plot
 
-    **elm_ids** (list, default None): the element IDs of the elm_type table for which markers
+        **elm_ids** (list, default None) - the element IDs of the elm_type table for which markers
         will be created. If None, all IDs in net[elm_type] that are not 0 or NaN in the
         `column_to_plot` will be used.
 
-    **column_to_plot** (str, default "p_mw"): the column in the net[elm_type] table that will be
-        plotted. The suffix (everything behind the last '_' in the column name) will be used as the
-        unit in the infofunction.
+        **column_to_plot** (str, default "p_mw") - the column in the net[elm_type] table that
+        will be plotted. The suffix (everything behind the last '_' in the column name) will be
+        used as the unit in the infofunction.
 
-    **sizemode** (str, default "area"): whether the markers' "area" or "diameter" (for circles)
+        **sizemode** (str, default "area") - whether the markers' "area" or "diameter" (for circles)
         will be proportional to the represented value
 
-    **color** (str, default "red") - color for the markers
+        **color** (str, default "red") - color for the markers
 
-    **patch_type** (str, default "circle") - plotly marker style that will be used (other options
+        **patch_type** (str, default "circle") - plotly marker style that will be used (other options
         are triangle, triangle-down and many more, cf. https://plotly.com/python/marker-style/)
 
-    **marker_scaling** (float, default 1.) - factor to scale the size of all markers
+        **marker_scaling** (float, default 1.) - factor to scale the size of all markers
 
-    **trace_name** (str, default ""): trace name for the legend. If empty, elm_type will be used.
+        **trace_name** (str, default ""): trace name for the legend. If empty, elm_type will be used.
 
-    **infofunc** (pd.Series, default None): hover-infofuction to overwrite the internal infofunction
+        **infofunc** (pd.Series, default None): hover-infofuction to overwrite the internal infofunction
 
-    **node_element** (str, default "bus") - the name of node elements in the net. "bus" for
+        **node_element** (str, default "bus") - the name of node elements in the net. "bus" for
         pandapower networks, "junction" for pandapipes networks
 
-    Returns
-    -------
-    marker_trace
+    OUTPUT:
+        **marker_trace**
     """
 
     # filter for relevant elements:

--- a/pandapower/plotting/plotly/traces.py
+++ b/pandapower/plotting/plotly/traces.py
@@ -813,13 +813,14 @@ def create_weighted_marker_trace(net, elm_type="load", elm_ids=None, column_to_p
         will be plotted. The suffix (everything behind the last '_' in the column name) will be
         used as the unit in the infofunction.
 
-        **sizemode** (str, default "area") - whether the markers' "area" or "diameter" (for circles)
-        will be proportional to the represented value
+        **sizemode** (str, default "area") - whether the markers' "area" or "diameter"  will be
+        proportional to the represented value
 
         **color** (str, default "red") - color for the markers
 
-        **patch_type** (str, default "circle") - plotly marker style that will be used (other options
-        are triangle, triangle-down and many more, cf. https://plotly.com/python/marker-style/)
+        **patch_type** (str, default "circle") - plotly marker style that will be used (other
+        options are triangle-up, triangle-down and many more; for non-filled markers, append "-open"
+        cf. https://plotly.com/python/marker-style/)
 
         **marker_scaling** (float, default 1.) - factor to scale the size of all markers
 

--- a/pandapower/plotting/plotly/vlevel_plotly.py
+++ b/pandapower/plotting/plotly/vlevel_plotly.py
@@ -37,17 +37,17 @@ def vlevel_plotly(net, respect_switches=True, use_line_geodata=None, colors_dict
         **respect_switches** (bool, True) - Respect switches when artificial geodata is created
 
         **use_line_geodata** (bool, True) - defines if lines patches are based on net.line_geodata
-            of the lines (True) or on net.bus_geodata of the connected buses (False)
+        of the lines (True) or on net.bus_geodata of the connected buses (False)
 
         *colors_dict** (dict, None) - dictionary for customization of colors for each voltage level
-            in the form: voltage : color
+        in the form: voltage : color
 
         **on_map** (bool, False) - enables using mapbox plot in plotly If provided geodata are not
-            real geo-coordinates in lon/lat form, on_map will be set to False.
+        real geo-coordinates in lon/lat form, on_map will be set to False.
 
         **projection** (String, None) - defines a projection from which network geo-data will be
-            transformed to lat-long. For each projection a string can be found at
-            http://spatialreference.org/ref/epsg/
+        transformed to lat-long. For each projection a string can be found at
+        http://spatialreference.org/ref/epsg/
 
         **map_style** (str, 'basic') - enables using mapbox plot in plotly
 
@@ -60,7 +60,7 @@ def vlevel_plotly(net, respect_switches=True, use_line_geodata=None, colors_dict
         **figsize** (float, 1) - aspectratio is multiplied by it in order to get final image size
 
         **aspectratio** (tuple, 'auto') - when 'auto' it preserves original aspect ratio of the
-            network geodata any custom aspectration can be given as a tuple, e.g. (1.2, 1)
+        network geodata any custom aspectration can be given as a tuple, e.g. (1.2, 1)
 
         **line_width** (float, 1.0) - width of lines
 

--- a/pandapower/plotting/powerflow_results.py
+++ b/pandapower/plotting/powerflow_results.py
@@ -54,6 +54,8 @@ def plot_voltage_profile(net, plot_transformers=True, ax=None, xlabel="Distance 
                     ax.plot(x, y, linewidth=0.4 * np.sqrt(net.res_line.loading_percent.at[lix]),
                             **kwargs)
                 if bus_colors is not None:
+                    if isinstance(bus_colors, str):
+                        bus_colors = {b: bus_colors for b in net.bus.index}
                     for bus, x, y in zip((from_bus, to_bus), x, y):
                         if bus in bus_colors:
                             ax.plot(x, y, 'or', color=bus_colors[bus], ms=bus_size)


### PR DESCRIPTION
Extends simple_plotly by a parameter `additional_traces`

New function `create_weighted_marker_trace` creates e.g. bubble traces with bubble size depending on a column

With this, simple_plotly can give better insights.

![grafik](https://user-images.githubusercontent.com/44288328/202670428-137ce30a-3942-4835-babc-87cc0168add2.png)
![grafik](https://user-images.githubusercontent.com/44288328/202670460-e2a4c1d1-66fb-44b2-8c27-4c6fe1136bb4.png)
