### PR TITLE
Change default value of encoding argument in converter methods #2419

### DIFF
--- a/pandapower/converter/cim/cim2pp/from_cim.py
+++ b/pandapower/converter/cim/cim2pp/from_cim.py
@@ -94,7 +94,7 @@ def get_converter_classes():
     return converter_classes
 
 
-def from_cim(file_list: List[str] = None, encoding: str = 'utf-8', convert_line_to_switch: bool = False,
+def from_cim(file_list: List[str] = None, encoding: str = None, convert_line_to_switch: bool = False,
              line_r_limit: float = 0.1, line_x_limit: float = 0.1,
              repair_cim: Union[str, interfaces.CIMRepair] = None,
              repair_cim_class: Type[interfaces.CIMRepair] = None,
@@ -123,7 +123,7 @@ def from_cim(file_list: List[str] = None, encoding: str = 'utf-8', convert_line_
     if there are errors in the conversion. Default: True.
 
     :param file_list: The path to the CGMES files as a list.
-    :param encoding: The encoding from the files. Optional, default: utf-8
+    :param encoding: The encoding from the files. Optional, default: None
     :param convert_line_to_switch: Set this parameter to True to enable line -> switch conversion. All lines with a
         resistance lower or equal than line_r_limit or a reactance lower or equal than line_x_limit will become a
         switch. Optional, default: False

--- a/pandapower/converter/cim/cim_classes.py
+++ b/pandapower/converter/cim/cim_classes.py
@@ -34,14 +34,14 @@ class CimParser:
         self.file_names: Dict[str, str] = dict()
         self.report_container = ReportContainer()
 
-    def parse_files(self, file_list: List[str] or str = None, encoding: str = 'utf-8', prepare_cim_net: bool = False,
+    def parse_files(self, file_list: List[str] or str = None, encoding: str = None, prepare_cim_net: bool = False,
                     set_data_types: bool = False) -> CimParser:
         """
         Parse CIM XML files from a storage.
 
         :param file_list: The path to the CGMES files as a list. Note: The files need a FullModel to parse the
         CGMES profile. Optional, default: None.
-        :param encoding: The encoding from the files. Optional, default: utf-8
+        :param encoding: The encoding from the files. Optional, default: None
         :param prepare_cim_net: Set this parameter to True to prepare the parsed cim data according to the
         CimConverter. Optional, default: False
         :param set_data_types: Set this parameter to True to set the cim data types at the parsed data. Optional,


### PR DESCRIPTION
Fix for issue #2419, changes default value of "encoding" keyword argument to None for parse_files() and from_cim().