### PR TITLE
Feature/optional vk updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Change Log
 
 [upcoming release] - 2024-..-..
 -------------------------------
+- [ADDED] A switch to disable updating the vk and vkr values for trafo3w
 - [FIXED] cast the column to the correct type before assigning values
 - [FIXED] replacement for deprecated namespaces scipy.sparse.csc and scipy.sparse.csr
 - [FIXED] copy array element to standard python scalar

--- a/pandapower/diagnostic.py
+++ b/pandapower/diagnostic.py
@@ -8,7 +8,6 @@ import copy
 import pandas as pd
 import numpy as np
 import pandapower as pp
-from pandapower import replace_xward_by_ward
 
 try:
     import pandaplan.core.pplog as logging
@@ -21,7 +20,7 @@ from functools import partial
 from pandapower.auxiliary import (LoadflowNotConverged, OPFNotConverged, ControllerNotConverged,
                                   NetCalculationNotConverged)
 from pandapower.run import runpp
-from pandapower.toolbox import get_connected_elements
+from pandapower.toolbox import get_connected_elements, replace_xward_by_ward
 from pandapower.diagnostic_reports import diagnostic_report
 
 # separator between log messages

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -21,7 +21,7 @@ import numpy as np
 import pandas.errors
 from deepdiff.diff import DeepDiff
 from packaging.version import Version
-from pandapower import __version__
+from pandapower._version import __version__
 import networkx
 import numpy
 import geojson

--- a/pandapower/networks/ieee_europen_lv_asymmetric.py
+++ b/pandapower/networks/ieee_europen_lv_asymmetric.py
@@ -5,7 +5,7 @@
 
 import os
 import pandapower as pp
-from pandapower import pp_dir
+from pandapower.__init__ import pp_dir
 
 
 def ieee_european_lv_asymmetric(scenario="on_peak_566", **kwargs):

--- a/pandapower/networks/lv_schutterwald.py
+++ b/pandapower/networks/lv_schutterwald.py
@@ -9,7 +9,7 @@ import os
 import pandapower as pp
 import pandapower.topology as top
 import pandapower.plotting.geo as geo
-from pandapower import pp_dir
+from pandapower.__init__ import pp_dir
 
 
 def lv_schutterwald(separation_by_sub=False, include_heat_pumps=False, **kwargs):

--- a/pandapower/networks/mv_oberrhein.py
+++ b/pandapower/networks/mv_oberrhein.py
@@ -10,8 +10,7 @@ import numpy as np
 
 import pandapower as pp
 import pandapower.topology as top
-import pandapower.plotting.geo as geo
-from pandapower import pp_dir
+from pandapower.__init__ import pp_dir
 
 
 def mv_oberrhein(scenario="load", cosphi_load=0.98, cosphi_pv=1.0, include_substations=False,

--- a/pandapower/networks/power_system_test_cases.py
+++ b/pandapower/networks/power_system_test_cases.py
@@ -8,7 +8,8 @@ import os
 
 import pandapower as pp
 import pandapower.toolbox
-from pandapower import pp_dir
+from pandapower.file_io import from_json
+from pandapower.__init__ import pp_dir
 import pandapower.plotting.geo as geo
 
 
@@ -61,7 +62,7 @@ def _change_ref_bus(net, ref_bus_idx, ext_grid_p=0):
 
 
 def sorted_from_json(path, **kwargs):
-    net = pp.from_json(path, **kwargs)
+    net = from_json(path, **kwargs)
     for elm in pandapower.toolbox.pp_elements():
         net[elm].sort_index(inplace=True)
     return net

--- a/pandapower/pd2ppc.py
+++ b/pandapower/pd2ppc.py
@@ -93,7 +93,7 @@ def _check_slack_at_vsc_bus(ppci):
                                   "this configuration is not implemented.")
 
 
