### PR TITLE
Copy array element to standard python scalar

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Change Log
 
 [upcoming release] - 2024-..-..
 -------------------------------
+- [FIXED] copy array element to standard python scalar
 - [ADDED] creating series capacitor added in pf to pp converter
 - [FIXED] using loc to remove the warning
 - [FIXED] replacing deprecated H and A from scipy.sparse.csc_matrix

--- a/pandapower/test/opf/test_pp_vs_pm.py
+++ b/pandapower/test/opf/test_pp_vs_pm.py
@@ -77,7 +77,7 @@ def test_case5_pm_pd2ppc():
     net["_options"]["mode"] = "opf"
     ppc = _pd2ppc(net)
     # check which one is the ref bus in ppc
-    ref_idx = int(ppc[0]["bus"][:, BUS_I][ppc[0]["bus"][:, BUS_TYPE] == REF])
+    ref_idx = int(ppc[0]["bus"][:, BUS_I][ppc[0]["bus"][:, BUS_TYPE] == REF].item())
     vmax = ppc[0]["bus"][ref_idx, VMAX]
     vmin = ppc[0]["bus"][ref_idx, VMIN]
 
@@ -87,7 +87,7 @@ def test_case5_pm_pd2ppc():
     # run pd2ppc with ext_grd controllable = True
     net.ext_grid["controllable"] = True
     ppc = _pd2ppc(net)
-    ref_idx = int(ppc[0]["bus"][:, BUS_I][ppc[0]["bus"][:, BUS_TYPE] == REF])
+    ref_idx = int(ppc[0]["bus"][:, BUS_I][ppc[0]["bus"][:, BUS_TYPE] == REF].item())
     vmax = ppc[0]["bus"][ref_idx, VMAX]
     vmin = ppc[0]["bus"][ref_idx, VMIN]
 
@@ -102,7 +102,7 @@ def test_case5_pm_pd2ppc():
     assert net.ext_grid["in_service"].values.dtype == bool
 
     ppc = _pd2ppc(net)
-    ref_idx = int(ppc[0]["bus"][:, BUS_I][ppc[0]["bus"][:, BUS_TYPE] == REF])
+    ref_idx = int(ppc[0]["bus"][:, BUS_I][ppc[0]["bus"][:, BUS_TYPE] == REF].item())
 
     vmax1 = ppc[0]["bus"][ref_idx, VMAX]
     vmin1 = ppc[0]["bus"][ref_idx, VMIN]


### PR DESCRIPTION
This PR removes warnings:

`
DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)`

Copy array element to standard python scalar. If the array is larger than one element, raise an error.