### PR TITLE
fix deprecated np.typedict to np.sctypedict in cim converter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Change Log
 [upcoming release] - 2023-..-..
 -------------------------------
 - [FIXED] recorrection of shunt values in CIGRE HV
+- [FIXED] deprecated np.typedict to np.sctypedict in cim converter
 
 [2.12.1] - 2023-04-18
 -------------------------------

--- a/pandapower/converter/cim/cim2pp/convert_measurements.py
+++ b/pandapower/converter/cim/cim2pp/convert_measurements.py
@@ -19,7 +19,7 @@ class CreateMeasurements:
         self.cim = cim
 
     def _set_measurement_element_datatype(self):
-        self.net.measurement.element = self.net.measurement.element.astype(np.typeDict.get("UInt32"))
+        self.net.measurement.element = self.net.measurement.element.astype(np.sctypeDict.get("UInt32"))
 
     def _copy_to_measurement(self, input_df: pd.DataFrame):
         pp_type = 'measurement'

--- a/pandapower/converter/cim/cim_tools.py
+++ b/pandapower/converter/cim/cim_tools.py
@@ -35,9 +35,9 @@ def extend_pp_net_cim(net: pandapowerNet, override: bool = True) -> pandapowerNe
     only missing columns will be created. Optional, default: True
     :return: The extended pandapower network.
     """
-    np_str_type = np.typeDict.get('str')
-    np_float_type = np.typeDict.get('float')
-    np_bool_type = np.typeDict.get('bool')
+    np_str_type = np.sctypeDict.get('str')
+    np_float_type = np.sctypeDict.get('float')
+    np_bool_type = np.sctypeDict.get('bool')
 
     sc = get_pp_net_special_columns_dict()
 


### PR DESCRIPTION
np.type dict is no longer supported under python 3.10 and numpy >= 1.24