### PR TITLE
Using loc to remove the warning

### DIFF
--- a/pandapower/converter/cim/cim2pp/build_pp_net.py
+++ b/pandapower/converter/cim/cim2pp/build_pp_net.py
@@ -68,7 +68,7 @@ class CimConverter:
                                       ignore_index=True, sort=False)
         for one_attr in self.net[pp_type].columns:
             if one_attr in input_df.columns:
-                self.net[pp_type][one_attr][start_index_pp_net:] = input_df[one_attr][:]
+                self.net[pp_type].loc[start_index_pp_net:, one_attr] = (input_df[one_attr][:]).values
 
     # noinspection PyShadowingNames
     def convert_to_pp(self, convert_line_to_switch: bool = False, line_r_limit: float = 0.1,

--- a/pandapower/converter/cim/cim2pp/build_pp_net.py
+++ b/pandapower/converter/cim/cim2pp/build_pp_net.py
@@ -68,7 +68,8 @@ class CimConverter:
                                       ignore_index=True, sort=False)
         for one_attr in self.net[pp_type].columns:
             if one_attr in input_df.columns:
-                self.net[pp_type].loc[start_index_pp_net:, one_attr] = (input_df[one_attr][:]).values
+                self.net[pp_type].loc[start_index_pp_net:, one_attr] = (
+                    (input_df[one_attr][:]).values)
 
     # noinspection PyShadowingNames
     def convert_to_pp(self, convert_line_to_switch: bool = False, line_r_limit: float = 0.1,

--- a/pandapower/converter/cim/cim2pp/convert_measurements.py
+++ b/pandapower/converter/cim/cim2pp/convert_measurements.py
@@ -32,7 +32,7 @@ class CreateMeasurements:
                                       ignore_index=True, sort=False)
         for one_attr in self.net[pp_type].columns:
             if one_attr in input_df.columns:
-                self.net[pp_type][one_attr][start_index_pp_net:] = input_df[one_attr][:]
+                self.net[pp_type].loc[start_index_pp_net:, one_attr] = input_df[one_attr][:]
 
     def create_measurements_from_analog(self):
         self.logger.info("------------------------- Creating measurements from Analog -------------------------")

--- a/pandapower/converter/cim/cim2pp/converter_classes/coordinates/coordinatesFromDLCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/coordinates/coordinatesFromDLCim16.py
@@ -58,7 +58,7 @@ class CoordinatesFromDLCim16:
                 one_ele_df['coords'] = one_ele_df[['xPosition', 'yPosition']].values.tolist()
                 one_ele_df['coords'] = one_ele_df[['coords']].values.tolist()
                 for _, df_group in one_ele_df.groupby(by=sc['o_id']):
