### PR TITLE
don't change pandas options when importing pandapower

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Change Log
 - [FIXED] Increasing geojson precision as the default precision might cause problems with pandahub
 - [ADDED] Add GeographicalRegion and SubGeographicalRegion names and ids to bus df in cim converter
 - [CHANGED] Capitalize first letter of columns busbar_id, busbar_name and substation_id in bus df for cim converter
+- [FIXED] Do not modify pandas options when importing pandapower
 
 [2.14.11] - 2024-07-08
 -------------------------------

--- a/pandapower/converter/cim/cim2pp/build_pp_net.py
+++ b/pandapower/converter/cim/cim2pp/build_pp_net.py
@@ -18,8 +18,6 @@ from ..other_classes import ReportContainer, Report, LogLevel, ReportCode
 
 logger = logging.getLogger('cim.cim2pp.build_pp_net')
 
-pd.set_option('display.max_columns', 900)
-pd.set_option('display.max_rows', 90000)
 sc = cim_tools.get_pp_net_special_columns_dict()
 
 


### PR DESCRIPTION
This fixes #1905 

When pandapower is imported, it changes the pandas options `display.max_rows` and `display.max_columns`, as the following example demonstrates:

```python
import pandas
pandas.get_option('display.max_rows')
# 60
pandas.get_option('display.max_columns')
# 0
import pandapower
pandas.get_option('display.max_rows')
# 90000
pandas.get_option('display.max_columns')
# 900
```

This is rather annoying especially since it often leads to long waiting time if one is printing a large DataFrame.

The reason are the following two lines in the file `pandapower/converter/cim/cim2pp/build_pp_net.py`:

```python
pd.set_option('display.max_columns', 900)
pd.set_option('display.max_rows', 90000)
```

The pull request removes those lines and fixes the problem.

```python
import pandas
pandas.get_option('display.max_rows')
# 60
pandas.get_option('display.max_columns')
# 0
import pandapower
pandas.get_option('display.max_rows')
# 60
pandas.get_option('display.max_columns')
# 0
```