### PR TITLE
register pytest.mark.slow in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,7 @@
 [metadata]
 description-file = installation.rst
 license_file = LICENSE
+
+[tool:pytest]
+markers:
+  slow: marks tests as slow (deselect with '-m "not slow"'), e.g. in run_fast_tests


### PR DESCRIPTION
By adding the attribute in setup.cfg, pytest will no longer complain about "unknown attribute 'slow'"