### PR TITLE
[fix] DC loadflow after AC loadflow

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Change Log
 [upcoming release] - 2025-..-..
 -------------------------------
 
+- [FIXED] DC loadflow after AC loadflow, had ambiguous results still present in net
 - [ADDED] add three columns: id_q_capability_curve_table, reactive_capability_curve, curve_style in gen and sgen
 - [ADDED] cim2pp converter- import reactive power capability curve data synchronousMachinesCim16.py
 - [ADDED] cim2pp converter - export parameter "governorSCD" in additional column in gen table

--- a/pandapower/results_bus.py
+++ b/pandapower/results_bus.py
@@ -243,6 +243,9 @@ def write_pq_results_to_element(net, ppc, element, suffix=None):
         net[res_]["q_mvar"].values[:] = el_data[q_mvar].values * scaling * element_in_service
         if is_controllable:
             net[res_].loc[controlled_elements, "q_mvar"] = ppc["gen"][gen_idx, QG] * gen_sign
+    else:
+        net[res_]["q_mvar"].values[:] = np.nan
+
     return net
 
 


### PR DESCRIPTION
If an dc loadflow is run after an ac loadflow, "old" results are still present, even if they do not make sense.