### PR TITLE
Replacing deprecated in1d with isin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Change Log
 
 [upcoming release] - 2024-..-..
 -------------------------------
+- [FIXED] replacing deprecated in1d with isin
 - [FIXED] cast the column to the correct type before assigning values
 - [FIXED] replacement for deprecated namespaces scipy.sparse.csc and scipy.sparse.csr
 - [FIXED] copy array element to standard python scalar

--- a/pandapower/build_branch.py
+++ b/pandapower/build_branch.py
@@ -966,8 +966,8 @@ def _branches_with_oos_buses(net, ppc, dc=False):
         t_bus = line_buses[:, 1]
 
         # determine on which side of the line the oos bus is located
-        mask_from = np.in1d(f_bus, bus_oos)
-        mask_to = np.in1d(t_bus, bus_oos)
+        mask_from = np.isin(f_bus, bus_oos)
+        mask_to = np.isin(t_bus, bus_oos)
 
         mask_and = mask_to & mask_from
         if np.any(mask_and):
@@ -986,7 +986,7 @@ def _branches_with_oos_buses(net, ppc, dc=False):
             ls_info = np.zeros((n_oos_buses_at_lines, 3), dtype=np.int64)
             ls_info[:, 0] = mask_to[mask_or] & ~mask_from[mask_or]
             ls_info[:, 1] = oos_buses_at_lines
-            ls_info[:, 2] = np.nonzero(np.in1d(net[line_table].index, line_is_idx[mask_or]))[0]
+            ls_info[:, 2] = np.nonzero(np.isin(net[line_table].index, line_is_idx[mask_or]))[0]
 
             # ls_info = list(map(mapfunc,
             #               line_switches["bus"].values,

--- a/pandapower/pf/run_bfswpf.py
+++ b/pandapower/pf/run_bfswpf.py
@@ -73,8 +73,8 @@ def _make_bibc_bcbv(bus, branch, graph):
 
         # if multiple networks get subnetwork branches
         if norefs > 1:
-            branches_sub_mask = (np.in1d(branches_arr[:, 0], buses_ordered_bfs) &
-                                 np.in1d(branches_arr[:, 1], buses_ordered_bfs))
+            branches_sub_mask = (np.isin(branches_arr[:, 0], buses_ordered_bfs) &
+                                 np.isin(branches_arr[:, 1], buses_ordered_bfs))
             branches = np.sort(branches_arr[branches_sub_mask, :], axis=1)
         else:
             branches = np.sort(branches_arr, axis=1)
