### PR TITLE
to_excel: truncate sheet names at 31 chars

### DIFF
--- a/pandapower/file_io.py
+++ b/pandapower/file_io.py
@@ -96,7 +96,7 @@ def to_excel(net, filename, include_empty_tables=False, include_results=True):
     dict_net = to_dict_of_dfs(net, include_results=include_results,
                                        include_empty_tables=include_empty_tables)
     for item, table in dict_net.items():
-        table.to_excel(writer, sheet_name=item)
+        table.to_excel(writer, sheet_name=item[:31])
 
     try:
         writer.save()


### PR DESCRIPTION
Excel sheet names can not be longer than 31 characters, which leads to an exception when writing pp3 networks with a "q_capability_curve_characteristic" table. 

Although a more compact name would be better, this change truncates overly long sheet names in  `pandapower.to_excel` to fix the export function. 