-                    one_ele_df['coords'][df_group.index.values[0]] = df_group[
+                    one_ele_df.at[df_group.index.values[0], 'coords'] = df_group[
                         ['xPosition', 'yPosition']].values.tolist()
                 one_ele_df = one_ele_df.drop_duplicates([sc['o_id']], keep='first')
                 one_ele_df['coords'] = one_ele_df['coords'].astype(str)

--- a/pandapower/converter/cim/cim2pp/converter_classes/coordinates/geoCoordinatesFromGLCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/coordinates/geoCoordinatesFromGLCim16.py
@@ -59,7 +59,7 @@ class GeoCoordinatesFromGLCim16:
         line_geo['coords'] = line_geo[['xPosition', 'yPosition']].values.tolist()
         line_geo['coords'] = line_geo[['coords']].values.tolist()
         for _, df_group in line_geo.groupby(by=sc['o_id']):
-            line_geo['coords'][df_group.index.values[0]] = df_group[['xPosition', 'yPosition']].values.tolist()
+            line_geo.at[df_group.index.values[0], 'coords'] = df_group[['xPosition', 'yPosition']].values.tolist()
         line_geo = line_geo.drop_duplicates([sc['o_id']], keep='first')
         line_geo = line_geo.sort_values(by='index')
         line_geo['geo'] = '{"coordinates": ' + line_geo['coords'].astype(str) + ', "type": "LineString"}'
@@ -83,7 +83,7 @@ class GeoCoordinatesFromGLCim16:
                 one_ele_df['coords'] = one_ele_df[['xPosition', 'yPosition']].values.tolist()
                 one_ele_df['coords'] = one_ele_df[['coords']].values.tolist()
                 for _, df_group in one_ele_df.groupby(by=sc['o_id']):
-                    one_ele_df['coords'][df_group.index.values[0]] = df_group[
+                    one_ele_df.at[df_group.index.values[0], 'coords'] = df_group[
                         ['xPosition', 'yPosition']].values.tolist()
                 one_ele_df = one_ele_df.drop_duplicates([sc['o_id']], keep='first')
                 one_ele_df['coords'] = one_ele_df['coords'].astype(str)

--- a/pandapower/converter/cim/cim2pp/converter_classes/externalnetworks/externalNetworkInjectionsCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/externalnetworks/externalNetworkInjectionsCim16.py
@@ -88,8 +88,8 @@ class ExternalNetworkInjectionsCim16:
                        how='left', left_on='ConnectivityNode', right_on='b_id')
 
         # convert pu generators with prio = 0 to pq generators (PowerFactory does it same)
-        eni['referencePriority'].loc[eni['referencePriority'] == 0] = -1
-        eni['controlEnabled'].loc[eni['referencePriority'] == -1] = False
+        eni.loc[eni['referencePriority'] == 0, 'referencePriority'] = -1
+        eni.loc[eni['referencePriority'] == -1, 'controlEnabled'] = False
         eni['p'] = -eni['p']
         eni['q'] = -eni['q']
         eni['x0x_max'] = ((eni['maxR1ToX1Ratio'] + 1j) /

--- a/pandapower/converter/cim/cim2pp/converter_classes/switches/switchesCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/switches/switchesCim16.py
@@ -36,19 +36,19 @@ class SwitchesCim16:
             pd.concat(
                 [eqssh_switches, self.cimConverter.merge_eq_ssh_profile('Disconnector', add_cim_type_column=True)],
                 ignore_index=True, sort=False)
-        eqssh_switches.type[start_index_cim_net:] = 'DS'
+        eqssh_switches.loc[start_index_cim_net:, 'type'] = 'DS'
         start_index_cim_net = eqssh_switches.index.size
         eqssh_switches = \
             pd.concat(
                 [eqssh_switches, self.cimConverter.merge_eq_ssh_profile('LoadBreakSwitch', add_cim_type_column=True)],
                 ignore_index=True, sort=False)
-        eqssh_switches.type[start_index_cim_net:] = 'LBS'
+        eqssh_switches.loc[start_index_cim_net:, 'type'] = 'LBS'
         start_index_cim_net = eqssh_switches.index.size
         # switches needs to be the last which getting appended because of class inherit problem in jpa
         eqssh_switches = pd.concat(
             [eqssh_switches, self.cimConverter.merge_eq_ssh_profile('Switch', add_cim_type_column=True)],
             ignore_index=True, sort=False)
-        eqssh_switches.type[start_index_cim_net:] = 'LS'
+        eqssh_switches.loc[start_index_cim_net:, 'type'] = 'LS'
         # drop all duplicates to fix class inherit problem in jpa
         eqssh_switches = eqssh_switches.drop_duplicates(subset=['rdfId'], keep='first')
         switch_length_before_merge = eqssh_switches.index.size

--- a/pandapower/grid_equivalents/auxiliary.py
+++ b/pandapower/grid_equivalents/auxiliary.py
@@ -206,16 +206,16 @@ def calc_zpbn_parameters(net, boundary_buses, all_external_buses, slack_as="gen"
             if i in net[ele].bus.values and net[ele].in_service[net[ele].bus == i].values.any():
                 ind = list(net[ele].index[net[ele].bus == i].values)
                 # act. values --> ref. values:
-                S[power][k] += sum(net[res_ele].p_mw[ind].values * sign) / net.sn_mva + \
+                S.loc[k, power] += sum(net[res_ele].p_mw[ind].values * sign) / net.sn_mva + \
                     1j * sum(net[res_ele].q_mvar[ind].values *
                              sign) / net.sn_mva
-                S[sn][k] = sum(net[ele].sn_mva[ind].values) + \
+                S.loc[k, sn] = sum(net[ele].sn_mva[ind].values) + \
                     1j * 0 if ele != "ext_grid" else 1e6 + 1j * 0
                 S[power.replace('_separate', '_integrated')] += S[power][k]
                 S[sn.replace('_separate', '_integrated')] += S[sn][k]
-        S.ext_bus[k] = all_external_buses[k]
-        S.v_m[k] = net.res_bus.vm_pu[i]
-        S.v_cpx[k] = S.v_m[k] * \
+        S.loc[k, 'ext_bus'] = all_external_buses[k]
+        S.loc[k, 'v_m'] = net.res_bus.vm_pu[i]
+        S.loc[k, 'v_cpx'] = S.v_m[k] * \
             np.exp(1j * net.res_bus.va_degree[i] * np.pi / 180)
         k = k + 1
 
@@ -445,7 +445,7 @@ def match_cost_functions_and_eq_net(net, boundary_buses, eq_type):
                 for pc in net[cost_elm].itertuples():
                     new_idx = net[pc.et].index[
                         net[pc.et].origin_id == pc.et_origin_id].values
-                    net[cost_elm].element[pc.Index] = new_idx[0]
+                    net[cost_elm].loc[pc.Index, 'element'] = new_idx[0]
             net[cost_elm] = net[cost_elm].drop(columns=["bus", "et_origin_id", "origin_idx", "origin_seq"])
 
 
@@ -511,7 +511,7 @@ def adaptation_phase_shifter(net, v_boundary, p_boundary):
                                 net[e].to_bus[i] = hb
                         elif e == "trafo":
                             if net[e].hv_bus[i] == lb:
-                                net[e].hv_bus[i] = hb
+                                net[e].loc[i, 'hv_bus'] = hb
                             else:
                                 net[e].lv_bus[i] = hb
                         elif e == "trafo3w":
@@ -524,7 +524,7 @@ def adaptation_phase_shifter(net, v_boundary, p_boundary):
                         elif e in ["bus", "load", "sgen", "gen", "shunt", "ward", "xward"]:
                             pass
                         else:
-                            net[e].bus[i] = hb
+                            net[e].loc[i, 'bus'] = hb
             pp.create_transformer_from_parameters(net, hb, lb, 1e5,
                                                   net.bus.vn_kv[hb]*(1-vm_errors[idx]),
                                                   net.bus.vn_kv[lb],

--- a/pandapower/grid_equivalents/rei_generation.py
+++ b/pandapower/grid_equivalents/rei_generation.py
@@ -317,7 +317,7 @@ def _create_net_zpbn(net, boundary_buses, all_internal_buses, all_external_buses
         else:
             if elm == "gen" and bus in net.ext_grid.bus.values and \
                     net.ext_grid.in_service[net.ext_grid.bus == bus].values[0]:
-                net_zpbn[elm].name[elm_idx] = str(net.ext_grid.name[
+                net_zpbn[elm].loc[elm_idx, 'name'] = str(net.ext_grid.name[
                     net.ext_grid.bus == bus].values[0]) + "-" + net_zpbn[elm].name[elm_idx]
                 ext_grid_cols = list(set(elm_org.columns) & set(net.ext_grid.columns) - \
                     {"name", "bus", "p_mw", "sn_mva", "in_service", "scaling"})
@@ -326,7 +326,7 @@ def _create_net_zpbn(net, boundary_buses, all_internal_buses, all_external_buses
             else:
                 names = elm_org.name[elm_org.bus == bus].values
                 names = [str(n) for n in names]
-                net_zpbn[elm].name[elm_idx] = "//".join(names) + "-" + net_zpbn[elm].name[elm_idx]
+                net_zpbn[elm].loc[elm_idx, 'name'] = "//".join(names) + "-" + net_zpbn[elm].name[elm_idx]
                 if len(names) > 1:
                     net_zpbn[elm].loc[elm_idx, list(other_cols_number)] = \
                         elm_org[list(other_cols_number)][elm_org.bus == bus].sum(axis=0)
@@ -361,10 +361,10 @@ def _create_net_zpbn(net, boundary_buses, all_internal_buses, all_external_buses
     for cost_elm in ["poly_cost", "pwl_cost"]:
         if len(net[cost_elm]):
             df = net_zpbn[cost_elm].copy()
-            df.et[(df.et == "ext_grid") &
-                  (~df.bus.isin(boundary_buses))] = "gen"
-            df.et[(df.et.isin(["storage", "dcline"]) &
-                             (~df.bus.isin(boundary_buses)))] = "load"
+            df.loc[(df.et == "ext_grid") &
+                  (~df.bus.isin(boundary_buses)), 'et'] = "gen"
+            df.loc[(df.et.isin(["storage", "dcline"]) &
+                             (~df.bus.isin(boundary_buses))), 'et'] = "load"
 
             logger.debug("During the equivalencing, also in polt_cost, " +
                          "storages and dclines are treated as loads, and" +
@@ -400,7 +400,7 @@ def _create_net_zpbn(net, boundary_buses, all_internal_buses, all_external_buses
                                 df.element[pc_idx[0]] = idx
                                 df = df.drop(pc_idx[1:])
                             elif len(pc_idx) == 1:
-                                df.element[pc_idx[0]] = idx
+                                df.loc[pc_idx[0], 'element'] = idx
             net_zpbn[cost_elm] = df
 
     drop_and_edit_cost_functions(net_zpbn, [], False, True, False)
@@ -704,5 +704,5 @@ def _integrate_power_elements_connected_with_switch_buses(net, net_external, all
             else:  # There ars some "external" elements connected with bus-bus switches.
                    # They will be aggregated.
                 elm1 = connected_elms[0]
-                net[elm].bus[connected_elms] = net[elm].bus[elm1]
-                net_external[elm].bus[connected_elms] = net_external[elm].bus[elm1]
+                net[elm].loc[connected_elms, 'bus'] = net[elm].bus[elm1]
+                net_external[elm].loc[connected_elms, 'bus'] = net_external[elm].bus[elm1]

--- a/pandapower/grid_equivalents/ward_generation.py
+++ b/pandapower/grid_equivalents/ward_generation.py
@@ -39,12 +39,12 @@ def _calculate_ward_and_impedance_parameters(Ybus_eq, bus_lookups, show_computin
         for j in range(nb_b_buses_ppc):
             if j > i:
                 if np.abs(params[i, j]) > 1e-10:
-                    impedance_parameter.from_bus[k] = b_buses_pd[i]
-                    impedance_parameter.to_bus[k] = b_buses_pd[j]
-                    impedance_parameter.rft_pu[k] = (-1 / params[i, j]).real
-                    impedance_parameter.xft_pu[k] = (-1 / params[i, j]).imag
-                    impedance_parameter.rtf_pu[k] = (-1 / params[j, i]).real
-                    impedance_parameter.xtf_pu[k] = (-1 / params[j, i]).imag
+                    impedance_parameter.loc[k, 'from_bus'] = b_buses_pd[i]
+                    impedance_parameter.loc[k, 'to_bus'] = b_buses_pd[j]
+                    impedance_parameter.loc[k, 'rft_pu'] = (-1 / params[i, j]).real
+                    impedance_parameter.loc[k, 'xft_pu'] = (-1 / params[i, j]).imag
+                    impedance_parameter.loc[k, 'rtf_pu'] = (-1 / params[j, i]).real
+                    impedance_parameter.loc[k, 'xtf_pu'] = (-1 / params[j, i]).imag
                     k += 1
                 else:
                     impedance_parameter = impedance_parameter[:-1]
@@ -173,9 +173,9 @@ def _replace_external_area_by_wards(net_external, bus_lookups, ward_parameter_no
     eq_power.q_mvar -= \
         pd.concat([net_external.res_ext_grid.q_mvar, net_external.res_gen.q_mvar[slack_gen]])
     for bus in eq_power.bus:
-        net_external.ward.ps_mw[net_external.ward.bus==bus] = \
+        net_external.ward.loc[net_external.ward.bus==bus, 'ps_mw'] = \
             eq_power.p_mw[eq_power.bus==bus].values
-        net_external.ward.qs_mvar[net_external.ward.bus==bus] = \
+        net_external.ward.loc[net_external.ward.bus==bus, 'qs_mvar'] = \
             eq_power.q_mvar[eq_power.bus==bus].values
 
     net_external.poly_cost = net_external.poly_cost[0:0]
@@ -257,9 +257,9 @@ def _replace_external_area_by_xwards(net_external, bus_lookups, xward_parameter_
     eq_power.q_mvar -= \
         pd.concat([net_external.res_ext_grid.q_mvar, net_external.res_gen.q_mvar[slack_gen]])
     for bus in eq_power.bus:
-        net_external.xward.ps_mw[net_external.xward.bus==bus] = \
+        net_external.xward.loc[net_external.xward.bus==bus, 'ps_mw'] = \
             eq_power.p_mw[eq_power.bus==bus].values
-        net_external.xward.qs_mvar[net_external.xward.bus==bus] = \
+        net_external.xward.loc[net_external.xward.bus==bus, 'qs_mvar'] = \
             eq_power.q_mvar[eq_power.bus==bus].values
 
     net_external.poly_cost=net_external.poly_cost[0:0]

--- a/pandapower/groups.py
+++ b/pandapower/groups.py
@@ -972,7 +972,7 @@ def set_group_reference_column(net, index, reference_column, element_type=None):
                 net[et][reference_column] = pd.Series([None]*net[et].shape[0], dtype=object)
             if pd.api.types.is_object_dtype(net[et][reference_column]):
                 idxs = net[et].index[net[et][reference_column].isnull()]
-                net[et][reference_column].loc[idxs] = ["%s_%i_%s" % (et, idx, str(
+                net[et].loc[idxs, reference_column] = ["%s_%i_%s" % (et, idx, str(
                     uuid.uuid4())) for idx in idxs]
 
             # determine duplicated values which would corrupt Groups functionality

--- a/pandapower/protection/utility_functions.py
+++ b/pandapower/protection/utility_functions.py
@@ -112,12 +112,12 @@ def create_sc_bus(net_copy, sc_line_id, sc_fraction):
     # check if switches are connected to the line and set the switches to new lines
     for switch_id in net.switch.index:
         if (aux_line.from_bus == net.switch.bus[switch_id]) & (net.switch.element[switch_id] == sc_line_id):
-            net.switch.element[switch_id] = sc_line1
+            net.switch.loc[switch_id, 'element'] = sc_line1
         elif (aux_line.to_bus == net.switch.bus[switch_id]) & (net.switch.element[switch_id] == sc_line_id):
             net.switch.element[switch_id] = sc_line2
 
     # set geodata for new bus
-    net.bus.geo.loc[max_idx_bus + 1] = None
+    net.bus.loc[max_idx_bus + 1, 'geo'] = None
 
     x1, y1 = _get_coords_from_bus_idx(net, aux_line.from_bus)[0]
     x2, y2 = _get_coords_from_bus_idx(net, aux_line.to_bus)[0]

--- a/pandapower/shortcircuit/results.py
+++ b/pandapower/shortcircuit/results.py
@@ -91,8 +91,8 @@ def _get_bus_results(net, ppc, ppc_0, bus):
         # in trafo3w, we add very high numbers (1e10) as impedances to block current
         # here, we need to replace such high values by np.inf
         baseZ = ppc_0["bus"][ppc_index, BASE_KV] ** 2 / ppc_0["baseMVA"]
-        net.res_bus_sc["xk0_ohm"].loc[net.res_bus_sc["xk0_ohm"]/baseZ > 1e9] = np.inf
-        net.res_bus_sc["rk0_ohm"].loc[net.res_bus_sc["rk0_ohm"]/baseZ > 1e9] = np.inf
+        net.res_bus_sc.loc[net.res_bus_sc["xk0_ohm"]/baseZ > 1e9, "xk0_ohm"] = np.inf
+        net.res_bus_sc.loc[net.res_bus_sc["rk0_ohm"]/baseZ > 1e9, "rk0_ohm"] = np.inf
     else:
         net.res_bus_sc["ikss_ka"] = ppc["bus"][ppc_index, IKSS1] + ppc["bus"][ppc_index, IKSS2]
         net.res_bus_sc["skss_mw"] = ppc["bus"][ppc_index, SKSS]
@@ -106,8 +106,8 @@ def _get_bus_results(net, ppc, ppc_0, bus):
     net.res_bus_sc["xk_ohm"] = ppc["bus"][ppc_index, X_EQUIV_OHM]
     # if for some reason (e.g. contribution of ext_grid set close to 0) we used very high values for rk, xk, we replace them by np.inf
     baseZ = ppc["bus"][ppc_index, BASE_KV] ** 2 / ppc["baseMVA"]
-    net.res_bus_sc["rk_ohm"].loc[net.res_bus_sc["rk_ohm"] / baseZ > 1e9] = np.inf
-    net.res_bus_sc["xk_ohm"].loc[net.res_bus_sc["xk_ohm"] / baseZ > 1e9] = np.inf
+    net.res_bus_sc.loc[net.res_bus_sc["rk_ohm"] / baseZ > 1e9, "rk_ohm"] = np.inf
+    net.res_bus_sc.loc[net.res_bus_sc["xk_ohm"] / baseZ > 1e9, "xk_ohm"] = np.inf
 
     net.res_bus_sc = net.res_bus_sc.loc[bus, :]
 

--- a/pandapower/test/api/test_group.py
+++ b/pandapower/test/api/test_group.py
@@ -428,7 +428,7 @@ def test_elements_connected_to_group():
     pp.create_switches(net, [0]*2, [10, 11], "b", closed=[True, False])
     net.load.at[0, "in_service"] = False
     net.line.at[4, "in_service"] = False
-    net.bus.in_service.loc[[3, 9]] = False
+    net.bus.loc[[3, 9], 'in_service'] = False
 
     # create group
     index = pp.create_group(net, ["bus", "line", "switch"], [[0], [net.line.index[-1]], [6, 7]])

--- a/pandapower/test/control/test_continuous_tap_control.py
+++ b/pandapower/test/control/test_continuous_tap_control.py
@@ -162,7 +162,7 @@ def test_continuous_tap_control_vectorized_lv():
         pp.create_transformer(net, hv, lv, "63 MVA 110/20 kV")
         pp.create_load(net, lv, 25*(lv-8), 25*(lv-8) * 0.4)
     pp.set_user_pf_options(net, init='dc', calculate_voltage_angles=True)
-    net.trafo.tap_side.iloc[3:] = "lv"
+    net.trafo.loc[3:, 'tap_side'] = "lv"
     tol = 1e-4
     # --- run loadflow
     pp.runpp(net)
@@ -200,7 +200,8 @@ def test_continuous_tap_control_vectorized_hv():
         pp.create_transformer(net, hv, lv, "63 MVA 110/20 kV")
         pp.create_load(net, hv, 2.5*(hv-8), 2.5*(hv-8) * 0.4)
     pp.set_user_pf_options(net, init='dc', calculate_voltage_angles=True)
-    net.trafo.tap_side.iloc[3:] = "lv"
+    net.trafo.loc[3:, 'tap_side'] = "lv"
+    print(net.trafo.tap_side.index)
     tol = 1e-4
     # --- run loadflow
     pp.runpp(net)

--- a/pandapower/test/control/test_discrete_tap_control.py
+++ b/pandapower/test/control/test_discrete_tap_control.py
@@ -294,7 +294,7 @@ def test_discrete_tap_control_vectorized_lv():
         pp.create_transformer(net, hv, lv, "63 MVA 110/20 kV")
         pp.create_load(net, lv, 25*(lv-8), 25*(lv-8) * 0.4)
     pp.set_user_pf_options(net, init='dc', calculate_voltage_angles=True)
-    net.trafo.tap_side.iloc[3:] = "lv"
+    net.trafo.loc[3:, 'tap_side'] = "lv"
     # --- run loadflow
     pp.runpp(net)
     assert not all(_vm_in_desired_area(net, 1.01, 1.03, "lv"))  # there should be something
@@ -332,7 +332,7 @@ def test_discrete_tap_control_vectorized_hv():
         pp.create_transformer(net, hv, lv, "63 MVA 110/20 kV")
         pp.create_load(net, hv, 2.5*(hv-8), 2.5*(hv-8) * 0.4)
     pp.set_user_pf_options(net, init='dc', calculate_voltage_angles=True)
-    net.trafo.tap_side.iloc[3:] = "lv"
+    net.trafo.loc[3:, 'tap_side'] = "lv"
     # --- run loadflow
     pp.runpp(net)
     assert not all(_vm_in_desired_area(net, 1.01, 1.03, "hv"))  # there should be something

--- a/pandapower/test/grid_equivalents/test_get_equivalent.py
+++ b/pandapower/test/grid_equivalents/test_get_equivalent.py
@@ -239,7 +239,7 @@ def test_basic_usecases():
 def test_case9_with_slack_generator_in_external_net():
     net = pp.networks.case9()
     idx = pp.replace_ext_grid_by_gen(net)
-    net.gen.slack.loc[idx] = True
+    net.gen.loc[idx, 'slack'] = True
     pp.runpp(net)
 
     # since the only slack is in the external_buses, we expect get_equivalent() to move the slack

--- a/pandapower/test/grid_equivalents/test_grid_equivalents_auxiliary.py
+++ b/pandapower/test/grid_equivalents/test_grid_equivalents_auxiliary.py
@@ -38,7 +38,7 @@ def test_drop_internal_branch_elements():
 
 def test_trafo_phase_shifter():
     net = pp.networks.create_cigre_network_mv(with_der="pv_wind")
-    net.trafo.shift_degree[0] = 150
+    net.trafo.loc[0, 'shift_degree'] = 150
     pp.runpp(net)
     net_eq = pp.grid_equivalents.get_equivalent(net, "rei", [4, 8], [0],
                                                 retain_original_internal_indices=True)
@@ -102,11 +102,11 @@ def test_drop_measurements_and_controllers():
 
 def test_check_network():
     net = pp.networks.case9()
-    net.bus.in_service[5] = False
+    net.bus.loc[5, 'in_service'] = False
     pp.runpp(net)
     _check_network(net)
 
-    net.bus.in_service[5] = True
+    net.bus.loc[5, 'in_service'] = True
     pp.runpp(net)
     pp.create_bus(net, net.bus.vn_kv.values[0])
     pp.create_bus(net, net.bus.vn_kv.values[0])

--- a/pandapower/test/loadflow/test_runpp.py
+++ b/pandapower/test/loadflow/test_runpp.py
@@ -898,8 +898,8 @@ def test_storage_pf():
     res_gen_beh = runpp_with_consistency_checks(net)
     res_ll_stor = net["res_line"].loading_percent.iloc[0]
 
-    net["storage"].in_service.iloc[0] = False
-    net["sgen"].in_service.iloc[1] = True
+    net["storage"].loc[0, 'in_service'] = False
+    net["sgen"].loc[1, 'in_service'] = True
 
     runpp_with_consistency_checks(net)
     res_ll_sgen = net["res_line"].loading_percent.iloc[0]
@@ -908,15 +908,15 @@ def test_storage_pf():
 
     # test load behaviour
     pp.create_load(net, b1, p_mw=0.01, in_service=False)
-    net["storage"].in_service.iloc[0] = True
-    net["storage"].p_mw.iloc[0] = 0.01
-    net["sgen"].in_service.iloc[1] = False
+    net["storage"].loc[0, 'in_service'] = True
+    net["storage"].loc[0, 'p_mw'] = 0.01
+    net["sgen"].loc[1, 'in_service'] = False
 
     res_load_beh = runpp_with_consistency_checks(net)
     res_ll_stor = net["res_line"].loading_percent.iloc[0]
 
-    net["storage"].in_service.iloc[0] = False
-    net["load"].in_service.iloc[1] = True
+    net["storage"].loc[0, 'in_service'] = False
+    net["load"].loc[1, 'in_service'] = True
 
     runpp_with_consistency_checks(net)
     res_ll_load = net["res_line"].loading_percent.iloc[0]

--- a/pandapower/test/loadflow/test_scenarios.py
+++ b/pandapower/test/loadflow/test_scenarios.py
@@ -475,11 +475,11 @@ def test_generator_as_slack():
     res_bus = net.res_bus.vm_pu.values
 
     pp.create_gen(net, b1, p_mw=0.1, vm_pu=1.02, slack=True)
-    net.ext_grid.in_service.iloc[0] = False
+    net.ext_grid.loc[0, 'in_service'] = False
     pp.runpp(net)
     assert np.allclose(res_bus, net.res_bus.vm_pu.values)
 
-    net.gen.slack.iloc[0] = False
+    net.gen.loc[0, 'slack'] = False
     with pytest.raises(UserWarning):
         pp.runpp(net)
 

--- a/pandapower/test/opf/test_basic.py
+++ b/pandapower/test/opf/test_basic.py
@@ -643,10 +643,10 @@ def test_storage_opf():
     pp.create_poly_cost(net, 1, "load", cp1_eur_per_mw=-3)
 
     # test storage generator behaviour
-    net["storage"].in_service.iloc[0] = True
-    net["storage"].p_mw.iloc[0] = -0.025
-    net["sgen"].in_service.iloc[1] = False
-    net["load"].in_service.iloc[1] = False
+    net["storage"].loc[0, 'in_service'] = True
+    net["storage"].loc[0, 'p_mw'] = -0.025
+    net["sgen"].loc[1, 'in_service'] = False
+    net["load"].loc[1, 'in_service'] = False
 
     pp.runopp(net)
     assert net["OPF_converged"]
@@ -655,10 +655,10 @@ def test_storage_opf():
     res_stor_q_mvar = net["res_storage"].q_mvar.iloc[0]
     res_cost_stor = net["res_cost"]
 
-    net["storage"].in_service.iloc[0] = False
-    net["storage"].p_mw.iloc[0] = -0.025
-    net["sgen"].in_service.iloc[1] = True
-    net["load"].in_service.iloc[1] = False
+    net["storage"].loc[0, 'in_service'] = False
+    net["storage"].loc[0, 'p_mw'] = -0.025
+    net["sgen"].loc[1, 'in_service'] = True
+    net["load"].loc[1, 'in_service'] = False
 
     pp.runopp(net)
     assert net["OPF_converged"]
@@ -673,17 +673,17 @@ def test_storage_opf():
     assert np.isclose(res_cost_stor, res_cost_sgen)
 
     # test storage load behaviour
-    net["storage"].in_service.iloc[0] = True
-    net["storage"].p_mw.iloc[0] = 0.025
-    net["storage"].max_p_mw.iloc[0] = 0.025
-    net["storage"].min_p_mw.iloc[0] = 0
-    net["storage"].max_q_mvar.iloc[0] = 0.025
-    net["storage"].min_q_mvar.iloc[0] = -0.025
+    net["storage"].loc[0, 'in_service'] = True
+    net["storage"].loc[0, 'p_mw'] = 0.025
+    net["storage"].loc[0, 'max_p_mw'] = 0.025
+    net["storage"].loc[0, 'min_p_mw'] = 0
+    net["storage"].loc[0, 'max_q_mvar'] = 0.025
+    net["storage"].loc[0, 'min_q_mvar'] = -0.025
     # gencost for storages: positive costs in pandapower per definition
     # --> storage gencosts are similar to sgen gencosts (make_objective.py, l.128ff. and l.185ff.)
-    net["poly_cost"].cp1_eur_per_mw.iloc[2] = net.poly_cost.cp1_eur_per_mw.iloc[4]
-    net["sgen"].in_service.iloc[1] = False
-    net["load"].in_service.iloc[1] = False
+    net["poly_cost"].loc[2, 'cp1_eur_per_mw'] = net.poly_cost.cp1_eur_per_mw.iloc[4]
+    net["sgen"].loc[1, 'in_service'] = False
+    net["load"].loc[1, 'in_service'] = False
 
     pp.runopp(net)
     assert net["OPF_converged"]
@@ -692,10 +692,10 @@ def test_storage_opf():
     res_stor_q_mvar = net["res_storage"].q_mvar.iloc[0]
     res_cost_stor = net["res_cost"]
 
-    net["storage"].in_service.iloc[0] = False
-    net["storage"].p_mw.iloc[0] = 0.025
-    net["sgen"].in_service.iloc[1] = False
-    net["load"].in_service.iloc[1] = True
+    net["storage"].loc[0, 'in_service'] = False
+    net["storage"].loc[0, 'p_mw'] = 0.025
+    net["sgen"].loc[1, 'in_service'] = False
+    net["load"].loc[1, 'in_service'] = True
 
     pp.runopp(net)
     assert net["OPF_converged"]
@@ -745,8 +745,8 @@ def test_in_service_controllables():
     pp.create_poly_cost(net, 1, "sgen", cp1_eur_per_mw=1)
     pp.create_poly_cost(net, 1, "load", cp1_eur_per_mw=-1)
 
-    net["sgen"].in_service.iloc[1] = False
-    net["load"].in_service.iloc[1] = False
+    net["sgen"].loc[1, 'in_service'] = False
+    net["load"].loc[1, 'in_service'] = False
 
     pp.runopp(net)
     assert net["OPF_converged"]

--- a/pandapower/test/opf/test_cost_consistency.py
+++ b/pandapower/test/opf/test_cost_consistency.py
@@ -49,7 +49,7 @@ def test_contingency_sgen(base_net):
     #                   | \
     #                   |  \
 
-    net.pwl_cost.points.loc[pwl] = [(0, net.sgen.max_p_mw.at[0], -1)]
+    net.pwl_cost.at[pwl, 'points'] = [(0, net.sgen.max_p_mw.at[0], -1)]
     pp.runopp(net)
 
     assert isclose(net.res_cost, -net.res_sgen.p_mw.at[0], atol=1e-4)
@@ -99,7 +99,7 @@ def test_contingency_load(base_net):
     #    p_min_mw       |\
     #                   | \
     #                   |  \
-    net.pwl_cost.points.iloc[0] = [(0, net.gen.max_p_mw.at[0], -1)]
+    net.pwl_cost.at[0, 'points'] = [(0, net.gen.max_p_mw.at[0], -1)]
     pp.runopp(net)
 
     assert isclose(net.res_cost, -net.res_gen.p_mw.at[0], atol=1e-3)
@@ -149,7 +149,7 @@ def test_contingency_gen(base_net):
     #    p_min_mw       |\
     #                   | \
     #                   |  \
-    net.pwl_cost.points.iloc[0] =  [(0, net.gen.max_p_mw.at[0], -1)]
+    net.pwl_cost.at[0, 'points'] =  [(0, net.gen.max_p_mw.at[0], -1)]
     pp.runopp(net)
 
     assert isclose(net.res_cost, -net.res_gen.p_mw.at[0], atol=1e-3)

--- a/pandapower/test/opf/test_opf_cigre.py
+++ b/pandapower/test/opf/test_opf_cigre.py
@@ -35,10 +35,10 @@ def test_opf_cigre():
     net.sgen["min_q_mvar"] = -0.01
     net.sgen["controllable"] = True
     net.load["controllable"] = False
-    net.sgen.in_service[net.sgen.bus == 4] = False
-    net.sgen.in_service[net.sgen.bus == 6] = False
-    net.sgen.in_service[net.sgen.bus == 8] = False
-    net.sgen.in_service[net.sgen.bus == 9] = False
+    net.sgen.loc[net.sgen.bus == 4, 'in_service'] = False
+    net.sgen.loc[net.sgen.bus == 6, 'in_service'] = False
+    net.sgen.loc[net.sgen.bus == 8, 'in_service'] = False
+    net.sgen.loc[net.sgen.bus == 9, 'in_service'] = False
 
     # run OPF
     pp.runopp(net)

--- a/pandapower/test/shortcircuit/test_iec60909_4.py
+++ b/pandapower/test/shortcircuit/test_iec60909_4.py
@@ -463,11 +463,11 @@ def test_iec_60909_4_1ph():
 
 def test_detect_power_station_units():
     net = iec_60909_4()
-    net.gen.power_station_trafo.loc[:] = None
+    net.gen.loc[:, 'power_station_trafo'] = None
 
     detect_power_station_unit(net)
     assert np.all(net.gen.power_station_trafo.values[[0, 1]] == np.array([0, 1]))
-    net.gen.power_station_trafo.loc[:] = None
+    net.gen.loc[:, 'power_station_trafo'] = None
 
     detect_power_station_unit(net, mode="trafo")
     assert np.all(net.gen.power_station_trafo.values[[0, 1]] == np.array([0, 1]))

--- a/pandapower/test/toolbox/test_grid_modification.py
+++ b/pandapower/test/toolbox/test_grid_modification.py
@@ -869,8 +869,8 @@ def test_repl_to_line_with_switch():
                     pp.create_switch(net, bus=bus, element=REPL, closed=False, et="l", type="LBS")
 
             # calculate runpp with REPL
-            net.line.in_service.loc[testindex] = False
-            net.line.in_service.loc[REPL] = True
+            net.line.loc[testindex, 'in_service'] = False
+            net.line.loc[REPL, 'in_service'] = True
             pp.runpp(net)
 
             fbus_repl = net.res_bus.loc[fbus]
@@ -882,9 +882,9 @@ def test_repl_to_line_with_switch():
             # get ne line impedances
             new_idx = pp.repl_to_line(net, testindex, std, in_service=True)
             # activate new idx line
-            net.line.in_service.loc[REPL] = False
-            net.line.in_service.loc[testindex] = True
-            net.line.in_service.loc[new_idx] = True
+            net.line.loc[REPL, 'in_service'] = False
+            net.line.loc[testindex, 'in_service'] = True
+            net.line.loc[new_idx, 'in_service'] = True
             pp.runpp(net)
             # compare lf results
             fbus_ne = net.res_bus.loc[fbus]
@@ -902,9 +902,9 @@ def test_repl_to_line_with_switch():
             assert np.isclose(qloss_repl, qloss_ne)
 
             # and reset to unreinforced state again
-            net.line.in_service.loc[testindex] = True
-            net.line.in_service.loc[new_idx] = False
-            net.line.in_service.loc[REPL] = False
+            net.line.loc[testindex, 'in_service'] = True
+            net.line.loc[new_idx, 'in_service'] = False
+            net.line.loc[REPL, 'in_service'] = False
 
 
 def test_merge_parallel_line():


### PR DESCRIPTION
This PR removes many warnings:

```
FutureWarning: ChainedAssignmentError: behaviour will change in pandas 3.0!
  You are setting values through chained assignment. Currently this works in certain cases, but when using Copy-on-Write (which will become the default behaviour in pandas 3.0) this will never work to update the original DataFrame or Series, because the intermediate object on which we are setting values will behave as a copy.
  A typical example is when you are setting values in a column of a DataFrame, like:
  
  df["col"][row_indexer] = value
  
  Use `df.loc[row_indexer, "col"] = values` instead, to perform the assignment in a single step and ensure this keeps updating the original `df`.
  
  See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
```
Where possible `loc `was used. Where the values ​​to set were a list `at` was used.
