### PR TITLE
Fix controlEnabled logic to handle NaN values in 'enabled' column

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Change Log
 
 [upcoming release] - 2025-..-..
 -------------------------------
+- [FIXED] pp control - handle NaN in 'enabled' column when computing 'controlEnabled' to ensure safe boolean evaluation
 
 [3.1.0] - 2025-05-26
 -------------------------------

--- a/pandapower/converter/cim/cim2pp/converter_classes/externalnetworks/externalNetworkInjectionsCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/externalnetworks/externalNetworkInjectionsCim16.py
@@ -82,7 +82,7 @@ class ExternalNetworkInjectionsCim16:
                        how='left', left_on='index_bus', right_index=True)
         eni = pd.merge(eni, self.cimConverter.cim['sv']['SvVoltage'][['TopologicalNode', 'v', 'angle']],
                        how='left', left_on=sc['ct'], right_on='TopologicalNode')
-        eni['controlEnabled'] = eni['controlEnabled'] & eni['enabled']
+        eni['controlEnabled'] = eni['controlEnabled'] & eni['enabled'].fillna(False)
         eni['vm_pu'] = eni['targetValue'] / eni['vn_kv']  # voltage from regulation
         eni['vm_pu'] = eni['vm_pu'].fillna(eni['v'] / eni['vn_kv'])  # voltage from measurement
         eni['vm_pu'] = eni['vm_pu'].fillna(1.)  # default voltage


### PR DESCRIPTION
Ensures that missing enabled values are treated as False by default
Improves robustness for incomplete data inputs
as an issue example
True & Nan = Nan
False & Nan = False