### PR TITLE
[Fix] Surface chained assignment warnings

### DIFF
--- a/pandapower/__init__.py
+++ b/pandapower/__init__.py
@@ -20,8 +20,6 @@ from pandapower.pf.runpp_3ph import runpp_3ph
 import geojson
 geojson.geometry.DEFAULT_PRECISION = 8
 
-import pandas as pd
-pd.options.mode.chained_assignment = None  # default='warn'
 
 # import pandapower packages
 import pandapower.control

--- a/pandapower/protection/utility_functions.py
+++ b/pandapower/protection/utility_functions.py
@@ -26,8 +26,6 @@ from pandapower.toolbox.element_selection import get_connected_buses_at_element,
 from pandapower.run import runpp
 from pandapower.shortcircuit.calc_sc import calc_sc
 
-import warnings
-
 logger = log.getLogger(__name__)
 
 try:
@@ -44,9 +42,6 @@ try:
 except ImportError:
     MPLCURSORS_INSTALLED = False
     logger.info('could not import mplcursors')
-
-warnings.filterwarnings('ignore')
-
 
 def _get_coords_from_bus_idx(net: pandapowerNet, bus_idx: pd.Index) -> List[Tuple[float, float]]:
     try:


### PR DESCRIPTION
Chained assignment in pandas has long been discouraged and will break in pandas 3.0:
* [pandas user guide: Copy on Write](https://pandas.pydata.org/docs/dev/user_guide/copy_on_write.html)
* [Deep Dive into Pandas Copy-on-Write Mode — Part III](https://medium.com/data-science/deep-dive-into-pandas-copy-on-write-mode-part-iii-c024eaa16ed4)

By default, pandas generates warnings if chained assignment is used, but they are disabled in pandapower. These warnings should be visible so the offending code can get fixed.

This PR restores the default chained assignment warnings. It also removes the blanket suppression of all warnings in `protection.utility_functions`.