### PR TITLE
GA: fix docs_check job

### DIFF
--- a/.github/workflows/github_test_action.yml
+++ b/.github/workflows/github_test_action.yml
@@ -301,21 +301,13 @@ jobs:
           python -m pytest -W error --nbmake -n=auto --nbmake-timeout=900 "./tutorials"
 
   docs_check:
+    name: Sphinx docs check
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: [ '3.9' ]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+      - name: Check sphinx build
+        uses: ammaraskar/sphinx-action@7.4.7
         with:
-          python-version: ${{ matrix.python-version }}
-      - name: Check docs for Python ${{ matrix.python-version }}
-        uses: e2nIEE/sphinx-action@master
-        with:
-          pre-build-command: "apt update && apt upgrade -y && apt install -y build-essential gfortran cmake pkg-config libopenblas-dev;
-            python -m pip install --upgrade pip;
-            python -m pip install .[docs];"
+          pre-build-command: "python -m pip install uv && uv pip install .[docs] --system --link-mode=copy"
           build-command: "sphinx-build -b html . _build -W"
           docs-folder: "doc/"

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,0 @@
-sphinx>=5.3.0
-sphinx_rtd_theme>=1.1.1
-numpydoc>=1.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ Download = "https://pypi.org/project/pandapower/#files"
 Changelog = "https://github.com/e2nIEE/pandapower/blob/develop/CHANGELOG.rst"
 
 [project.optional-dependencies]
-docs = ["numpydoc", "matplotlib", "sphinx", "sphinx_rtd_theme", "sphinx-pyproject"]
+docs = ["numpydoc>=1.5.0", "matplotlib", "sphinx>=5.3.0", "sphinx_rtd_theme>=1.1.1", "sphinx-pyproject"]
 plotting = ["plotly>=3.1.1", "matplotlib", "igraph", "geopandas>=1.0"]
 test = ["pytest~=8.1", "pytest-xdist", "nbmake"]
 performance = ["ortools", "numba>=0.25", "lightsim2grid==0.9.0"]
@@ -68,7 +68,7 @@ converter = ["matpowercaseframes"]
 pgm = ["power-grid-model-io"]
 control = ["shapely"]
 all = [
-    "numpydoc", "sphinx", "sphinx_rtd_theme", "sphinx-pyproject",
+    "numpydoc>=1.5.0", "sphinx>=5.3.0", "sphinx_rtd_theme>=1.1.1", "sphinx-pyproject",
     "plotly>=3.1.1", "matplotlib", "igraph", "geopandas>=1.0",
     "pytest~=8.1", "pytest-xdist", "nbmake",
     "ortools", "numba>=0.25", "lightsim2grid==0.9.0",


### PR DESCRIPTION
The e2niee/sphinx-action clone (used to make sure documentation can be build) uses the [latest sphinxdoc/sphinx image](https://github.com/e2nIEE/sphinx-action/blob/1c785bcbb732cc38e1c573106af98332605f43ac/Dockerfile#L1) available. 

But one day that means running python 3.13, and numpy has no wheels for it yet, but to build them requires libraries missing in the python-slim base image, and that is how you end up installing the fortran compiler just to build docs and the whole thing takes 10 minutes to complete.

Switching sphinx-action back to upstream and pinning the sphinx image version to 7.4.7 (and python 3.12) makes the doc_test job complete in ~45s.

