### PR TITLE
pandas deprecation fix for read_json

### DIFF
--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -24,6 +24,7 @@ from pandapower import __version__
 from pandapower.auxiliary import _preserve_dtypes
 import networkx
 import numpy
+from io import StringIO
 import pandas as pd
 from networkx.readwrite import json_graph
 from numpy import ndarray, generic, equal, isnan, allclose, any as anynp
@@ -506,7 +507,11 @@ class FromSerializableRegistry():
         column_name = self.d.pop('column_name', None)
         column_names = self.d.pop('column_names', None)
 
-        df = pd.read_json(self.obj, precise_float=True, convert_axes=False, **self.d)
+        obj = self.obj
+        if type(obj) == str:
+            obj = StringIO(obj)
+
+        df = pd.read_json(obj, precise_float=True, convert_axes=False, **self.d)
 
         if not df.shape[0] or self.d.get("orient", False) == "columns":
             try:

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -508,7 +508,7 @@ class FromSerializableRegistry():
         column_names = self.d.pop('column_names', None)
 
         obj = self.obj
-        if type(obj) == str:
+        if isinstance(obj, str):
             obj = StringIO(obj)
 
         df = pd.read_json(obj, precise_float=True, convert_axes=False, **self.d)


### PR DESCRIPTION
Hi,

since pandas version 2.10 read_json from literal (string) is deprecated. The message is really annoying and messes up logfiles.
Therefore this patch, which will wrap a string into an StringIO object (as recommmended by the pandas people). Probably it will also be faster?

BR