### PR TITLE
Resolving simple bug [bug] Incorrect Pluralization in plural_s Function (Simple) #2180

### DIFF
--- a/pandapower/auxiliary.py
+++ b/pandapower/auxiliary.py
@@ -318,9 +318,9 @@ class pandapowerNet(ADict):
 
 def plural_s(number):
     if number > 1:
-        return ""
-    else:
         return "s"
+    else:
+        return ""
 
 def _preserve_dtypes(df, dtypes):
     for item, dtype in list(dtypes.items()):


### PR DESCRIPTION
## Description:
This pull request addresses the bug identified in the plural_s function within the pandapower project. The issue occurs when attempting to pluralize a word based on a given number. The current implementation incorrectly returns an empty string when the number is greater than 1, indicating the plural form. The fix ensures that the function now correctly returns an empty string for numbers equal to or less than 1, and "s" for numbers greater than 1.

## Changes Made:
Modified the plural_s function to correctly handle pluralization based on the input number.

Issue opened number #2180