### PR TITLE
Update .readthedocs.yml, install plotting packages

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,3 +7,5 @@ python:
          path: .
          extra_requirements:
             - docs
+            - plotting
+            


### PR DESCRIPTION
add matplotlib etc. to the readthedocs requirements

this is required because otherwise the create_collection functions cannot be imported and are not shown in the online documentation

(could help on #1566)
