### PR TITLE
ADD: Extracting synchronous generator reactive power curve from CGMES data and adding gen characteristics table in net and add columnd id_characteristics in gen and sgen

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,9 @@ Change Log
 
 [upcoming release] - 2025-..-..
 -------------------------------
+
+- [ADDED] add three columns: id_q_capability_curve_table, reactive_capability_curve, curve_style in gen and sgen
+- [ADDED] cim2pp converter- import reactive power capability curve data synchronousMachinesCim16.py
 - [ADDED] cim2pp converter - export parameter "governorSCD" in additional column in gen table
 - [FIXED] a problem with create_nxgraph
 - [ADDED] parameter slack_as_gen for `from_ucte()` converter (changed the default behavior)

--- a/pandapower/converter/cim/cim2pp/build_pp_net.py
+++ b/pandapower/converter/cim/cim2pp/build_pp_net.py
@@ -17,7 +17,7 @@ from .. import cim_classes
 from .. import cim_tools
 from .. import pp_tools
 from ..other_classes import ReportContainer, Report, LogLevel, ReportCode
-from pandapower.control.util.auxiliary import create_q_capability_curve_characteristics_object
+#from pandapower.control.util.auxiliary import create_q_capability_curve_characteristics_object
 
 logger = logging.getLogger('cim.cim2pp.build_pp_net')
 
@@ -135,7 +135,7 @@ class CimConverter:
         self.classes_dict['powerTransformersCim16'](cimConverter=self).convert_power_transformers_cim16()
 
         # --------- create reactive power capability characteristics ---------
-        create_q_capability_curve_characteristics_object(self.net)
+        #create_q_capability_curve_characteristics_object(self.net)
 
         # create the geo coordinates
         if self.cim['gl']['Location'].index.size > 0 and self.cim['gl']['PositionPoint'].index.size > 0:

--- a/pandapower/converter/cim/cim2pp/build_pp_net.py
+++ b/pandapower/converter/cim/cim2pp/build_pp_net.py
@@ -17,6 +17,7 @@ from .. import cim_classes
 from .. import cim_tools
 from .. import pp_tools
 from ..other_classes import ReportContainer, Report, LogLevel, ReportCode
+from pandapower.control.util.auxiliary import create_q_capability_curve_characteristics_object
 
 logger = logging.getLogger('cim.cim2pp.build_pp_net')
 
@@ -112,7 +113,7 @@ class CimConverter:
         # --------- convert switches ---------
         self.classes_dict['switchesCim16'](cimConverter=self).convert_switches_cim16()
         # --------- convert loads ---------
-        self.classes_dict['energyConcumersCim16'](cimConverter=self).convert_energy_consumers_cim16()
+        self.classes_dict['energyConcumersCim16'](cimConverter=self).convert_energy_consumers_cim16()  #todo  correction of spelling mistake
         self.classes_dict['conformLoadsCim16'](cimConverter=self).convert_conform_loads_cim16()
         self.classes_dict['nonConformLoadsCim16'](cimConverter=self).convert_non_conform_loads_cim16()
         self.classes_dict['stationSuppliesCim16'](cimConverter=self).convert_station_supplies_cim16()
@@ -132,6 +133,9 @@ class CimConverter:
         self.classes_dict['equivalentInjectionsCim16'](cimConverter=self).convert_equivalent_injections_cim16()
         # --------- convert transformers ---------
         self.classes_dict['powerTransformersCim16'](cimConverter=self).convert_power_transformers_cim16()
+
+        # --------- create reactive power capability characteristics ---------
+        create_q_capability_curve_characteristics_object(self.net)
 
         # create the geo coordinates
         if self.cim['gl']['Location'].index.size > 0 and self.cim['gl']['PositionPoint'].index.size > 0:

--- a/pandapower/converter/cim/cim2pp/converter_classes/externalnetworks/externalNetworkInjectionsCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/externalnetworks/externalNetworkInjectionsCim16.py
@@ -42,6 +42,13 @@ class ExternalNetworkInjectionsCim16:
         eni_gens = eqssh_eni.loc[(eqssh_eni['slack_weight'] != ref_prio_min) & (eqssh_eni['controllable'])]
         eni_sgens = eqssh_eni.loc[~eqssh_eni['controllable']]
 
