### PR TITLE
Fix and vectorize apparent power saturation in DER Control

### DIFF
--- a/pandapower/control/controller/DERController/der_control.py
+++ b/pandapower/control/controller/DERController/der_control.py
@@ -110,7 +110,8 @@ class DERController(PQController):
         # --- init DER Model params
         self.q_model = q_model
         self.pqv_area = pqv_area
-        self.saturate_sn_mva = saturate_sn_mva
+        self.saturate_sn_mva = np.array(ensure_iterability(saturate_sn_mva))
+        self.saturate_sn_mva_active = isinstance(self.saturate_sn_mva, np.ndarray) 
         self.q_prio = q_prio
         self.damping_coef = damping_coef
 
@@ -122,7 +123,7 @@ class DERController(PQController):
         if n_nan_sn := sum(self.sn_mva.isnull()):
             logger.error(f"The DERController relates to sn_mva, but for {n_nan_sn} elements "
                          "sn_mva is NaN.")
-        if self.saturate_sn_mva <= 0:
+        if self.saturate_sn_mva_active and (self.saturate_sn_mva <= 0).any():
             raise ValueError(f"saturate_sn_mva cannot be <= 0 but is {self.saturate_sn_mva}")
         if self.q_model is not None and not isinstance(self.q_model, QModel):
             logger.warning(f"The Q model is expected of type QModel, however {type(self.q_model)} "
@@ -171,7 +172,7 @@ class DERController(PQController):
         q_pu = self._step_q(p_series_mw=p_series_mw, q_series_mvar=q_series_mvar, vm_pu=vm_pu)
 
         # --- Second Step: Saturates P, Q according to SnMVA and PQV_AREA
-        if self.saturate_sn_mva or (self.pqv_area is not None):
+        if self.saturate_sn_mva_active or (self.pqv_area is not None):
             p_pu, q_pu = self._saturate(p_pu, q_pu, vm_pu)
 
         # --- Third Step: Convert relative P, Q to p_mw, q_mvar
@@ -206,7 +207,7 @@ class DERController(PQController):
                 q_pu[~in_area] = np.minimum(np.maximum(
                     q_pu[~in_area], min_max_q_pu[:, 0]), min_max_q_pu[:, 1])
 
-        if not np.isnan(self.saturate_sn_mva):
+        if self.saturate_sn_mva_active:
             p_pu, q_pu = self._saturate_sn_mva_step(p_pu, q_pu, vm_pu)
         return p_pu, q_pu
 
@@ -219,7 +220,7 @@ class DERController(PQController):
                 if (
                         isinstance(self.pqv_area, PQVArea4110) or isinstance(self.pqv_area, QVArea4110)
                 ) and any(
-                    (0.95 < vm[to_saturate]) & (vm[to_saturate] < 1.05) &
+                    (0.95 < vm_pu[to_saturate]) & (vm_pu[to_saturate] < 1.05) &
                     (-0.328684 < q_pu[to_saturate]) & any(q_pu[to_saturate] < 0.328684)
                 ):
                     logger.warning(f"Such kind of saturation is performed that is not in line with"


### PR DESCRIPTION
The DER Controller supports saturating the apparent power with saturate_sn_mva. However, the saturate_sn_mva parameter was a single number, which would mean that only one sn_mva for all controlled sgens can be passed, even though every sgen can have a different sn_mva. Also the code for saturation was broken, since a variable was misnamed.

This PR:
- fixes the vm_pu --> vm misnaming to avoid an error every time saturation is used
- makes saturate_sn_mva_active iterable, so that an array can be passed with an sn_mva value for each sgen