### PR TITLE
Extend error message if diff. v setpoints

### DIFF
--- a/pandapower/build_gen.py
+++ b/pandapower/build_gen.py
@@ -303,7 +303,7 @@ def _check_voltage_setpoints_at_same_bus(ppc):
     # generator setpoints:
     gen_vm = ppc['gen'][:, VG]
     if _different_values_at_one_bus(gen_bus, gen_vm):
-        raise UserWarning("Generators or external grids with different voltage setpoints connected to the same bus")
+        raise UserWarning("Voltage controlling elements, i.e. generators, external grids, or DC lines, at the same bus have different setpoints.")
 
 
 def _check_voltage_angles_at_same_bus(net, ppc):

--- a/pandapower/build_gen.py
+++ b/pandapower/build_gen.py
@@ -303,7 +303,7 @@ def _check_voltage_setpoints_at_same_bus(ppc):
     # generator setpoints:
     gen_vm = ppc['gen'][:, VG]
     if _different_values_at_one_bus(gen_bus, gen_vm):
-        raise UserWarning("Generators with different voltage setpoints connected to the same bus")
+        raise UserWarning("Generators or external grids with different voltage setpoints connected to the same bus")
 
 
 def _check_voltage_angles_at_same_bus(net, ppc):


### PR DESCRIPTION
This check also checks the ext grids.
I've added this to the error message so that the user also considers the ext_grid table before checking the gen table again and again...