+        # create curve_dependency_table flag
+        if 'curve_dependency_table' not in eni_gens.columns:
+            eni_gens['curve_dependency_table'] = False
+        # create curve_dependency_table flag
+        if 'curve_dependency_table' not in eni_sgens.columns:
+            eni_sgens['curve_dependency_table'] = False
+
         self.cimConverter.copy_to_pp('ext_grid', eni_slacks)
         self.cimConverter.copy_to_pp('gen', eni_gens)
         self.cimConverter.copy_to_pp('sgen', eni_sgens)

--- a/pandapower/converter/cim/cim2pp/converter_classes/generators/energySourcesCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/generators/energySourcesCim16.py
@@ -24,6 +24,9 @@ class EnergySourceCim16:
         eqssh_energy_sources = self._prepare_energy_sources_cim16()
         es_slack = eqssh_energy_sources.loc[eqssh_energy_sources.vm_pu.notna()]
         es_sgen = eqssh_energy_sources.loc[eqssh_energy_sources.vm_pu.isna()]
+        # create curve_dependency_table flag
+        if 'curve_dependency_table' not in es_sgen.columns:
+            es_sgen['curve_dependency_table'] = False
         self.cimConverter.copy_to_pp('ext_grid', es_slack)
         self.cimConverter.copy_to_pp('sgen', es_sgen)
         # self._copy_to_pp('sgen', eqssh_energy_sources)

--- a/pandapower/converter/cim/cim2pp/converter_classes/generators/synchronousMachinesCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/generators/synchronousMachinesCim16.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import pandas as pd
+from numpy import where
 
 from pandapower.converter.cim import cim_tools
 from pandapower.converter.cim.cim2pp import build_pp_net
@@ -21,6 +22,9 @@ class SynchronousMachinesCim16:
         time_start = time.time()
         self.logger.info("Start converting SynchronousMachines.")
         eqssh_synchronous_machines = self._prepare_synchronous_machines_cim16()
+
+        #add synchronousmaschine characteristics table and id_characteristics_table
+        eqssh_synchronous_machines = self._create_gen_characteristics_table(eqssh_synchronous_machines);
 
         # convert the SynchronousMachines with voltage control to gens
         eqssh_sm_gens = eqssh_synchronous_machines.loc[(eqssh_synchronous_machines['mode'] == 'voltage') &
@@ -147,3 +151,47 @@ class SynchronousMachinesCim16:
             'minOperatingP': 'min_p_mw', 'maxOperatingP': 'max_p_mw', 'minQ': 'min_q_mvar', 'maxQ': 'max_q_mvar',
             'ratedPowerFactor': 'cos_phi', 'referencePriority': 'slack_weight'})
         return synchronous_machines
