### PR TITLE
Revert "Update setup.py"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
                       "deepdiff"],
     extras_require={
         "docs": ["numpydoc", "sphinx", "sphinx_rtd_theme"],
-        "plotting": ["plotly", "matplotlib", "python-igraph", "geopandas", "geojson"],
+        "plotting": ["plotly", "matplotlib", "igraph", "geopandas", "geojson"],
         # "shapely", "pyproj" are dependencies of geopandas and so already available;
         # "base64", "hashlib", "zlib" produce installing problems, so they are not included
         "test": ["pytest<=7.0", "pytest-xdist"],
@@ -62,7 +62,7 @@ setup(
         # "fiona" is a depedency of geopandas and so already available
         "converter": ["matpowercaseframes"],
         "all": ["numpydoc", "sphinx", "sphinx_rtd_theme",
-                "plotly>=3.1.1", "matplotlib", "python-igraph", "geopandas", "geojson",
+                "plotly>=3.1.1", "matplotlib", "igraph", "geopandas", "geojson",
                 "pytest<=7.0", "pytest-xdist",
                 "ortools",  # lightsim2grid,
                 "xlsxwriter", "openpyxl", "cryptography",


### PR DESCRIPTION
Reverts e2nIEE/pandapower#2165

Reason: the correct version is igraph, not python-igraph: https://pypi.org/project/python-igraph/

"This package is deprecated; use the igraph package instead. This package will be kept in sync with igraph until Sep 1, 2022 and it will not receive any updates after Sep 1, 2022."