### PR TITLE
BugFix in PF converter for station controller

### DIFF
--- a/pandapower/converter/powerfactory/pp_import_functions.py
+++ b/pandapower/converter/powerfactory/pp_import_functions.py
@@ -2132,7 +2132,7 @@ def create_sgen_sym(net, item, pv_as_slack, pf_variable_p_gen, dict_net, export_
 
         pstac = item.c_pstac
         # "None" if station controller is not available
-        if pstac is not None and export_ctrl:
+        if pstac is not None and not pstac.outserv and export_ctrl:
             if pstac.i_droop:
                 av_mode = 'constq'
             else:
@@ -3139,7 +3139,7 @@ def create_stactrl(net, item):
             distribution.append(item.cvqq / 100)
         i = i + 1
 
-    if item.imode != 0:
+    if item.imode > 2:
         raise NotImplementedError(f"{item}: reactive power distribution {item.imode=} not implemented")
 
     phase = item.i_phase

--- a/pandapower/converter/powerfactory/pp_import_functions.py
+++ b/pandapower/converter/powerfactory/pp_import_functions.py
@@ -1920,7 +1920,7 @@ def create_sgen_genstat(net, item, pv_as_slack, pf_variable_p_gen, dict_net, is_
 
         # create...
         pstac = item.c_pstac  # "None" if station controller is not available
-        if pstac is not None and export_ctrl:
+        if pstac is not None and not pstac.outserv and export_ctrl:
             if pstac.i_droop:
                 av_mode = 'constq'
             else:


### PR DESCRIPTION
During import from pandapower, the status of outserv of the coresponding station controller needed to be taken into account. Also, support of 2 imode for reactive power distribution were not considered. Changes now lead to better results during import from power factory