### PR TITLE
Minor fixes to the docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -189,21 +189,29 @@ latex_elements = {
 #'pointsize': '10pt',
 
 # Additional stuff for the LaTeX preamble.
-# here: fix the fancy table formmatting the "ugly" way -> longtable instead of tabular globaally
-'preamble': '\\renewenvironment{tabular}{\\begin{longtable}}{\\end{longtable}} \n\\usepackage{minted} \n\\fvset{breaklines=true}\n\\usepackage{graphicx}\n\\setkeys{Gin}{width=.85\\textwidth}',
-'babel': '\\usepackage[english]{babel}'
+# here: fix the fancy table formatting the "ugly" way -> longtable instead of tabular globally
+'preamble': r'''
+\usepackage{newunicodechar}
+\newunicodechar{➔}{\rightarrow}
+\renewenvironment{tabular}{\begin{longtable}}{\end{longtable}}
+\usepackage{minted}
+\fvset{breaklines=true}
+\usepackage{graphicx}
+\setkeys{Gin}{width=.85\textwidth}
+''',
+'babel': r'\usepackage[english]{babel}'
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title, author, documentclass [howto/manual]).
 latex_documents = [
-  ('latex_index', 'pandapower.tex', u'pandapower Documentation',
-   'Fraunhofer IEE\\\ Universit\\"{a}t Kassel', 'manual'),
+  ('index', 'pandapower.tex', u'pandapower Documentation',
+   r'Fraunhofer IEE\\Universität Kassel', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
 # the title page.
-#latex_logo = 'doc/pandapower/pics/LogoE2N.png'
+#latex_logo = 'pics/e2n.png'
 
 # For "manual" documents, if this is true, then toplevel headings are parts,
 # not chapters.

--- a/doc/plotting/plotly/geo_data_to_latlong.rst
+++ b/doc/plotting/plotly/geo_data_to_latlong.rst
@@ -7,3 +7,4 @@ the map-projections, it may be converted to lat/long by providing number of the 
 A sample of converting geodata from mv_oberrhein network can be found in the tutorial.
 
 .. autofunction:: pandapower.plotting.geo.convert_crs
+    :no-index:

--- a/pandapower/contingency/contingency.py
+++ b/pandapower/contingency/contingency.py
@@ -41,38 +41,29 @@ def run_contingency(net, nminus1_cases, pf_options=None, pf_options_nminus1=None
                     contingency_evaluation_function=runpp, **kwargs):
     """
     Obtain either loading (N-0) or max. loading (N-0 and all N-1 cases), and min/max bus voltage magnitude.
-    The variable "temperature_degree_celsius" can be used in addition to "loading_percent" to obtain max. temperature.
-    In the returned dictionary, the variable "loading_percent" represents the loading in N-0 case,
-    "max_loading_percent" and "min_loading_percent" represent highest and lowest observed loading_percent among all
-    calculated N-1 cases. The same convention applies to "temperature_degree_celsius" when applicable.
-    This function can be passed through to pandapower.timeseries.run_timeseries as the run_control_fct argument.
+    The variable `temperature_degree_celsius` can be used in addition to `loading_percent` to obtain max. temperature.
+    In the returned dictionary, the variable `loading_percent` represents the loading in N-0 case,
+    `max_loading_percent` and `min_loading_percent` represent highest and lowest observed `loading_percent` among all
+    calculated N-1 cases. The same convention applies to `temperature_degree_celsius` when applicable.
+    This function can be passed through to :func:`pandapower.timeseries.run_timeseries` as the `run_control_fct` argument.
 
-    INPUT
-    ----------
-    **net** - pandapowerNet
-    **nminus1_cases** - dict
-        describes all N-1 cases, e.g. {"line": {"index": [1, 2, 3]}, "trafo": {"index": [0]}, "trafo3w": {"index": [1]}}
-    **pf_options** - dict
-        options for power flow calculation in N-0 case
-    **pf_options_nminus1** - dict
-        options for power flow calculation in N-1 cases
-    **write_to_net** - bool
-        whether to write the results of contingency analysis to net (in "res_" tables). The results will be written for
-        the following additional variables: table res_bus with columns "max_vm_pu", "min_vm_pu",
-        tables res_line, res_trafo, res_trafo3w with columns "max_loading_percent", "min_loading_percent",
-        "causes_overloading", "cause_element", "cause_index", table res_line with columns
-        "max_temperature_degree_celsius", "min_temperature_degree_celsius" (if "tdpf" set to True)
+    :param pandapowerNet net: The pandapower network
+    :param dict nminus1_cases: describes all N-1 cases, e.g. {"line": {"index": [1, 2, 3]}, "trafo": {"index": [0]}, "trafo3w": {"index": [1]}}
+    :param dict pf_options: options for power flow calculation in N-0 case
+    :param dict pf_options_nminus1: options for power flow calculation in N-1 cases
+    :param bool write_to_net: whether to write the results of contingency analysis to net (in `res_` tables). The results will be written for
+        the following additional variables: table `res_bus` with columns `max_vm_pu`, `min_vm_pu`,
+        tables `res_line`, `res_trafo`, `res_trafo3w` with columns `max_loading_percent`, `min_loading_percent`,
+        `causes_overloading`, `cause_element`, `cause_index`, table `res_line` with columns
+        `max_temperature_degree_celsius`, `min_temperature_degree_celsius` (if `tdpf` set to True)
         "causes_overloading": does this element, when defining the N-1 case, cause overloading of other elements? the
         overloading is defined by net.line["max_loading_percent_nminus1"] (if set) or net.line["max_loading_percent"]
         "cause_element": element ("line", "trafo", "trafo3w") that causes max. loading of this element
         "cause_index": index of the element ("line", "trafo", "trafo3w") that causes max. loading of this element
-    **contingency_evaluation_function** - func
-        function to use for power flow calculation, default pp.runpp
+    :param callable contingency_evaluation_function: function to use for power flow calculation, default pp.runpp
 
-    OUTPUT
-    -------
-    **contingency_results** - dict
-        dict of arrays per element for index, min/max result
+    :return: contingency results dict of arrays per element for index, min/max result
+    :rtype: dict
     """
     # set up the dict for results and relevant variables
     # ".get" in case the options have been set in pp.set_user_pf_options:
@@ -163,15 +154,10 @@ def run_contingency_ls2g(net, nminus1_cases, contingency_evaluation_function=run
     "cause_index": index of the element ("line", "trafo", "trafo3w") that causes max. loading of this element
     "congestion_caused_mva": overall congestion in the grid in MVA during the N-1 case due to the failure of the element
 
-    INPUT
-    ----------
-
-    **net** - pandapowerNet
-    **nminus1_cases** - dict
-        describes all N-1 cases, e.g. {"line": {"index": [1, 2, 3]}, "trafo": {"index": [0]}}
+    :param pandapowerNet net: The pandapower network
+    :param dict nminus1_cases: describes all N-1 cases, e.g. {"line": {"index": [1, 2, 3]}, "trafo": {"index": [0]}}
         Note: trafo3w is not supported
-    **contingency_evaluation_function** - func
-        function to use for power flow calculation, default pp.runpp (but only relevant for N-0 case)
+    :param callable contingency_evaluation_function: function to use for power flow calculation, default pp.runpp (but only relevant for N-0 case)
     """
     if not lightsim2grid_installed:
         raise UserWarning("lightsim2grid package not installed. "
@@ -388,13 +374,10 @@ def get_element_limits(net):
     """
     Construct the dictionary of element limits
 
-    INPUT
-    ----------
-    **net** - pandapowerNet
+    :param pandapowerNet net:
 
-    OUTPUT
-    -------
-    **element_limits** - dict
+    :return: element limits
+    :rtype: dict
     """
     element_limits = {}
     if "max_vm_pu" in net.bus and "min_vm_pu" in net.bus:
@@ -455,19 +438,14 @@ def check_elements_within_limits(element_limits, contingency_results, nminus1=Fa
     """
     Check if elements are within limits
 
-    INPUT
-    ----------
-    **element_limits** - dict
-    **contingency_results** - dict
-    **nminus1** - bool
-    **branch_tol** - float
-        tolerance of the limit violation check for branch limits
-    **bus_tol** - float
-        tolerance of the limit violation check for bus limits
+    :param dict element_limits:
+    :param dict contingency_results:
+    :param bool nminus1:
+    :param float branch_tol: tolerance of the limit violation check for branch limits
+    :param float bus_tol: tolerance of the limit violation check for bus limits
 
-    OUTPUT
-    -------
-    True if all within limits (no violations), False if any limits violated
+    :return: True if all within limits (no violations), False if any limits violated
+    :rtype: bool
     """
     for element, values in contingency_results.items():
         limit = element_limits[element]
@@ -519,14 +497,10 @@ def report_contingency_results(element_limits, contingency_results, branch_tol=1
     """
     Print log messages for elements with violations of limits
 
-    INPUT
-    ----------
-    **element_limits** - dict
-    **contingency_results** - dict
-    **branch_tol** - float
-        tolerance for branch results
-    **bus_tol** - float
-        tolerance for bus results
+    :param dict element_limits:
+    :param dict contingency_results:
+    :param float branch_tol: tolerance for branch results
+    :param float bus_tol: tolerance for bus results
     """
     for element, results in contingency_results.items():
         limit = element_limits[element]

--- a/pandapower/control/controller/DERController/der_control.py
+++ b/pandapower/control/controller/DERController/der_control.py
@@ -44,67 +44,48 @@ class DERController(PQController):
         the elements (called P_{b,installed} in the VDE AR N standards). Scalings and limits are
         usually relative to that (sn_mva) values.
 
-    INPUT:
-        **net** (pandapower net)
-
-        **element_index** (int[]) - IDs of the controlled elements
-
-    OPTIONAL:
-        **element** (str, "sgen") - element type which is controlled
-
-        **q_model** (object, None) - an q_model, such as provided in this file, should be passed to
-        model how the q value should be determined.
-
-        **pqv_area** (object, None) - an pqv_area, such as provided in this file, should be passed
-        to model q values are allowed.
-
-        **saturate_sn_mva** (float, NaN) - Maximum apparent power of the inverter. If given, the
+    :param pandapowerNet net: The pandapower network
+    :param list[int] element_index: IDs of the controlled elements
+    :param Optional[str] element: element type which is controlled (default: "sgen")
+    :param Optional q_model: an q_model, such as provided in this file, should be passed to
+        model how the q value should be determined. (default: None)
+    :param Optional pqv_area: an pqv_area, such as provided in this file, should be passed
+        to model q values are allowed. (default: None)
+    :param Optional[float] saturate_sn_mva: Maximum apparent power of the inverter. If given, the
         p or q values (depending on q_prio) are reduced to this maximum apparent power. Usually,
         it is not necessary to pass this values since the inverter needs to be dimensioned to provide
-        the standardized reactive power requirements.
-
-        **q_prio** (bool, True) - If True, the active power is reduced first in case of power
-        reduction due to saturate_sn_mva. Otherwise, the reactive power is reduced first.
-
-        **damping_coef** (float, 2) - damping coefficient to influence the power updating process
+        the standardized reactive power requirements. (default: NaN)
+    :param Optional[bool] q_prio: If True, the active power is reduced first in case of power
+        reduction due to saturate_sn_mva. Otherwise, the reactive power is reduced first. (default: True)
+    :param Optional[float] damping_coef: damping coefficient to influence the power updating process
         of the control loop. A higher value mean slower changes of p and q towards the latest target
-        values
-
-        **max_p_error** (float, 0.0001) - Maximum absolute error of active power in MW
-
-        **max_q_error** (float, 0.0001) - Maximum absolute error of reactive power in Mvar
-
-        **pq_simultaneity_factor** (float, 1.0) - Simultaneity factor applied to P and Q
-
-        **data_source** ( , None) - A DataSource that contains profiles
-
-        **p_profile** (str[], None) - The profile names of the controlled elements in the data
-        source for active power time series values
-
-        **profile_from_name** (bool, False) - If True, the profile names of the controlled elements
+        values (default: 2.0)
+    :param Optional[float] max_p_error: Maximum absolute error of active power in MW (default: 0.0001)
+    :param Optional[float] max_q_error: Maximum absolute error of reactive power in Mvar (default: 0.0001)
+    :param Optional[float] pq_simultaneity_factor: Simultaneity factor applied to P and Q (default: 1.0)
+    :param Optional data_source: A DataSource that contains profiles (default: None)
+    :param Optional[list[str]] p_profile: The profile names of the controlled elements in the data
+        source for active power time series values (default: None)
+    :param Optional[bool] profile_from_name: If True, the profile names of the controlled elements
         in the data source for active power time series values will be set be the name of the
         controlled elements, e.g. for controlled sgen "SGEN_1", the active power profile "P_SGEN_1"
-        is applied
+        is applied (default: False)
+    :param Optional[float] profile_scale: A scaling factor applied to the values of profiles (default: 1.0)
+    :param Optional[bool] in_service: Indicates if the controller is currently in_service (default: True)
+    :param Optional[bool] ts_absolute: Whether the time step values are absolute power values or
+        scaling factors (default: True)
 
-        **profile_scale** (float, 1.0) - A scaling factor applied to the values of profiles
-
-        **in_service** (bool, True) - Indicates if the controller is currently in_service
-
-        **ts_absolute** (bool, True) - Whether the time step values are absolute power values or
-        scaling factors
-
-    Example
-    -------
-    >>> from pandapower.networks.cigre_networks import create_cigre_network_mv
-    >>> from pandapower.control.controller.DERController import DERController, QModelCosphiP, PQVArea4120V2
-    >>> from pandapower.run import runpp
-    >>> net = create_cigre_network_mv(with_der=True)
-    >>> controlled_sgens = DERController(
-    ...     net, net.sgen.index,
-    ...     q_model=QModelCosphiP(cosphi=-0.95),
-    ...     pqv_area=PQVArea4120V2()
-    ... )
-    >>> runpp(net, run_control=True)
+    :example:
+        >>> from pandapower.networks.cigre_networks import create_cigre_network_mv
+        >>> from pandapower.control.controller.DERController import DERController, QModelCosphiP, PQVArea4120V2
+        >>> from pandapower.run import runpp
+        >>> net = create_cigre_network_mv(with_der=True)
+        >>> controlled_sgens = DERController(
+        ...     net, net.sgen.index,
+        ...     q_model=QModelCosphiP(cosphi=-0.95),
+        ...     pqv_area=PQVArea4120V2()
+        ... )
+        >>> runpp(net, run_control=True)
     """
 
     def __init__(self, net, element_index, element="sgen",

--- a/pandapower/converter/jao/from_jao.py
+++ b/pandapower/converter/jao/from_jao.py
@@ -30,88 +30,88 @@ def from_jao(excel_file_path: str,
              apply_data_correction: bool = True,
              max_i_ka_fillna: Union[float, int] = 999,
              **kwargs) -> pandapowerNet:
-    """Converts European (Core) EHV grid data provided by JAO (Joint Allocation Office), the
+    """
+    Converts European (Core) EHV grid data provided by JAO (Joint Allocation Office), the
     "Single Allocation Platform (SAP) for all European Transmission System Operators (TSOs) that
     operate in accordance to EU legislation".
 
     **Data Sources and Availability:**
-
     The data are available at the website
     `JAO Static Grid Model <https://www.jao.eu/static-grid-model>`_ (November 2024).
     There, a map is provided to get an fine overview of the geographical extent and the scope of
     the data. These inlcude information about European (Core) lines, tielines, and transformers.
 
     **Limitations:**
-
     No information is available on load or generation.
     The data quality with regard to the interconnection of the equipment, the information provided
     and the (incomplete) geodata should be considered with caution.
 
     **Features of the converter:**
-
     - **Data Correction:** corrects known data inconsistencies, such as inconsistent spellings and missing necessary information.
     - **Geographical Data Parsing:** Parses geographical data from the HTML file to add geolocation information to buses and lines.
     - **Grid Group Connections:** Optionally extends the network by connecting islanded grid groups to avoid disconnected components.
     - **Data Customization:** Allows for customization through additional parameters to control transformer creation, grid group dropping, and voltage level deviations.
 
-    Parameters
-    ----------
-    excel_file_path : str
+    :param str excel_file_path:
         input data including electrical parameters of grids' utilities, stored in multiple sheets
         of an excel file
-    html_file_path : str
+
+    :param str html_file_path:
         input data for geo information. If The converter should be run without geo information, None
         can be passed., provided by an html file
-    extend_data_for_grid_group_connections : bool
+
+    :param bool extend_data_for_grid_group_connections:
         if True, connections (additional transformers and merging buses) are created to avoid
         islanded grid groups, by default False
-    drop_grid_groups_islands : bool, optional
+
+    :param Optional[bool] drop_grid_groups_islands:
         if True, islanded grid groups will be dropped if their number of buses is below
-        min_bus_number (default is 6), by default False
-    apply_data_correction : bool, optional
-        _description_, by default True
-    max_i_ka_fillna : float | int, optional
+        `min_bus_number` default for this is 6 (default: False)
+
+    :param Optional[bool] apply_data_correction:
+        _description_ (default: True)
+
+    :param Optional[float|int] max_i_ka_fillna:
         value to fill missing values or data of false type in max_i_ka of lines and transformers.
-        If no value should be set, you can also pass np.nan. By default 999
+        If no value should be set, you can also pass np.nan. (default: 999)
 
-    Returns
-    -------
-    pandapowerNet
-        net created from the jao data
+    :param '**'kwargs: following params are available
 
-    Additional Parameters
-    ---------------------
-    minimal_trafo_invention : bool, optional
+    :param Optional[bool] minimal_trafo_invention:
         applies if extend_data_for_grid_group_connections is True. Then, if minimal_trafo_invention
         is True, adding transformers stops when no grid groups is islanded anymore (does not apply
         for release version 5 or 6, i.e. it does not care what value is passed to
         minimal_trafo_invention). If False, all equally named buses that have different voltage
-        level and lay in different groups will be connected via additional transformers,
-        by default False
-    min_bus_number : Union[int,str], optional
+        level and lay in different groups will be connected via additional transformers (default: False)
+
+    :param Optional[int|str] min_bus_number:
         Threshold value to decide which small grid groups should be dropped and which large grid
         groups should be kept. If all islanded grid groups should be dropped except of the one
         largest, set "max". If all grid groups that do not contain a slack element should be
-        dropped, set "unsupplied". By default 6
-    rel_deviation_threshold_for_trafo_bus_creation : float, optional
+        dropped, set "unsupplied". (default: 6)
+
+    :param Optional[float] rel_deviation_threshold_for_trafo_bus_creation:
         If the voltage level of transformer locations is far different than the transformer data,
         additional buses are created. rel_deviation_threshold_for_trafo_bus_creation defines the
-        tolerance in which no additional buses are created. By default 0.2
-    log_rel_vn_deviation : float, optional
-        This parameter allows a range below rel_deviation_threshold_for_trafo_bus_creation in which
-        a warning is logged instead of a creating additional buses. By default 0.12
+        tolerance in which no additional buses are created. (default: 0.2)
 
-    Examples
-    --------
-    >>> from pathlib import Path
-    >>> import os
-    >>> import pandapower as pp
-    >>> net = pp.converter.from_jao()
-    >>> home = str(Path.home())
-    >>> # assume that the files are located at your desktop:
-    >>> excel_file_path = os.path.join(home, "desktop", "202409_Core Static Grid Mode_6th release")
-    >>> html_file_path = os.path.join(home, "desktop", "2024-09-13_Core_SGM_publication.html")
-    >>> net = from_jao(excel_file_path, html_file_path, True, drop_grid_groups_islands=True)
+    :param Optional[float] log_rel_vn_deviation:
+        This parameter allows a range below rel_deviation_threshold_for_trafo_bus_creation in which
+        a warning is logged instead of a creating additional buses. (default: 0.12)
+
+    :return: net created from the jao data
+    :rtype: pandapowerNet
+
+    :example:
+        >>> from pathlib import Path
+        >>> import os
+        >>> import pandapower as pp
+        >>> net = pp.converter.from_jao()
+        >>> home = str(Path.home())
+        >>> # assume that the files are located at your desktop:
+        >>> excel_file_path = os.path.join(home, "desktop", "202409_Core Static Grid Mode_6th release")
+        >>> html_file_path = os.path.join(home, "desktop", "2024-09-13_Core_SGM_publication.html")
+        >>> net = from_jao(excel_file_path, html_file_path, True, drop_grid_groups_islands=True)
     """
 
     # --- read data
@@ -163,23 +163,17 @@ def _data_correction(
         data: dict[str, pd.DataFrame],
         html_str: Optional[str],
         max_i_ka_fillna: Union[float, int]) -> Optional[str]:
-    """Corrects input data in particular with regard to obvious weaknesses in the data provided,
+    """
+    Corrects input data in particular with regard to obvious weaknesses in the data provided,
     such as inconsistent spellings and missing necessary information
 
-    Parameters
-    ----------
-    data : dict[str, pd.DataFrame]
-        data provided by the excel file which will be corrected
-    html_str : str | None
-        data provided by the html file which will be corrected
-    max_i_ka_fillna : float | int
-        value to fill missing values or data of false type in max_i_ka of lines and transformers.
+    :param dict[str, pd.DataFrame] data: data provided by the excel file which will be corrected
+    :param str|None html_str: data provided by the html file which will be corrected
+    :param float|int max_i_ka_fillna: value to fill missing values or data of false type in max_i_ka of lines and transformers.
         If no value should be set, you can also pass np.nan.
 
-    Returns
-    -------
-    str
-        corrected html_str
+    :return: corrected html_str
+    :rtype: str
     """
     # old name -> new name
     rename_locnames = [("PSTMIKULOWA", "PST MIKULOWA"),
@@ -253,18 +247,14 @@ def _data_correction(
 
 
 def _parse_html_str(html_str: str) -> pd.DataFrame:
-    """Converts ths geodata from the html file (information hidden in the string), from Lines in
+    """
+    Converts ths geodata from the html file (information hidden in the string), from Lines in
     particular, to a DataFrame that can be used later in _add_bus_geo()
 
-    Parameters
-    ----------
-    html_str : str
-        html file that includes geodata information
+    :param str html_str: html file that includes geodata information
 
-    Returns
-    -------
-    pd.DataFrame
-        extracted geodata for a later and easy use
+    :return: extracted geodata for a later and easy use
+    :rtype: pd.DataFrame
     """
     def _filter_name(st: str) -> str:
         name_start = "<b>NE name: "
@@ -303,12 +293,8 @@ def _create_buses_from_line_data(net: pandapowerNet, data: dict[str, pd.DataFram
     """Creates buses to the pandapower net using information from the lines and tielines sheets
     (excel file).
 
-    Parameters
-    ----------
-    net : pandapowerNet
-        net to be filled by buses
-    data : dict[str, pd.DataFrame]
-        data provided by the excel file which will be corrected
+    :param pandapowerNet net: net to be filled by buses
+    :param dict[str, pd.DataFrame data: data provided by the excel file which will be corrected
     """
     bus_df_empty = pd.DataFrame({"name": str(), "vn_kv": float(), "TSO": str()}, index=[])
     bus_df = deepcopy(bus_df_empty)
@@ -330,17 +316,12 @@ def _create_lines(
         net: pandapowerNet,
         data: dict[str, pd.DataFrame],
         max_i_ka_fillna: Union[float, int]) -> None:
-    """Creates lines to the pandapower net using information from the lines and tielines sheets
-    (excel file).
+    """
+    Creates lines to the pandapower net using information from the lines and tielines sheets (excel file).
 
-    Parameters
-    ----------
-    net : pandapowerNet
-        net to be filled by buses
-    data : dict[str, pd.DataFrame]
-        data provided by the excel file which will be corrected
-    max_i_ka_fillna : float | int
-        value to fill missing values or data of false type in max_i_ka of lines and transformers.
+    :param pandapowerNet net: net to be filled by buses
+    :param dict[str, pd.DataFrame] data: data provided by the excel file which will be corrected
+    :param float|int max_i_ka_fillna: value to fill missing values or data of false type in max_i_ka of lines and transformers.
         If no value should be set, you can also pass np.nan.
     """
 
@@ -379,15 +360,11 @@ def _create_lines(
 
 def _create_transformers_and_buses(
         net: pandapowerNet, data: dict[str, pd.DataFrame], **kwargs) -> None:
-    """Creates transformers to the pandapower net using information from the transformers sheet
-    (excel file).
+    """
+    Creates transformers to the pandapower net using information from the transformers sheet (excel file).
 
-    Parameters
-    ----------
-    net : pandapowerNet
-        net to be filled by buses
-    data : dict[str, pd.DataFrame]
-        data provided by the excel file which will be corrected
+    :param pandapowerNet net: net to be filled by buses
+    :param dict[str, pd.DataFrame] data: data provided by the excel file which will be corrected
     """
 
     # --- data preparations
@@ -448,22 +425,19 @@ def _create_transformers_and_buses(
 
 def _invent_connections_between_grid_groups(
         net: pandapowerNet, minimal_trafo_invention: bool = False, **kwargs) -> None:
-    """Adds connections between islanded grid groups via:
+    """
+    Adds connections between islanded grid groups via:
 
     - adding transformers between equally named buses that have different voltage level and lay in different groups
     - merge buses of same voltage level, different grid groups and equal name base
     - fuse buses that are close to each other
 
-    Parameters
-    ----------
-    net : pandapowerNet
-        net to be manipulated
-    minimal_trafo_invention : bool, optional
-        if True, adding transformers stops when no grid groups is islanded anymore (does not apply
+    :param pandapowerNet net: net to be manipulated
+    :param Optional[bool] minimal_trafo_invention: if True, adding transformers stops when no grid groups is islanded anymore (does not apply
         for release version 5 or 6, i.e. it does not care what value is passed to
         minimal_trafo_invention). If False, all equally named buses that have different voltage
         level and lay in different groups will be connected via additional transformers,
-        by default False
+        (default: False)
     """
     grid_groups = get_grid_groups(net)
     bus_idx = _get_bus_idx(net)
@@ -562,14 +536,11 @@ def drop_islanded_grid_groups(
         net: pandapowerNet,
         min_bus_number: Union[int, str],
         **kwargs) -> None:
-    """Drops grid groups that are islanded and include a number of buses below min_bus_number.
+    """
+    Drops grid groups that are islanded and include a number of buses below min_bus_number.
 
-    Parameters
-    ----------
-    net : pandapowerNet
-        net in which islanded grid groups will be dropped
-    min_bus_number : int | str, optional
-        Threshold value to decide which small grid groups should be dropped and which large grid
+    :param panadpowerNet net: net in which islanded grid groups will be dropped
+    :param Optional[int|str] min_bus_number: Threshold value to decide which small grid groups should be dropped and which large grid
         groups should be kept. If all islanded grid groups should be dropped except of the one
         largest, set "max". If all grid groups that do not contain a slack element should be
         dropped, set "unsupplied".
@@ -607,12 +578,8 @@ def _add_bus_geo(net: pandapowerNet, line_geo_data: pd.DataFrame) -> None:
     include no or multiple geodata per bus. Primarly, the geodata are allocate via EIC Code names,
     if ambigous, names are considered.
 
-    Parameters
-    ----------
-    net : pandapowerNet
-        net in which geodata are added to the buses
-    line_geo_data : pd.DataFrame
-        Converted geodata from the html file
+    :param pandapowerNet net: net in which geodata are added to the buses
+    :param pd.DataFrame: line_geo_data: Converted geodata from the html file
     """
     iSl = pd.IndexSlice
     lgd_EIC_bus = line_geo_data.pivot_table(values="value", index=["EIC_Code", "bus"],
@@ -750,31 +717,21 @@ def _allocate_trafos_to_buses_and_create_buses(
     voltage level than the transformer, either a warning is logged or additional buses are created
     according to rel_deviation_threshold_for_trafo_bus_creation and log_rel_vn_deviation.
 
-    Parameters
-    ----------
-    net : pandapowerNet
-        pandapower net
-    data : dict[str, pd.DataFrame]
-        _description_
-    bus_idx : pd.Series
-        Series of indices and corresponding location names and voltage levels in the MultiIndex of
+    :param pandapowerNet net: pandapower net
+    :param dict[str, pd.DataFrame] data: _description_
+    :param pd.Series bus_idx: Series of indices and corresponding location names and voltage levels in the MultiIndex of
         the Series
-    vn_hv_kv : np.ndarray
-        nominal voltages of the hv side of the transformers
-    vn_lv_kv : np.ndarray
-        Nominal voltages of the lv side of the transformers
-    rel_deviation_threshold_for_trafo_bus_creation : float, optional
-        If the voltage level of transformer locations is far different than the transformer data,
+    :param np.ndarray vn_hv_kv: nominal voltages of the hv side of the transformers
+    :param np.ndarray vn_lv_kv: Nominal voltages of the lv side of the transformers
+    :param Optional[float] rel_deviation_threshold_for_trafo_bus_creation: If the voltage level of transformer locations
+        is far different than the transformer data,
         additional buses are created. rel_deviation_threshold_for_trafo_bus_creation defines the
-        tolerance in which no additional buses are created. By default 0.2
-    log_rel_vn_deviation : float, optional
-        This parameter allows a range below rel_deviation_threshold_for_trafo_bus_creation in which
-        a warning is logged instead of a creating additional buses. By default 0.12
+        tolerance in which no additional buses are created. (default: 0.2)
+    :param Optional[float] log_rel_vn_deviation: This parameter allows a range below rel_deviation_threshold_for_trafo_bus_creation in which
+        a warning is logged instead of a creating additional buses. (default: 0.12)
 
-    Returns
-    -------
-    pd.DataFrame
-        information to which bus the trafos should be connected to. Columns are
+    :rtype: pd.DataFrame
+    :return: information to which bus the trafos should be connected to. Columns are
         ["name", "hv_bus", "lv_bus", "vn_hv_kv", "vn_lv_kv", ...]
     """
 


### PR DESCRIPTION
fixed some issues in docs compilation
fixed docstring not showing in docs because of incorrect headings


Fixed all errors from the latex doc build.
Found section not compiling to html or latex doc as it used `INPUT` and `OUTPUT` instead of `Parameters` and `Returns`. Updated it for Consistency to the `:param type name:` docstring.