### PR TITLE
fix NaN in tap controllers

### DIFF
--- a/pandapower/control/controller/trafo/ContinuousTapControl.py
+++ b/pandapower/control/controller/trafo/ContinuousTapControl.py
@@ -4,6 +4,7 @@
 # and Energy System Technology (IEE), Kassel. All rights reserved.
 
 import numpy as np
+
 from pandapower.auxiliary import read_from_net, write_to_net
 from pandapower.control.controller.trafo_control import TrafoController
 
@@ -97,6 +98,9 @@ class ContinuousTapControl(TrafoController):
             return True
 
         vm_pu = read_from_net(net, "res_bus", self.controlled_bus, "vm_pu", self._read_write_flag)
+        # this is possible in case the trafo is set out of service by the connectivity check
+        if np.isnan(vm_pu):
+            return True
         self.tap_pos = read_from_net(net, self.trafotable, self.controlled_tid, "tap_pos", self._read_write_flag)
         difference = 1 - self.vm_set_pu / vm_pu
 

--- a/pandapower/control/controller/trafo/ContinuousTapControl.py
+++ b/pandapower/control/controller/trafo/ContinuousTapControl.py
@@ -99,8 +99,7 @@ class ContinuousTapControl(TrafoController):
 
         vm_pu = read_from_net(net, "res_bus", self.controlled_bus, "vm_pu", self._read_write_flag)
         # this is possible in case the trafo is set out of service by the connectivity check
-        if np.isnan(vm_pu):
-            return True
+        is_nan =  np.isnan(vm_pu)
         self.tap_pos = read_from_net(net, self.trafotable, self.controlled_tid, "tap_pos", self._read_write_flag)
         difference = 1 - self.vm_set_pu / vm_pu
 
@@ -114,4 +113,4 @@ class ContinuousTapControl(TrafoController):
         else:
             converged = np.abs(difference) < self.tol
 
-        return np.all(converged)
+        return np.all(np.logical_or(converged, is_nan))

--- a/pandapower/control/controller/trafo/DiscreteTapControl.py
+++ b/pandapower/control/controller/trafo/DiscreteTapControl.py
@@ -118,8 +118,7 @@ class DiscreteTapControl(TrafoController):
 
         vm_pu = read_from_net(net, "res_bus", self.controlled_bus, "vm_pu", self._read_write_flag)
         # this is possible in case the trafo is set out of service by the connectivity check
-        if np.isnan(vm_pu):
-            return True
+        is_nan = np.isnan(vm_pu)
         self.tap_pos = read_from_net(net, self.trafotable, self.controlled_tid, "tap_pos", self._read_write_flag)
 
         reached_limit = np.where(self.tap_side_coeff * self.tap_sign == 1,
@@ -130,5 +129,4 @@ class DiscreteTapControl(TrafoController):
 
         converged = np.logical_or(reached_limit, np.logical_and(self.vm_lower_pu < vm_pu, vm_pu < self.vm_upper_pu))
 
-        return np.all(converged)
-
+        return np.all(np.logical_or(converged, is_nan))

--- a/pandapower/control/controller/trafo/DiscreteTapControl.py
+++ b/pandapower/control/controller/trafo/DiscreteTapControl.py
@@ -3,8 +3,10 @@
 # Copyright (c) 2016-2023 by University of Kassel and Fraunhofer Institute for Energy Economics
 # and Energy System Technology (IEE), Kassel. All rights reserved.
 import numpy as np
+
 from pandapower.auxiliary import read_from_net, write_to_net
 from pandapower.control.controller.trafo_control import TrafoController
+
 
 class DiscreteTapControl(TrafoController):
     """
@@ -115,6 +117,9 @@ class DiscreteTapControl(TrafoController):
             return True
 
         vm_pu = read_from_net(net, "res_bus", self.controlled_bus, "vm_pu", self._read_write_flag)
+        # this is possible in case the trafo is set out of service by the connectivity check
+        if np.isnan(vm_pu):
+            return True
         self.tap_pos = read_from_net(net, self.trafotable, self.controlled_tid, "tap_pos", self._read_write_flag)
 
         reached_limit = np.where(self.tap_side_coeff * self.tap_sign == 1,


### PR DESCRIPTION
if trafos are set out of service by connectivity check, the result is NaN, which leads to convergence problems of tap controllers --> fixed with this change