### PR TITLE
Copy array element to standard python scalar

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Change Log
 
 [upcoming release] - 2024-..-..
 -------------------------------
+- [FIXED] copy array element to standard python scalar
 - [FIXED] replacing deprecated in1d with isin
 - [ADDED] A switch to disable updating the vk and vkr values for trafo3w
 - [FIXED] cast the column to the correct type before assigning values

--- a/pandapower/estimation/state_estimation.py
+++ b/pandapower/estimation/state_estimation.py
@@ -333,7 +333,7 @@ class StateEstimation:
         self.logger.debug("Result of Chi^2 test:")
         self.logger.debug("Number of measurements: %d" % m)
         self.logger.debug("Number of state variables: %d" % n)
-        self.logger.debug("Performance index: %.2f" % J)
+        self.logger.debug("Performance index: %.2f" % J.item())
         self.logger.debug("Chi^2 test threshold: %.2f" % test_thresh)
 
         if J <= test_thresh:
@@ -421,7 +421,7 @@ class StateEstimation:
                 else:
                     self.logger.debug(
                         "Largest normalized residual test failed (%.1f > %.1f)."
-                        % (max(rN), rn_max_threshold))
+                        % (max(rN).item(), rn_max_threshold))
 
                     # Identify bad data: Determine index corresponding to max(rN):
                     idx_rN = np.argsort(rN, axis=0)[-1]

--- a/pandapower/grid_equivalents/rei_generation.py
+++ b/pandapower/grid_equivalents/rei_generation.py
@@ -261,7 +261,7 @@ def _create_net_zpbn(net, boundary_buses, all_internal_buses, all_external_buses
                                      sn_mva=Sn, index=max_sgen_idx+len(net_zpbn.sgen)+1)
         elif elm == "gen":
             vm_pu = v[key+"_vm_total"][v.ext_bus == int(re.findall(r"\d+", busstr)[0])].values.real
-            elm_idx = pp.create_gen(net_zpbn, i, float(P), float(vm_pu), name=key+"_rei_"+busstr,
+            elm_idx = pp.create_gen(net_zpbn, i, float(P), float(vm_pu.item()), name=key+"_rei_"+busstr,
                                     sn_mva=Sn, index=max_gen_idx+len(net_zpbn.gen)+1)
 
     # ---- match other columns

--- a/pandapower/test/control/test_discrete_tap_control.py
+++ b/pandapower/test/control/test_discrete_tap_control.py
@@ -39,13 +39,13 @@ def test_discrete_tap_control_lv():
 
     logger.info("case1: low voltage")
     logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
 
     # run control
     pp.runpp(net, run_control=True)
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
     assert net.trafo.tap_pos.at[0] ==  -1
 
     # increase voltage from 1.0 pu to 1.03 pu
@@ -56,13 +56,13 @@ def test_discrete_tap_control_lv():
 
     logger.info("case2: high voltage")
     logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
 
     # run control
     pp.runpp(net, run_control=True)
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
     assert net.trafo.tap_pos.at[0] == -2
     # reduce voltage from 1.03 pu to 0.949 pu
     net.ext_grid.vm_pu = 0.949
@@ -72,13 +72,13 @@ def test_discrete_tap_control_lv():
 
     logger.info("case2: high voltage")
     logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
 
     # run control
     pp.runpp(net, run_control=True)
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
     assert net.trafo.tap_pos.at[0] == 1
 
 
@@ -100,13 +100,13 @@ def test_discrete_tap_control_hv():
 
     logger.info("case1: low voltage")
     logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
 
     # run control
     pp.runpp(net, run_control=True)
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
     assert net.trafo.tap_pos.at[0] == 1
     # increase voltage from 1.0 pu to 1.03 pu
     net.ext_grid.vm_pu = 1.03
@@ -116,13 +116,13 @@ def test_discrete_tap_control_hv():
 
     logger.info("case2: high voltage")
     logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
 
     # run control
     pp.runpp(net, run_control=True)
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
     assert net.trafo.tap_pos.at[0] == 2
     # increase voltage from 1.0 pu to 1.03 pu
     net.ext_grid.vm_pu = 0.949
@@ -132,13 +132,13 @@ def test_discrete_tap_control_hv():
 
     logger.info("case2: high voltage")
     logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
 
     # run control
     pp.runpp(net, run_control=True)
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
     assert net.trafo.tap_pos.at[0] == -1
 
 
@@ -160,13 +160,13 @@ def test_discrete_tap_control_lv_from_tap_step_percent():
 
     logger.info("case1: low voltage")
     logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
 
     # run control
     pp.runpp(net, run_control=True)
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
     assert net.trafo.tap_pos.at[0] ==  -1
 
     # check if it changes the lower and upper limits
@@ -187,13 +187,13 @@ def test_discrete_tap_control_lv_from_tap_step_percent():
 
     logger.info("case2: high voltage")
     logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
 
     # run control
     pp.runpp(net, run_control=True)
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
     assert net.trafo.tap_pos.at[0] == -2
     # reduce voltage from 1.03 pu to 0.969 pu
     net.ext_grid.vm_pu = 0.969
@@ -203,13 +203,13 @@ def test_discrete_tap_control_lv_from_tap_step_percent():
 
     logger.info("case2: high voltage")
     logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
 
     # run control
     pp.runpp(net, run_control=True)
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
     assert net.trafo.tap_pos.at[0] == 1
 
 
@@ -231,13 +231,13 @@ def test_discrete_tap_control_hv_from_tap_step_percent():
 
     logger.info("case1: low voltage")
     logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
 
     # run control
     pp.runpp(net, run_control=True)
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
     assert net.trafo.tap_pos.at[0] ==  1
 
     # check if it changes the lower and upper limits
@@ -258,13 +258,13 @@ def test_discrete_tap_control_hv_from_tap_step_percent():
 
     logger.info("case2: high voltage")
     logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
 
     # run control
     pp.runpp(net, run_control=True)
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
     assert net.trafo.tap_pos.at[0] == 2
     # reduce voltage from 1.03 pu to 0.969 pu
     net.ext_grid.vm_pu = 0.969
@@ -274,13 +274,13 @@ def test_discrete_tap_control_hv_from_tap_step_percent():
 
     logger.info("case2: high voltage")
     logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
 
     # run control
     pp.runpp(net, run_control=True)
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values, net.trafo.tap_pos.values))
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
     assert net.trafo.tap_pos.at[0] == -1
 
 


### PR DESCRIPTION
This PR removes warnings:

` DeprecationWarning: Conversion of an array with ndim > 0 to a scalar is deprecated, and will error in future. Ensure you extract a single element from your array before performing this operation. (Deprecated NumPy 1.25.)`

Copy array element to standard python [scalar.](https://numpy.org/doc/stable/reference/generated/numpy.ndarray.item.html) If the array is larger than one element, raise an error.

Test to check:

```
pytest pandapower/test/control/test_discrete_tap_control.py::test_discrete_tap_control_lv
pytest pandapower/test/control/test_discrete_tap_control.py::test_discrete_tap_control_hv
pytest pandapower/test/control/test_discrete_tap_control.py::test_discrete_tap_control_lv_from_tap_step_percent
pytest pandapower/test/control/test_discrete_tap_control.py::test_discrete_tap_control_hv_from_tap_step_percent
pytest pandapower/test/estimation/test_wls_estimation.py::test_3bus_with_bad_data
pytest pandapower/test/estimation/test_wls_estimation.py::test_cigre_with_bad_data
pytest pandapower/test/grid_equivalents/test_get_equivalent.py
pytest pandapower/test/grid_equivalents/test_get_equivalent_networks.py
```