### PR TITLE
avoid KeyError Exeption on traces with empty x/y coordinate array and missing lon/lat field

### DIFF
--- a/pandapower/plotting/plotly/traces.py
+++ b/pandapower/plotting/plotly/traces.py
@@ -1092,8 +1092,8 @@ def draw_traces(traces, on_map=False, map_style='basic', showlegend=True, figsiz
             xs = []
             ys = []
             for trace in traces:
-                xs += trace.get('x') or trace['lon']
-                ys += trace.get('y') or trace['lat']
+                xs += trace.get('x') or trace.get('lon') or []
+                ys += trace.get('y') or trace.get('lat') or []
             xs_arr = np.array(xs)
             ys_arr = np.array(ys)
             xrange = np.nanmax(xs_arr) - np.nanmin(xs_arr)


### PR DESCRIPTION
Fix for the following issue: Results might fail to plot with `pf_res_plotly` due to empty x/y coordinate data arrays by KeyError on non-existing lon/lat fields.
