### PR TITLE
some improvements for grid equivalents

### DIFF
--- a/pandapower/grid_equivalents/get_equivalent.py
+++ b/pandapower/grid_equivalents/get_equivalent.py
@@ -30,7 +30,6 @@ def get_equivalent(net, eq_type, boundary_buses, internal_buses,
                    ward_type="ward_injection", adapt_va_degree=False,
                    calculate_voltage_angles=True,
                    allow_net_change_for_convergence=False,
-                   retain_original_internal_indices=False,
                    runpp_fct=_runpp_except_voltage_angles, **kwargs):
     """
     This function calculates and implements the rei or ward/xward network
@@ -123,9 +122,6 @@ def get_equivalent(net, eq_type, boundary_buses, internal_buses,
             True, the code tests if changes to unusual impedance values solve the divergence issue.
 
         **calculate_voltage_angles** (bool, True) - parameter passed to internal runpp() runs.
-
-        **retain_original_internal_indices** (bool, False) - if True, the element indices in \
-            the internal net are retained; otherwise the indices will be reordered from 0.
 
         ****kwargs** - key word arguments, such as sgen_separate, load_separate, gen_separate, \
         group_name.
@@ -267,8 +263,7 @@ def get_equivalent(net, eq_type, boundary_buses, internal_buses,
         logger.debug("Merging of internal and equivalent network begins.")
         net_eq = merge_internal_net_and_equivalent_external_net(
             net_eq, net_internal, eq_type, show_computing_time,
-            calc_volt_angles=calculate_voltage_angles,
-            retain_original_internal_indices=retain_original_internal_indices)
+            calc_volt_angles=calculate_voltage_angles)
         # run final power flow calculation
         net_eq = runpp_fct(net_eq, calculate_voltage_angles=calculate_voltage_angles)
     else:
@@ -334,7 +329,7 @@ def get_equivalent(net, eq_type, boundary_buses, internal_buses,
 
 def merge_internal_net_and_equivalent_external_net(
         net_eq, net_internal, eq_type, show_computing_time=False,
-        calc_volt_angles=False, retain_original_internal_indices=False, **kwargs):
+        calc_volt_angles=False, **kwargs):
     """
     Merges the internal network and the equivalent external network.
     It is expected that the boundaries occur in both, equivalent net and
