### PR TITLE
plotly changed the interface and renamed the titlefont property.

### DIFF
--- a/pandapower/plotting/plotly/traces.py
+++ b/pandapower/plotting/plotly/traces.py
@@ -1111,7 +1111,7 @@ def draw_traces(traces, on_map=False, map_style='basic', showlegend=True, figsiz
     # setting Figure object
     fig = Figure(data=traces,  # edge_trace
                  layout=Layout(
-                     titlefont=dict(size=16),
+                     title_font=dict(size=16),
                      showlegend=showlegend,
                      autosize=(aspectratio == 'auto'),
                      hovermode='closest',


### PR DESCRIPTION
fix for plotly version 6