+
+    def _create_gen_characteristics_table(self, syn_gen_df_origin) -> pd.DataFrame:
+        eq = self.cimConverter.cim['eq']
+        if not eq['ReactiveCapabilityCurve'].empty and not eq['CurveData'].empty:
+            if 'id_q_capability_curve_table' not in syn_gen_df_origin.columns:
+                    syn_gen_df_origin['id_q_capability_curve_table'] = pd.Series(pd.NA, dtype="Int64")
+            if 'q_capability_curve_table' not in self.cimConverter.net.keys():
+                self.cimConverter.net['q_capability_curve_table'] = pd.DataFrame(
+                    columns=['id_capability_curve', 'p_mw', 'q_min_mvar', 'q_max_mvar'])
+
+            # get the curve data
+            curve_data = self.cimConverter.cim['eq']['ReactiveCapabilityCurve'][['rdfId', 'curveStyle']].rename(
+                columns={'rdfId': 'Curve', 'curveStyle': 'curve_style'})
+            curve_points = pd.merge(curve_data, self.cimConverter.cim['eq']['CurveData'][
+                ['rdfId', 'Curve', 'xvalue', 'y1value', 'y2value']], how='left', on='Curve')
+
+            curve_points['id_q_capability_curve_table'] = pd.factorize(curve_points['Curve'])[0]
+            curve_points['id_q_capability_curve_table'] = curve_points['id_q_capability_curve_table'].astype('Int64')
+            curve_points = curve_points.drop(columns=['rdfId']).rename(columns={'Curve': 'rdfId', 'xvalue': 'p_mw',
+                                                                                'y1value': 'q_min_mvar',
+                                                                                'y2value': 'q_max_mvar'})
+
+            # Move 'id_q_capability_curve_table' to the first column and save to net
+            curve_points = curve_points[
+                ['id_q_capability_curve_table'] + [col for col in curve_points.columns if
+                                                   col != 'id_q_capability_curve_table']]
+            self.cimConverter.net['q_capability_curve_table'] = curve_points
+            self.cimConverter.net['q_capability_curve_table'] = (self.cimConverter.net['q_capability_curve_table'].
+            drop(columns=['rdfId', 'curve_style']).rename(
+                columns={'id_q_capability_curve_table': 'id_q_capability_curve'}))
+
+            # Drop unnecessary columns and duplicate rdfId
+            curve_points = (
+                curve_points.drop(columns=['p_mw', 'q_min_mvar', 'q_max_mvar']).drop_duplicates(subset=['rdfId']).
+                rename(columns={'rdfId': 'InitialReactiveCapabilityCurve'}))
+
+            syn_gen_df_origin = syn_gen_df_origin.drop(columns=['id_q_capability_curve_table'])
+            syn_gen_df_origin = pd.merge(syn_gen_df_origin, curve_points, how='left',
+                                         on=['InitialReactiveCapabilityCurve'])
+
+            # create curve_dependency_table flag
+            if 'curve_dependency_table' not in syn_gen_df_origin.columns:
+                syn_gen_df_origin['curve_dependency_table'] = False
+        return syn_gen_df_origin

--- a/pandapower/converter/cim/cim_classes.py
+++ b/pandapower/converter/cim/cim_classes.py
@@ -236,7 +236,7 @@ class CimParser:
                 'NuclearGeneratingUnit': pd.DataFrame(columns=['rdfId', 'nominalP', 'minOperatingP', 'maxOperatingP', 'governorSCD']),
                 'RegulatingControl': pd.DataFrame(columns=['rdfId', 'name', 'mode', 'Terminal']),
                 'SynchronousMachine': pd.DataFrame(columns=[
-                    'rdfId', 'name', 'description', 'GeneratingUnit', 'EquipmentContainer', 'ratedU', 'ratedS', 'type',
+                    'rdfId', 'name', 'description', 'GeneratingUnit', 'EquipmentContainer', 'ratedU', 'ratedS', 'type', 'InitialReactiveCapabilityCurve',
                     'r2', 'x2', 'ratedPowerFactor', 'voltageRegulationRange', 'minQ', 'maxQ', 'RegulatingControl']),
                 'AsynchronousMachine': pd.DataFrame(columns=[
                     'rdfId', 'name', 'description', 'GeneratingUnit', 'ratedS', 'ratedU', 'ratedPowerFactor',
@@ -294,7 +294,11 @@ class CimParser:
                     'PowerSystemResource', 'positiveFlowIn']),
                 'AnalogValue': pd.DataFrame(columns=[
                     'rdfId', 'name', 'sensorAccuracy', 'MeasurementValueSource', 'Analog', 'value']),
