### PR TITLE
updated read_json to be able to read a json string

### DIFF
--- a/pandapower/file_io.py
+++ b/pandapower/file_io.py
@@ -243,7 +243,7 @@ def _from_excel_old(xls):
     return net
 
 
-def from_json(filename, convert=True, encryption_key=None, elements_to_deserialize=None,
+def from_json(filename_or_str, convert=True, encryption_key=None, elements_to_deserialize=None,
               keep_serialized_elements=True, add_basic_std_types=False, replace_elements=None,
               empty_dict_like_object=None, ignore_unknown_objects=False):
     """
@@ -252,8 +252,8 @@ def from_json(filename, convert=True, encryption_key=None, elements_to_deseriali
     Index columns of all pandas DataFrames are sorted in ascending order.
 
     INPUT:
-        **filename** (string or file) - The absolute or relative path to the input file or
-        file-like object
+        **filename_or_str** (file or string) - The absolute or relative path to the input file or
+        file-like object or a json string
 
         **convert** (bool, True) - If True, converts the format of the net loaded from json
         from the older version of pandapower to the newer version format
@@ -284,28 +284,31 @@ def from_json(filename, convert=True, encryption_key=None, elements_to_deseriali
         **net** (dict) - The pandapower format network
 
     EXAMPLE:
-
-        >>> net = pp.from_json("example.json")
+        >>> from pandapower.file_io import from_json
+        >>> net = from_json("example.json")
 
     """
-    if hasattr(filename, 'read'):
-        json_string = filename.read()
-    elif not os.path.isfile(filename):
-        raise UserWarning("File {} does not exist!!".format(filename))
-    else:
-        with open(filename, "r") as fp:
+    if hasattr(filename_or_str, 'read'):
+        json_string = filename_or_str.read()
+    elif os.path.isfile(filename_or_str):
+        with open(filename_or_str, "r") as fp:
             json_string = fp.read()
-
-    return from_json_string(
-        json_string,
-        convert=convert,
-        encryption_key=encryption_key,
-        elements_to_deserialize=elements_to_deserialize,
-        keep_serialized_elements=keep_serialized_elements,
-        add_basic_std_types=add_basic_std_types,
-        replace_elements=replace_elements,
-        empty_dict_like_object=empty_dict_like_object,
-        ignore_unknown_objects=ignore_unknown_objects)
+    else:
+        json_string = filename_or_str
+    try:
+        return from_json_string(
+            json_string,
+            convert=convert,
+            encryption_key=encryption_key,
+            elements_to_deserialize=elements_to_deserialize,
+            keep_serialized_elements=keep_serialized_elements,
+            add_basic_std_types=add_basic_std_types,
+            replace_elements=replace_elements,
+            empty_dict_like_object=empty_dict_like_object,
+            ignore_unknown_objects=ignore_unknown_objects
+        )
+    except ValueError as e:
+        raise UserWarning(f"Failed to load as json or file: {e}")
 
 
 def from_json_string(json_string, convert=False, encryption_key=None, elements_to_deserialize=None,

--- a/pandapower/test/api/test_file_io.py
+++ b/pandapower/test/api/test_file_io.py
@@ -188,7 +188,7 @@ def test_json(net_in, tmp_path):
 def test_encrypted_json(net_in, tmp_path):
     filename = os.path.abspath(str(tmp_path)) + "testfile.json"
     to_json(net_in, filename, encryption_key="verysecret")
-    with pytest.raises(json.JSONDecodeError):
+    with pytest.raises(UserWarning):
         from_json(filename)
     with pytest.raises(cryptography.fernet.InvalidToken):
         from_json(filename, encryption_key="wrong")


### PR DESCRIPTION
As mentioned in #722 I have updated read_json to be able to take a json string as input.

Changing this leads to a different error when the file cant be loaded so the test was changed to fail with a UserWarning instead of the JSONDecodeError. I think this is still appropriate since the message in the UserWarning still applies if the Encryption Key is missing.
The JSONDecodeError also did not mention that it Failed due to a missing encryption key. So this is just as ambiguous as before.