### PR TITLE
fixes #2138

### DIFF
--- a/pandapower/plotting/geo.py
+++ b/pandapower/plotting/geo.py
@@ -23,7 +23,7 @@ except ImportError:
     geopandas_INSTALLED = False
 
 try:
-    from pyproj import Proj, transform, Transformer
+    from pyproj import Transformer
 
     pyproj_INSTALLED = True
 except ImportError:
@@ -106,9 +106,8 @@ def _convert_xy_epsg(x, y, epsg_in=4326, epsg_out=31467):
     """
     if not pyproj_INSTALLED:
         soft_dependency_error(str(sys._getframe().f_code.co_name)+"()", "pyproj")
-    in_proj = Proj(init='epsg:%i' % epsg_in)
-    out_proj = Proj(init='epsg:%i' % epsg_out)
-    return transform(in_proj, out_proj, x, y)
+    transformer = Transformer.from_crs(f'EPSG:{epsg_in}', f'EPSG:{epsg_out}', always_xy=True)
+    return transformer.transform(x, y)
 
 
 def convert_gis_to_geodata(net, node_geodata=True, branch_geodata=True):

--- a/pandapower/plotting/geo.py
+++ b/pandapower/plotting/geo.py
@@ -319,7 +319,7 @@ def dump_to_geojson(net, nodes=False, branches=False):
                     coords.append(net.pipe_geodata.loc[uid].coords)
                 coords.append([float(to_coords.x), float(to_coords.y)])
 
-            geom = geojson.LineString(row.coords.tolist() if is_pandapower else coords)
+            geom = geojson.LineString(row.coords if is_pandapower else coords)
             features.append(geojson.Feature(geometry=geom, id=uid, properties=props[uid]))
     # find and set crs if available
     crs_node = None

--- a/pandapower/test/helper_functions.py
+++ b/pandapower/test/helper_functions.py
@@ -53,7 +53,7 @@ def create_test_network():
 
     pp.create_line_from_parameters(net, b2, b3, 1, name="line1", r_ohm_per_km=0.2067,
                                    ices=0.389985, c_nf_per_km=720.0, max_i_ka=0.328,
-                                   x_ohm_per_km=0.1897522, geodata=np.array([[1, 2], [3, 4]]))
+                                   x_ohm_per_km=0.1897522, geodata=[[1, 2], [3, 4]])
     # NAYY 1x150RM 0.6/1kV ir
     pp.create_line_from_parameters(net, b1, b4, 1, name="line2", r_ohm_per_km=0.876,
                                    c_nf_per_km=260.0, max_i_ka=0.123, x_ohm_per_km=0.1159876)


### PR DESCRIPTION
fixed create_test_network using numpy.array for geocoords eventhough the doc calls for list
fixed issue in geo.py resulting from #2138

updated deprecated pyproj.transform to pyproj.Transformer in geo.py

ran all test: 995 passed, 51 skipped, 16 xfailed, 1169 warnings
No warnings come from changes implemented in this PR.