-                'MeasurementValueSource': pd.DataFrame(columns=['rdfId', 'name'])
+                'MeasurementValueSource': pd.DataFrame(columns=['rdfId', 'name']),
+                'ReactiveCapabilityCurve': pd.DataFrame(columns=['rdfId', 'name', 'curveStyle', 'xUnit', 'y1Unit',
+                                                                 'y2Unit']),
+                'CurveData': pd.DataFrame(columns=['rdfId', 'Curve', 'xvalue', 'y1value', 'y2value'])
+
             }),
             'eq_bd': MappingProxyType({
                 'ConnectivityNode': pd.DataFrame(columns=['rdfId', 'name', 'ConnectivityNodeContainer']),
@@ -639,7 +643,7 @@ class CimParser:
                 'RegulatingControl': pd.DataFrame(columns=['rdfId', 'name', 'mode', 'Terminal']),
                 'SynchronousMachine': pd.DataFrame(columns=[
                     'rdfId', 'name', 'description', 'GeneratingUnit', 'EquipmentContainer', 'ratedU', 'ratedS', 'type',
-                    'ratedPowerFactor', 'minQ', 'maxQ', 'RegulatingControl']),
+                    'InitialReactiveCapabilityCurve','ratedPowerFactor', 'minQ', 'maxQ', 'RegulatingControl']),
                 'AsynchronousMachine': pd.DataFrame(columns=[
                     'rdfId', 'name', 'description', 'GeneratingUnit', 'ratedS', 'ratedU', 'ratedPowerFactor']),
                 'EnergySource': pd.DataFrame(columns=[
@@ -685,7 +689,10 @@ class CimParser:
                 'SeriesCompensator': pd.DataFrame(columns=[
                     'rdfId', 'name', 'description', 'BaseVoltage', 'r', 'x']),
                 'MeasurementValueSource': pd.DataFrame(columns=['rdfId', 'name']),
-                'PetersenCoil': pd.DataFrame(columns=['rdfId', 'name', 'description'])
+                'PetersenCoil': pd.DataFrame(columns=['rdfId', 'name', 'description']),
+                'ReactiveCapabilityCurve': pd.DataFrame(columns=['rdfId', 'name', 'curveStyle', 'xUnit', 'y1Unit',
+                                                                 'y2Unit']),
+                'CurveData': pd.DataFrame(columns=['rdfId', 'Curve', 'xvalue', 'y1value', 'y2value'])
             }),
             'eq_bd': MappingProxyType({
                 'ConnectivityNode': pd.DataFrame(columns=['rdfId', 'name', 'ConnectivityNodeContainer']),

--- a/pandapower/create.py
+++ b/pandapower/create.py
@@ -79,6 +79,9 @@ def create_empty_network(name="", f_hz=50., sn_mva=1, add_stdtypes=True):
                  ("q_mvar", "f8"),
                  ("sn_mva", "f8"),
                  ("scaling", "f8"),
+                 ('id_q_capability_curve_table', 'u4'),
+                 ('curve_dependency_table', 'bool'),
+                 ('curve_style', dtype(object)),
                  ("in_service", 'bool'),
                  ("type", dtype(object)),
                  ("current_source", "bool")],
@@ -142,6 +145,9 @@ def create_empty_network(name="", f_hz=50., sn_mva=1, add_stdtypes=True):
                 ("max_q_mvar", "f8"),
                 ("scaling", "f8"),
                 ("slack", "bool"),
+                ('id_q_capability_curve_table', 'u4'),
+                ('curve_dependency_table', 'bool'),
+                ('curve_style', dtype(object)),
                 ("in_service", 'bool'),
                 ("slack_weight", 'f8'),
                 ("type", dtype(object))],