-def _pd2ppc(net, sequence=None):
+def _pd2ppc(net, sequence=None, **kwargs):
     """
     Converter Flow:
         1. Create an empty pypower datatructure
@@ -153,8 +153,10 @@ def _pd2ppc(net, sequence=None):
         # Calculates ppc0 branch impedances from branch elements
         _build_branch_ppc_zero(net, ppc)
     else:
+        # get config if trafo3w vk and vkr values should be recalculated
+        update_vk_values = kwargs.get("update_vk_values", True)
         # Calculates ppc1/ppc2 branch impedances from branch elements
-        _build_branch_ppc(net, ppc)
+        _build_branch_ppc(net, ppc, update_vk_values)
     _build_branch_dc_ppc(net, ppc)
 
     _build_tcsc_ppc(net, ppc, mode)

--- a/pandapower/pd2ppc_zero.py
+++ b/pandapower/pd2ppc_zero.py
@@ -11,7 +11,7 @@ import numpy as np
 from itertools import product
 
 import pandapower.auxiliary as aux
-from pandapower import DC_NONE, DC_BUS_TYPE
+from pandapower.pypower.idx_bus_dc import DC_NONE, DC_BUS_TYPE
 from pandapower.build_bus import _build_bus_ppc, _build_svc_ppc, _build_ssc_ppc, _build_vsc_ppc, _build_bus_dc_ppc
 from pandapower.build_gen import _build_gen_ppc
 # from pandapower.pd2ppc import _ppc2ppci, _init_ppc

--- a/pandapower/plotting/collections.py
+++ b/pandapower/plotting/collections.py
@@ -36,8 +36,7 @@ except ImportError:
     class TextPath:  # so that the test does not fail
         pass
 
-from pandapower import pandapowerNet
-from pandapower.auxiliary import soft_dependency_error
+from pandapower.auxiliary import soft_dependency_error, pandapowerNet
 from pandapower.plotting.patch_makers import load_patches, node_patches, gen_patches, \
     sgen_patches, ext_grid_patches, trafo_patches, storage_patches, ward_patches, xward_patches, vsc_patches
 from pandapower.plotting.plotting_toolbox import _rotate_dim2, coords_from_node_geodata, \

--- a/pandapower/plotting/geo.py
+++ b/pandapower/plotting/geo.py
@@ -18,7 +18,7 @@ import pandas as pd
 from numpy import array
 
 import pandapower
-from pandapower.auxiliary import soft_dependency_error
+from pandapower.auxiliary import soft_dependency_error, pandapowerNet
 
 # get logger (same as in simple_plot)
 try:
@@ -231,7 +231,7 @@ def convert_epsg_bus_geodata(net, epsg_in=4326, epsg_out=31467):
     return net
 
 
-def convert_crs(net: pandapower.pandapowerNet or 'pandapipes.pandapipesNet', epsg_in=4326, epsg_out=31467):
+def convert_crs(net: pandapowerNet or 'pandapipes.pandapipesNet', epsg_in=4326, epsg_out=31467):
     """
     This function works for pandapowerNet and pandapipesNet. Documentation will refer to names from pandapower.
     Converts bus and line geodata in net from epsg_in to epsg_out
