### PR TITLE
Updated toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,15 +68,8 @@ fileio = ["xlsxwriter", "openpyxl", "cryptography", "geopandas>=1.0", "psycopg2"
 converter = ["matpowercaseframes"]
 pgm = ["power-grid-model-io"]
 control = ["shapely"]
-all = [
-    "numpydoc>=1.5.0", "sphinx>=5.3.0", "sphinx_rtd_theme>=1.1.1", "sphinx-pyproject",
-    "plotly>=3.1.1", "matplotlib", "igraph", "geopandas>=1.0",
-    "pytest~=8.1", "pytest-xdist", "nbmake",
-    "ortools", "numba==0.60.0", "lightsim2grid==0.10.1",
-    "xlsxwriter", "openpyxl", "cryptography", "psycopg2",
-    "matpowercaseframes",
-    "power-grid-model-io"
-]
+
+all = ["pandapower[docs,plotting,test,performance,fileio,converter,pgm,control]"]
 # "shapely", "pyproj", "Pyogrio" are dependencies of geopandas and should be already available ("Fiona" got dropped)
 # "hashlib", "zlib", "base64" produce install problems, so they are not included
 


### PR DESCRIPTION
Since pip 21.2 recursive optional dependencies are possible. So here is a pr that adds this in pandapower.

- changed the all group to use recursive dependencies to avoid forgetting to define new dependencies twice