@@ -4542,7 +4548,7 @@ def create_shunt(net, bus, q_mvar, p_mw=0., vn_kv=None, step=1, max_step=1, name
         **q_mvar** (float) - shunt reactive power in MVAr at v = 1.0 p.u. per step
 
     OPTIONAL:
-        **vn_kv** (float, None) - rated voltage of the shunt. Defaults to rated voltage of connected bus, since this \ 
+        **vn_kv** (float, None) - rated voltage of the shunt. Defaults to rated voltage of connected bus, since this \
             value is mandatory for powerflow calculations. If it is set to NaN it will be replaced by the bus vn_kv \
             during power flow
 

--- a/pandapower/create.py
+++ b/pandapower/create.py
@@ -9,7 +9,6 @@ from typing import Tuple, List, Union, Iterable
 import warnings
 
 import pandas as pd
-from numba import int64
 from numpy import nan, zeros, isnan, arange, dtype, isin, any as np_any, array, bool_, \
     all as np_all, float64, intersect1d, unique as uni
 from pandas import isnull
@@ -1408,7 +1407,7 @@ def create_sgen(net, bus, p_mw, q_mvar=0, sn_mva=nan, name=None, index=None,
     _set_value_if_not_nan(net, index, curve_dependency_table, "curve_dependency_table", "sgen",
                           dtype= bool_)
 
-    _set_value_if_not_nan(net, index, curve_style, "curve_style", "sgen")
+    _set_value_if_not_nan(net, index, curve_style, "curve_style", "sgen", dtype=object, default_val=None)
 
     _set_value_if_not_nan(net, index, rx, "rx", "sgen")  # rx is always required
     if np.isfinite(kappa):
@@ -1971,7 +1970,7 @@ def create_gen(net, bus, p_mw, vm_pu=1., sn_mva=nan, name=None, index=None, max_
     _set_value_if_not_nan(net, index, id_q_capability_curve_table, "id_q_capability_curve_table", "gen", dtype="Int64")
 
     # behaviour of reactive power capability curve
-    _set_value_if_not_nan(net, index, curve_style, "curve_style", "gen", dtype="string")
+    _set_value_if_not_nan(net, index, curve_style, "curve_style", "gen", dtype=object, default_val=None)
 
     _set_value_if_not_nan(net, index, curve_dependency_table, "curve_dependency_table", "gen", dtype=bool_)
 

--- a/pandapower/test/api/test_create.py
+++ b/pandapower/test/api/test_create.py
@@ -1571,6 +1571,9 @@ def test_create_sgens():
         p_mw=[0, 0, 1],
         q_mvar=0.0,
         controllable=[True, False, False],
+        id_q_capability_curve_table=[0, 1, 2],
+        curve_dependency_table=False,
+        curve_style=["straightLineYValues", "straightLineYValues", "straightLineYValues"],
         max_p_mw=0.2,
         min_p_mw=[0, 0.1, 0],
         max_q_mvar=0.2,
@@ -1602,6 +1605,9 @@ def test_create_sgens():
     assert all(net.sgen.rx.values == 0.4)
     assert all(net.sgen.current_source)
     assert all(net.sgen.test_kwargs == "dummy_string")
+    assert all(net.sgen.id_q_capability_curve_table.values == [0,1,2])
+    assert all(net.sgen.curve_style == "straightLineYValues")
+    assert all(net.sgen.curve_dependency_table == [False, False, False])
 
 
 def test_create_sgens_raise_errorexcept():
@@ -1674,6 +1680,9 @@ def test_create_gens():
         p_mw=[0, 0, 1],
         vm_pu=1.0,
         controllable=[True, False, False],
+        id_q_capability_curve_table=[0, 1, 2],
+        curve_dependency_table=False,
+        curve_style= ["straightLineYValues", "straightLineYValues", "straightLineYValues"],
         max_p_mw=0.2,
         min_p_mw=[0, 0.1, 0],
         max_q_mvar=0.2,
@@ -1707,7 +1716,9 @@ def test_create_gens():
     assert all(net.gen.rdss_pu.values == 0.1)
     assert all(net.gen.cos_phi.values == 1.0)
     assert all(net.gen.test_kwargs == "dummy_string")
-
+    assert all(net.gen.id_q_capability_curve_table.values == [0,1,2])
+    assert all(net.gen.curve_style == "straightLineYValues")
+    assert all(net.gen.curve_dependency_table == [False, False, False])
 
 def test_create_gens_raise_errorexcept():
     net = create_empty_network()
@@ -1773,7 +1784,6 @@ def test_create_gens_raise_errorexcept():
             cos_phi=1.0,
             index=g,
         )
-
 
 if __name__ == "__main__":
     pytest.main([__file__, "-xs"])


### PR DESCRIPTION
- Extracted synchronous generator reactive power curve data points from CGMES data
- Stored extracted data in the dataframe as Q capability curve table
- Added Q capability curve characteristics for gen and sgen in CIM2PP
- Changed the empty_network data structure
- Adjusted create_gen, create_gens, create_sgen, and create_sgens functions to support Q capability characteristics
@mrifraunhofer @panos-xenos 