### PR TITLE
Update github_test_action.yml

### DIFF
--- a/.github/workflows/github_test_action.yml
+++ b/.github/workflows/github_test_action.yml
@@ -37,7 +37,7 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
           pip install .["all"]
           if ${{ matrix.python-version == '3.9' }}; then python -m pip install pypower; fi
-          if ${{ matrix.python-version != '3.9' && matrix.python-version != '3.11' }}; then python -m pip install numba; fi
+          if ${{ matrix.python-version != '3.9' }}; then python -m pip install numba; fi
           if ${{ matrix.python-version == '3.8' || matrix.python-version == '3.10' }}; then python -m pip install lightsim2grid; fi
       - name: Install Julia
         if: ${{ matrix.python-version == '3.9' }}
@@ -83,7 +83,7 @@ jobs:
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install .
         pip install matplotlib
-        if ${{ matrix.python-version != '3.11' }}; then python -m pip install numba; fi
+        if ${{ matrix.python-version != '3.9' }}; then python -m pip install numba; fi
     - name: Install pandapipes and simbench
       run: |
         python -m pip install git+https://github.com/e2nIEE/pandapipes@develop#egg=pandapipes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,13 +103,13 @@ jobs:
         if: matrix.os  == 'windows-latest'
         run: |
           if ( '${{ matrix.python-version }}'  -eq '3.9' ) { python -m pip install pypower }
-          if ( '${{ matrix.python-version }}'  -ne '3.9' -and '${{ matrix.python-version }}' -ne '3.11' ) { python -m pip install numba }
+          if ( '${{ matrix.python-version }}'  -ne '3.9' ) { python -m pip install numba }
           if ( '${{ matrix.python-version }}'  -eq '3.8' -or '${{ matrix.python-version }}'  -eq '3.10' ) { python -m pip install lightsim2grid }
       - name: Install specific dependencies (Ubuntu)
         if: matrix.os  == 'ubuntu-latest'
         run: |
           if ${{ matrix.python-version == '3.9' }}; then python -m pip install pypower; fi
-          if ${{ matrix.python-version != '3.9' && matrix.python-version != '3.11' }}; then python -m pip install numba; fi
+          if ${{ matrix.python-version != '3.9' }}; then python -m pip install numba; fi
           if ${{ matrix.python-version == '3.8' || matrix.python-version == '3.10' }}; then python -m pip install lightsim2grid; fi
       - name: Install Julia
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.9'

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Change Log
 - [FIXED] loading net from xlsx with MultiIndex
 - [FIXED] setting MultiIndex when loading empty DataFrame from JSON, getting next index from DataFrame with MultiIndex
 - [FIXED] some fixes and small updates at cim2pp
+- [CHANGED] add numba in the dependencies for Python 3.11 for GitHub test actions
 
 
 [2.13.1] - 2023-05-12

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Change Log
 - [FIXED] loading net from xlsx with MultiIndex
 - [FIXED] setting MultiIndex when loading empty DataFrame from JSON, getting next index from DataFrame with MultiIndex
 - [FIXED] some fixes and small updates at cim2pp
-- [CHANGED] add numba in the dependencies for Python 3.11 for GitHub test actions
+- [CHANGED] add numba in the dependencies for Python 3.11 for GitHub test and release actions
 
 
 [2.13.1] - 2023-05-12


### PR DESCRIPTION
include numba for test pipeline of 3.11 (now only skip for 3.9 for testing) because numba 0.57 supports python 3.11