@@ -373,10 +368,8 @@ def merge_internal_net_and_equivalent_external_net(
     # --- merge equivalent external net and internal net
     merged_net = pp.merge_nets(
         net_internal, net_eq, validate=kwargs.pop("validate", False),
-        retain_original_indices_in_net1=retain_original_internal_indices,
-        # TODO: remove retain_original_indices_in_net1 and uncomment the following:
-        # net2_reindex_log_level=kwargs.pop("net2_reindex_log_level", "debug"),
-        # merge_results=kwargs.pop("merge_results", False),
+        net2_reindex_log_level=kwargs.pop("net2_reindex_log_level", "debug"),
+        merge_results=kwargs.pop("merge_results", False),
         **kwargs)
     try:
         merged_net.gen.max_p_mw[-len(net_eq.gen.max_p_mw):] = net_eq.gen.max_p_mw.values

--- a/pandapower/test/grid_equivalents/test_get_equivalent.py
+++ b/pandapower/test/grid_equivalents/test_get_equivalent.py
@@ -443,23 +443,21 @@ def test_retain_original_internal_indices():
     net.sgen.index = sgen_idxs
     net.line.index = line_idxs
     pp.reindex_buses(net, bus_lookup)
-    
+    first3buses = net.bus.index.tolist()[0:3]
+    assert not np.array_equal(first3buses, list(range(3)))
     pp.runpp(net)
     eq_type = "rei"
     boundary_buses = [bus_lookup[b] for b in [3, 9, 22]]
     internal_buses = [bus_lookup[0]]
-    for retain_original_internal_indices in [True, False]:
-        net_eq = pp.grid_equivalents.get_equivalent(net, eq_type, boundary_buses, internal_buses,
-                                                    calculate_voltage_angles=True,
-                                                    retain_original_internal_indices=\
-                                                        retain_original_internal_indices)
-        if retain_original_internal_indices:
-            assert net_eq.sgen.index.tolist()[:3] == sgen_idxs[:3]
-            assert set(net_eq.line.index.tolist()) - set(line_idxs) == set()
-            assert set(net_eq.bus.index.tolist()[:-2]) - set(bus_idxs) == set()
-        else:
-            assert net_eq.sgen.index.tolist() == list(range(len(net_eq.sgen)))
-            assert net_eq.line.index.tolist() == list(range(len(net_eq.line)))
+
+    net_eq = pp.grid_equivalents.get_equivalent(net, eq_type, boundary_buses, internal_buses,
+                                                calculate_voltage_angles=True,
+                                                retain_original_internal_indices=True)
+    
+    assert net_eq.sgen.index.tolist()[:3] == sgen_idxs[:3]
+    assert set(net_eq.line.index.tolist()) - set(line_idxs) == set()
+    assert set(net_eq.bus.index.tolist()[:-2]) - set(bus_idxs) == set()
+    assert np.array_equal(first3buses, net_eq.bus.index.tolist()[0:3])
 
 
 def test_switch_sgens():
@@ -602,7 +600,7 @@ def test_sgen_bswitch():
 
         
 if __name__ == "__main__":
-    if 1:
+    if 0:
         pytest.main(['-x', __file__])
     else:
         # test_cost_consideration()
@@ -611,12 +609,12 @@ if __name__ == "__main__":
         # test_adopt_columns_to_separated_eq_elms()
         # test_equivalent_groups()
         # test_shifter_degree()
-        # test_retain_original_internal_indices()
+        test_retain_original_internal_indices()
         # test_switch_sgens()
         # test_characteristic()
         # test_controller()
-        test_motor()
-        test_sgen_bswitch()
+        # test_motor()
+        # test_sgen_bswitch()
     pass
 
     

--- a/pandapower/test/grid_equivalents/test_grid_equivalents_auxiliary.py
+++ b/pandapower/test/grid_equivalents/test_grid_equivalents_auxiliary.py
@@ -30,7 +30,7 @@ def test_drop_internal_branch_elements():
 
 
 if __name__ == "__main__":
-    if 0:
+    if 1:
         pytest.main(['-x', __file__])
     else:
         test_drop_internal_branch_elements()

--- a/pandapower/toolbox.py
+++ b/pandapower/toolbox.py
@@ -1948,7 +1948,7 @@ def _merge_nets_deprecated(net1, net2, validate=True, merge_results=True, tol=1e
     # net1 = copy.deepcopy(net1)  # commented to save time. net1 will not be changed (only by runpp)
     net2 = copy.deepcopy(net2)
     if create_continuous_bus_indices:
-        create_continuous_bus_index(net2, start=net1.bus.index.max() + 1)
+        create_continuou_bus_index(net2, start=net1.bus.index.max() + 1)
     if validate:
         runpp(net1, **kwargs)
         runpp(net2, **kwargs)


### PR DESCRIPTION
- the parameter "retain_original_internal_indices" is removed. The indices for all "internal" elements are kept. The new (equivalent) elements are numbered from the maximal index of the internal ones.
-  The dataframe column matching is improved.
    1. the data type is recognized according to the data (e.g., `net.sgen.type.apply(type)`) , not the column (e.g., `net.sgen.type.dtype`). In this case, all columns are divided into five groups: **mixed**, **number**, **bool**, **str**, and **none**. 
    2. if the data of one column have different types (e.g, string and None), the aggregated value is "mixed data type".
    3. if the data of one column are all string and identical (e.g, "a", "a", "a"), the aggregated value is the same (e.g., "a").
    4. if the data of one column are all string but different (e.g, "a", "b", "c"), the aggregated value is modified (e.g., "a//b//c").
   