### PR TITLE
fix key error in unbalanced powerflow if trafo index is not consecutive or not starting at zero

### DIFF
--- a/pandapower/results_branch.py
+++ b/pandapower/results_branch.py
@@ -341,7 +341,7 @@ def _get_trafo_results_3ph(net, ppc0, ppc1, ppc2, I012_f, V012_f, I012_t, V012_t
     if len(gap_trafo_index > 0):
         for i_trafo in gap_trafo_index:
             Iabc_sum = [0, 0, 0]
-            lv_bus = net.trafo.lv_bus[i_trafo]
+            lv_bus = net.trafo.lv_bus.iat[i_trafo]
             V_bus_abc = np.array([[net.res_bus_3ph['vm_a_pu'][lv_bus] * net.bus['vn_kv'][lv_bus]],
                                   [net.res_bus_3ph['vm_b_pu'][lv_bus] * net.bus['vn_kv'][lv_bus]],
                                   [net.res_bus_3ph['vm_c_pu'][lv_bus] * net.bus['vn_kv'][lv_bus]]])


### PR DESCRIPTION
Running pp.runpp_3ph fails with a key error if trafo index is not starting at 0 or it is not consecutive.

Minimal example:

```python
import pandapower as pp
import pandapower.networks as nw

net = nw.ieee_european_lv_asymmetric("on_peak_566")
net.trafo.loc[1] = net.trafo.loc[0]
net.trafo.drop(0, inplace=True)

pp.runpp_3ph(net) # -> KeyError: 0

```

Fixed by this PR.