@@ -285,7 +285,7 @@ def convert_crs(net: pandapower.pandapowerNet or 'pandapipes.pandapipesNet', eps
 
 
 def dump_to_geojson(
-        net: pandapower.pandapowerNet or 'pandapipes.pandapipesNet',
+        net: pandapowerNet or 'pandapipes.pandapipesNet',
         nodes: Union[bool, List[int]] = False,
         branches: Union[bool, List[int]] = False,
         switches: Union[bool,  List[int]] = False,
@@ -501,7 +501,7 @@ def dump_to_geojson(
 
 
 def convert_geodata_to_geojson(
-        net: pandapower.pandapowerNet or 'pandapipes.pandapipesNet',
+        net: pandapowerNet or 'pandapipes.pandapipesNet',
         delete: bool = True,
         lonlat: bool = False) -> None:
     """
@@ -566,7 +566,7 @@ def convert_geodata_to_geojson(
 
 
 def convert_gis_to_geojson(
-        net: pandapower.pandapowerNet or 'pandapipes.pandapipesNet',
+        net: pandapowerNet or 'pandapipes.pandapipesNet',
         delete: bool = True) -> None:
     """
     Transforms the bus and line geodataframes of a net into a geojson object.

--- a/pandapower/plotting/plotly/mapbox_plot.py
+++ b/pandapower/plotting/plotly/mapbox_plot.py
@@ -91,7 +91,7 @@ def geo_data_to_latlong(net, projection):
 
 
 def set_mapbox_token(token):
-    from pandapower import pp_dir
+    from pandapower.__init__ import pp_dir
     path = os.path.join(pp_dir, "plotting", "plotly")
     filename = os.path.join(path, 'mapbox_token.txt')
     with open(filename, "w") as mapbox_file:
@@ -99,7 +99,7 @@ def set_mapbox_token(token):
 
 
 def _get_mapbox_token():
-    from pandapower import pp_dir
+    from pandapower.__init__ import pp_dir
     path = os.path.join(pp_dir, "plotting", "plotly")
     filename = os.path.join(path, 'mapbox_token.txt')
     with open(filename, "r") as mapbox_file:

--- a/pandapower/powerflow.py
+++ b/pandapower/powerflow.py
@@ -81,6 +81,7 @@ def _recycled_powerflow(net, **kwargs):
     algorithm = options["algorithm"]
     ac = options["ac"]
     recycle = options["recycle"]
+    update_vk_values = kwargs.get("update_vk_values", True)
     ppci = {"bus": net["_ppc"]["internal"]["bus"],
             "gen": net["_ppc"]["internal"]["gen"],
             "branch": net["_ppc"]["internal"]["branch"],
@@ -104,9 +105,9 @@ def _recycled_powerflow(net, **kwargs):
         # update trafo in branch and Ybus
         lookup = net._pd2ppc_lookups["branch"]
         if "trafo" in lookup:
-            _calc_trafo_parameter(net, ppc)
+            _calc_trafo_parameter(net, ppc, update_vk_values=update_vk_values)
         if "trafo3w" in lookup:
-            _calc_trafo3w_parameter(net, ppc)
+            _calc_trafo3w_parameter(net, ppc, update_vk_values=update_vk_values)
 
     if "gen" in recycle and recycle["gen"]:
         # updates the ppc["gen"] part

--- a/pandapower/powerflow.py
+++ b/pandapower/powerflow.py
@@ -59,7 +59,7 @@ def _powerflow(net, **kwargs):
                            "branch": array([], dtype=int64), "branch_dc": array([], dtype=int64)}
 
     # convert pandapower net to ppc
-    ppc, ppci = _pd2ppc(net)
+    ppc, ppci = _pd2ppc(net, **kwargs)
 
     # store variables
     net["_ppc"] = ppc

--- a/pandapower/pypower/newtonpf.py
+++ b/pandapower/pypower/newtonpf.py
@@ -14,19 +14,18 @@ import numpy as np
 from numpy import float64, array, angle, sqrt, square, exp, linalg, conj, r_, inf, arange, zeros, \
     max, zeros_like, column_stack, flatnonzero, nan_to_num
 from pandapower.pypower.bustypes import bustypes_dc
-from pandapower.pypower.idx_brch_dc import DC_BR_R, DC_PF, DC_IF, DC_PT, DC_IT, DC_BR_STATUS
+from pandapower.pypower.idx_brch_dc import DC_BR_R, DC_PF, DC_IF, DC_PT, DC_IT, DC_BR_STATUS, DC_F_BUS, DC_T_BUS
 from scipy.sparse import csr_matrix, eye, vstack
 from scipy.sparse.linalg import spsolve
 
 from pandapower.auxiliary import _sum_by_group
-from pandapower import VSC_STATUS, VSC_BUS, VSC_INTERNAL_BUS, DC_F_BUS, DC_T_BUS
 from pandapower.pf.iwamoto_multiplier import _iwamoto_step
 from pandapower.pf.makeYbus_facts import makeYbus_svc, makeYft_tcsc, calc_y_svc_pu, \
     makeYbus_ssc_vsc, make_Ybus_facts, make_Yft_facts
-from pandapower.pypower.idx_bus_dc import DC_PD, DC_VM, DC_BUS_TYPE, DC_NONE, DC_BUS_I, DC_REF, DC_P, DC_B2B, DC_BASE_KV
+from pandapower.pypower.idx_bus_dc import DC_PD, DC_VM, DC_BUS_TYPE, DC_NONE, DC_BUS_I, DC_REF, DC_P
 from pandapower.pypower.idx_vsc import VSC_CONTROLLABLE, VSC_MODE_AC, VSC_VALUE_AC, VSC_MODE_DC, VSC_VALUE_DC, VSC_R, \
     VSC_X, VSC_Q, VSC_P, VSC_BUS_DC, VSC_P_DC, VSC_MODE_AC_SL, VSC_MODE_AC_V, VSC_MODE_AC_Q, VSC_MODE_DC_P, \
-    VSC_MODE_DC_V, VSC_INTERNAL_BUS_DC, VSC_R_DC, VSC_PL_DC
+    VSC_MODE_DC_V, VSC_INTERNAL_BUS_DC, VSC_R_DC, VSC_PL_DC, VSC_STATUS, VSC_BUS, VSC_INTERNAL_BUS
 from pandapower.pypower.makeSbus import makeSbus
 from pandapower.pf.create_jacobian import create_jacobian_matrix, get_fastest_jacobian_function
 from pandapower.pypower.idx_gen import PG

--- a/pandapower/results_bus.py
+++ b/pandapower/results_bus.py
@@ -7,7 +7,6 @@
 import numpy as np
 import pandas as pd
 from numpy import complex128
-from pandapower import VSC_INTERNAL_BUS
 from pandapower.auxiliary import _sum_by_group, sequence_to_phase, _sum_by_group_nvals
 from pandapower.pypower.idx_bus import VM, VA, PD, QD, LAM_P, LAM_Q, BASE_KV, NONE, BS, BUS_TYPE, BUS_I
 from pandapower.pypower.idx_bus_dc import DC_VM, DC_BUS_TYPE, DC_NONE, DC_PD, DC_BUS_I

--- a/pandapower/results_bus.py
+++ b/pandapower/results_bus.py
@@ -15,7 +15,7 @@ from pandapower.pypower.idx_gen import PG, QG
 from pandapower.build_bus import _get_motor_pq, _get_symmetric_pq_of_unsymetric_element
 from pandapower.pypower.idx_ssc import SSC_X_CONTROL_VM, SSC_X_CONTROL_VA, SSC_Q, SSC_INTERNAL_BUS
 from pandapower.pypower.idx_svc import SVC_THYRISTOR_FIRING_ANGLE, SVC_Q, SVC_X_PU
-from pandapower.pypower.idx_vsc import VSC_Q, VSC_P, VSC_P_DC, VSC_BUS_DC, VSC_INTERNAL_BUS_DC
+from pandapower.pypower.idx_vsc import VSC_Q, VSC_P, VSC_P_DC, VSC_BUS_DC, VSC_INTERNAL_BUS_DC, VSC_INTERNAL_BUS
 
 try:
     import pandaplan.core.pplog as logging

--- a/pandapower/run.py
+++ b/pandapower/run.py
@@ -222,7 +222,7 @@ def runpp(net, algorithm='nr', calculate_voltage_angles=True, init="auto",
 
         **tdpf_update_r_theta** (bool, True) - TDPF parameter, whether to update R_Theta in Newton-Raphson or to assume a constant R_Theta (either from net.line.r_theta, if set, or from a calculation based on the thermal model of Ngoko et.al.)
 
-        **update_vk_values** (bool, True) - If True vk_ and vkr_ values of trafo3w are recalculated based on characteristics, otherwise the values from the table are used. Can improve performance for large models.
+        **update_vk_values** (bool, True) - If True vk and vkr values of trafo3w are recalculated based on characteristics, otherwise the values from the table are used. Can improve performance for large models.
     """
 
     # if dict 'user_pf_options' is present in net, these options overrule the net._options

--- a/pandapower/run.py
+++ b/pandapower/run.py
@@ -222,6 +222,7 @@ def runpp(net, algorithm='nr', calculate_voltage_angles=True, init="auto",
 
         **tdpf_update_r_theta** (bool, True) - TDPF parameter, whether to update R_Theta in Newton-Raphson or to assume a constant R_Theta (either from net.line.r_theta, if set, or from a calculation based on the thermal model of Ngoko et.al.)
 
+        **update_vk_values** (bool, True) - If True vk_ and vkr_ values of trafo3w are recalculated based on characteristics, otherwise the values from the table are used. Can improve performance for large models.
     """
 
     # if dict 'user_pf_options' is present in net, these options overrule the net._options

--- a/pandapower/test/__init__.py
+++ b/pandapower/test/__init__.py
@@ -1,5 +1,5 @@
 import os
-from pandapower import pp_dir
+from pandapower.__init__ import pp_dir
 
 test_path = os.path.join(pp_dir, 'test')
 tutorials_path = os.path.join(os.path.dirname(pp_dir), 'tutorials')

--- a/pandapower/test/loadflow/test_runpp.py
+++ b/pandapower/test/loadflow/test_runpp.py
@@ -578,6 +578,17 @@ def test_bsfw_algorithm_with_branch_loops():
     assert np.allclose(va_nr, va_alg)
 
 
+def test_disabling_vk_update():
+    net = example_simple()
+    pp.runpp(net, calculate_voltage_angles="auto")
+    net.trafo.loc[:, "vk_percent"] = 100.
+    net.trafo.loc[:, "vkr_percent"] = 100.
+
+    pp.runpp(net, calculate_voltage_angles="auto", update_vk_values=False)
+
+    assert net.res_trafo.loc[0, 'loading_percent'] > 70.
+
+
 @pytest.mark.slow
 def test_pypower_algorithms_iter():
     alg_to_test = ['fdbx', 'fdxb', 'gs']

--- a/pandapower/timeseries/read_batch_results.py
+++ b/pandapower/timeseries/read_batch_results.py
@@ -2,7 +2,7 @@ from cmath import rect
 
 from numpy import real, vectorize, deg2rad, maximum, sqrt, empty, zeros, nan, int64
 
-from pandapower import F_BUS, T_BUS
+from pandapower.pypower.idx_brch import F_BUS, T_BUS
 from pandapower.pf.pfsoln_numba import calc_branch_flows_batch
 from pandapower.pypower.idx_bus import BASE_KV
 from pandapower.results_branch import _get_trafo3w_lookups

--- a/pandapower/timeseries/run_time_series.py
+++ b/pandapower/timeseries/run_time_series.py
@@ -7,8 +7,7 @@ from collections.abc import Iterable
 import tqdm
 
 import pandapower as pp
-from pandapower import LoadflowNotConverged, OPFNotConverged
-from pandapower.auxiliary import ControllerNotConverged, NetCalculationNotConverged
+from pandapower.auxiliary import ControllerNotConverged
 from pandapower.control import prepare_run_ctrl, run_control
 from pandapower.control.util.diagnostic import control_diagnostic
 from pandapower.timeseries.output_writer import OutputWriter

--- a/pandapower/toolbox/element_selection.py
+++ b/pandapower/toolbox/element_selection.py
@@ -12,7 +12,7 @@ from packaging.version import Version
 
 from pandapower.auxiliary import ets_to_element_types
 
-from pandapower import __version__
+from pandapower._version import __version__
 
 try:
     import pandaplan.core.pplog as logging


### PR DESCRIPTION
Solves Issue #2393, makes updating the vk_ and vkr_ values of trafo3w optional (normally enabled) since for large networks with many trafo3w using characteristics this is unnecesseray and costs a lot of computational power to do essentially nothing.