### PR TITLE
Nets equal: flag to deal with geo data

### DIFF
--- a/pandapower/toolbox/comparison.py
+++ b/pandapower/toolbox/comparison.py
@@ -21,7 +21,7 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
-def dataframes_equal(df1, df2, ignore_index_order=True, **kwargs):
+def dataframes_equal(df1, df2, ignore_index_order=True, assume_geojson_strings=True, **kwargs):
     """
     Returns a boolean whether the given two dataframes are equal or not.
     """
@@ -37,12 +37,18 @@ def dataframes_equal(df1, df2, ignore_index_order=True, **kwargs):
         df2 = df2.sort_index().sort_index(axis=1)
 
     # geo columns are compared later
-    df1_cols = df1.columns.difference({"geo"})
-    df2_cols = df2.columns.difference({"geo"})
+    if assume_geojson_strings:
+        df1_cols = df1.columns.difference({"geo"})
+        df2_cols = df2.columns.difference({"geo"})
+    else:
+        df1_cols = df1.columns
+        df2_cols = df2.columns
 
     # --- pandas implementation
     try:
         pdt.assert_frame_equal(df1[df1_cols], df2[df2_cols], **kwargs)
+        if not assume_geojson_strings:
+            return True
     except AssertionError:
         return False
 
@@ -106,7 +112,7 @@ def compare_arrays(x, y):
 
 
 def nets_equal(net1, net2, check_only_results=False, check_without_results=False, exclude_elms=None,
-               name_selection=None, **kwargs):
+               name_selection=None, assume_geojson_strings=True, **kwargs):
     """
     Returns a boolean whether the two given pandapower networks are equal.
 
@@ -139,7 +145,7 @@ def nets_equal(net1, net2, check_only_results=False, check_without_results=False
         return False
     not_equal, not_checked_keys = nets_equal_keys(
         net1, net2, check_only_results, check_without_results, exclude_elms, name_selection,
-        **kwargs)
+        assume_geojson_strings, **kwargs)
     if len(not_checked_keys) > 0:
         logger.warning("These keys were ignored by the comparison of the networks: %s" % (', '.join(
             not_checked_keys)))
@@ -152,7 +158,7 @@ def nets_equal(net1, net2, check_only_results=False, check_without_results=False
 
 
 def nets_equal_keys(net1, net2, check_only_results, check_without_results, exclude_elms,
-                     name_selection, **kwargs):
+                     name_selection, assume_geojson_strings, **kwargs):
     """ Returns a lists of keys which are 1) not equal and 2) not checked.
     Used within nets_equal(). """
     if check_without_results and check_only_results:
@@ -191,7 +197,8 @@ def nets_equal_keys(net1, net2, check_only_results, check_without_results, exclu
 
         if isinstance(net1[key], pd.DataFrame):
             if not isinstance(net2[key], pd.DataFrame) or not dataframes_equal(
-                    net1[key], net2[key], **kwargs):
+                    net1[key], net2[key], assume_geojson_strings=assume_geojson_strings,
+                    **kwargs):
                 not_equal.append(key)
 
         elif isinstance(net1[key], np.ndarray):


### PR DESCRIPTION
added flag in nets_equal function whether or not to assume that geo columns only contain geojson strings