### PR TITLE
Handle json indent conversion for Python 3.13 compatibility

### DIFF
--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -397,7 +397,12 @@ def check_net_version(net):
 
 class PPJSONEncoder(json.JSONEncoder):
     def __init__(self, isinstance_func=isinstance_partial, **kwargs):
-        super(PPJSONEncoder, self).__init__(**kwargs)
+        # In Python 3.13, the indent handling moved from _make_iterencode to iterencode.
+        # We now handle indent here: convert integers to spaces, then pass to super.
+        indent = kwargs.pop("indent", None)
+        if indent is not None and not isinstance(indent, str):
+            indent = " " * indent
+        super().__init__(indent=indent, **kwargs)
         self.isinstance_func = isinstance_func
 
     def iterencode(self, o, _one_shot=False):


### PR DESCRIPTION
### Change Summary
Modifies `__init__` to explicitly handle `indent` parameter conversion previously done in `_make_iterencode`. This is required because Python 3.13 moved indent handling logic to `iterencode`.

### Background
In Python 3.13, the JSON encoder implementation changed:
- Indent conversion (integer to spaces) was moved from `_make_iterencode` to `iterencode`, see https://github.com/python/cpython/pull/118105
- Our encoder needs to replicate this conversion before calling the superclass initializer

### Compatibility
Maintains backward compatibility while ensuring correct behavior under Python 3.13+.