### PR TITLE
Improvements to README if using dark color scheme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,12 @@
+.. raw:: html
 
-.. image:: https://www.pandapower.org/images/pp.svg
-   :target: https://www.pandapower.org
-   :alt: logo
+    <a href="https://www.pandapower.org">
+       <picture>
+         <source media="(prefers-color-scheme: dark)" srcset="https://www.pandapower.org/images/pp_light.svg">
+         <source media="(prefers-color-scheme: light)" srcset="https:////www.pandapower.org/images/pp.svg">
+         <img alt="logo" src="//www.pandapower.org/images/pp.svg">
+       </picture>
+    </a>
 
 |
 
@@ -91,9 +96,15 @@ Operation at the Fraunhofer Institute for Energy Economics and Energy System Tec
 
 |
 
-.. image:: http://www.pandapower.org/images/contact/Logo_Fraunhofer_IEE.png
-    :target: https://www.iee.fraunhofer.de/en.html
-    :width: 500
+.. raw:: html
+
+    <a href="https://www.iee.fraunhofer.de/en.html">
+       <picture>
+         <source media="(prefers-color-scheme: dark)" srcset="https://www.pandapower.org/images/contact/Logo_Fraunhofer_IEE_negativ.png">
+         <source media="(prefers-color-scheme: light)" srcset="https:////www.pandapower.org/images/contact/Logo_Fraunhofer_IEE.png">
+         <img alt="logo" src="//www.pandapower.org/images/contact/Logo_Fraunhofer_IEE.png" width=500 >
+       </picture>
+    </a>
 
 |
 


### PR DESCRIPTION
**Requires [PR 12](https://github.com/e2nIEE/pandapower-homepage/pull/12) in pandapower-homepage to be accepted first!**

Updated README.rst to use different versions of pp.svg and Logo_Fraunhofer_IEE if a dark color scheme is used on github.