@@ -252,7 +252,7 @@ def _bfswpf(DLF, bus, gen, branch, baseMVA, Ybus, Sbus, V0, ref, pv, pq, buses_o
     Ysh = _makeYsh_bfsw(bus, branch, baseMVA)
 
     # detect generators on PV buses which have status ON
-    gen_pv = np.in1d(gen[:, GEN_BUS], pv) & (gen[:, GEN_STATUS] > 0)
+    gen_pv = np.isin(gen[:, GEN_BUS], pv) & (gen[:, GEN_STATUS] > 0)
     qg_lim = np.zeros(ngen, dtype=bool)  # initialize generators which violated Q limits
 
     Iinj = np.conj(Sbus / V0) - Ysh * V0   # Initial current injections

--- a/pandapower/shortcircuit/ppc_conversion.py
+++ b/pandapower/shortcircuit/ppc_conversion.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 
 
 def _get_is_ppci_bus(net, bus):
-    is_bus = bus[np.in1d(bus, net._is_elements_final["bus_is_idx"])]
+    is_bus = bus[np.isin(bus, net._is_elements_final["bus_is_idx"])]
     ppci_bus = np.unique(net._pd2ppc_lookups["bus"][is_bus])
     return ppci_bus
 

--- a/pandapower/shortcircuit/toolbox.py
+++ b/pandapower/shortcircuit/toolbox.py
@@ -77,10 +77,10 @@ def detect_power_station_unit(net, mode="auto",
             # Check parallel trafo
             if not len(np.intersect1d(connected_bus_at_lv_side, trafo_lv_bus)) == 1:
                 raise UserWarning("Failure in power station units detection! Parallel trafos on generator detected!")
-            if np.in1d(required_gen_bus, gen_bus_at_lv_side).sum() > 1:
+            if np.isin(required_gen_bus, gen_bus_at_lv_side).sum() > 1:
                 logger.info("More than 1 gen detected at the lv side of a power station trafo! Will not be considered as power station unit")
                 continue
-            net.gen.loc[np.in1d(net.gen.bus.values, gen_bus_at_lv_side),
+            net.gen.loc[np.isin(net.gen.bus.values, gen_bus_at_lv_side),
                         "power_station_trafo"] = t_ix
 
 

--- a/pandapower/test/loadflow/test_results.py
+++ b/pandapower/test/loadflow/test_results.py
@@ -6,7 +6,7 @@ import os
 import pandas as pd
 import pytest
 import numpy as np
-from numpy import in1d, isnan, isclose, allclose
+from numpy import isin, isnan, isclose, allclose
 
 import pandapower as pp
 import pandapower.control
@@ -815,7 +815,7 @@ def test_shunt_split(result_test_network, v_tol=1e-6, i_tol=1e-6, s_tol=5e-3, l_
 def test_open(result_test_network):
     net = result_test_network
     buses = net.bus[net.bus.zone == "two_open_switches_on_deactive_line"]
-    lines = net['line'][in1d(net['line'].from_bus, buses.index) | in1d(net['line'].to_bus, buses.index)]
+    lines = net['line'][isin(net['line'].from_bus, buses.index) | isin(net['line'].to_bus, buses.index)]
 
     assert isnan(net['res_line'].at[lines.index[1], "i_ka"])
 

--- a/pandapower/topology/create_graph.py
+++ b/pandapower/topology/create_graph.py
@@ -148,7 +148,7 @@ def create_nxgraph(net, respect_switches=True, include_lines=True, include_imped
             mask = (net.switch.et.values == "l") & open_sw
             if mask.any():
                 open_lines = net.switch.element.values[mask]
-                open_lines_mask = np.in1d(indices[:, INDEX], open_lines)
+                open_lines_mask = np.isin(indices[:, INDEX], open_lines)
                 in_service &= ~open_lines_mask
 
         parameter[:, WEIGHT] = line.length_km.values
@@ -221,7 +221,7 @@ def create_nxgraph(net, respect_switches=True, include_lines=True, include_imped
             mask = (net.switch.et.values == "t") & open_sw
             if mask.any():
                 open_trafos = net.switch.element.values[mask]
-                open_trafos_mask = np.in1d(indices[:, INDEX], open_trafos)
+                open_trafos_mask = np.isin(indices[:, INDEX], open_trafos)
                 in_service &= ~open_trafos_mask
 
         if calc_branch_impedances:
@@ -264,7 +264,7 @@ def create_nxgraph(net, respect_switches=True, include_lines=True, include_imped
 
             if respect_switches and len(open_trafo3w):
                 for BUS in [F_BUS, T_BUS]:
-                    open_switch = np.in1d(indices[:, INDEX] + indices[:, BUS] * 1j,
+                    open_switch = np.isin(indices[:, INDEX] + indices[:, BUS] * 1j,
                                           open_trafo3w)
                     in_service &= ~open_switch
             if calc_branch_impedances:


### PR DESCRIPTION
This PR removes many warnings:  `DeprecationWarning: in1d is deprecated. Use np.isin instead.`


`isin` in contrast to `in1d`: return the same shape as [`element`](https://numpy.org/doc/stable/reference/generated/numpy.isin.html#numpy.isin)

```
element = np.array([[0, 1, 2, 5, 33], [3, 7, 12, 15, 10]])
test_elements = [0, 2, 15]
```
isin
`print(np.isin(element, test_elements))`

Output
```
[[ True False  True False False]
 [False False False  True False]]
```
in1d
`print(np.in1d(element, test_elements))`

Output
`[ True False  True False False False False False  True False]`


