### PR TITLE
Fix pypower link in index.rst

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -2,7 +2,7 @@
 pandapower
 ############################
 
-pandapower combines the data analysis library `pandas <http://pandas.pydata.org>`_ and the power flow solver `PYPOWER <https:/pypi.python.org/pypi/PYPOWER>`_ to create an easy to use network calculation program
+pandapower combines the data analysis library `pandas <http://pandas.pydata.org>`_ and the power flow solver `PYPOWER <https://pypi.python.org/pypi/PYPOWER>`_ to create an easy to use network calculation program
 aimed at automation of analysis and optimization in power systems.
 
 .. image:: /pics/pp.svg


### PR DESCRIPTION
This commit fixes pypower URL link in `doc/index.rst`.