### PR TITLE
Feature/fix ziploads for powerfactory converter

### DIFF
--- a/pandapower/converter/powerfactory/pp_import_functions.py
+++ b/pandapower/converter/powerfactory/pp_import_functions.py
@@ -1786,15 +1786,16 @@ def create_pp_load(net, item, pf_variable_p_loads, dict_net, is_unbalanced):
                 z_q = 0
                 for cc_p, ee_p, cc_q, ee_q in zip(("aP", "bP", "cP"), ("kpu0", "kpu1", "kpu"),
                                       ("aQ", "bQ", "cQ"), ("kqu0", "kqu1", "kqu")):
-                    c_p = ga(load_type, cc_p)
-                    e_p = ga(load_type, ee_p)
+                    
+                    c_p = load_type.GetAttribute(cc_p)
+                    e_p = load_type.GetAttribute(ee_p)
                     if e_p == 1:
                         i_p += 100 * c_p
                     elif e_p == 2:
                         z_p += 100 * c_p
 
-                    c_q = ga(load_type, cc_q)
-                    e_q = ga(load_type, ee_q)
+                    c_q = load_type.GetAttribute(cc_q)
+                    e_q = load_type.GetAttribute(ee_q)
                     if e_q == 1:
                         i_q += 100 * c_q
                     elif e_q == 2:

--- a/tutorials/converter_powerfactory.ipynb
+++ b/tutorials/converter_powerfactory.ipynb
@@ -10,21 +10,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 2,
    "id": "43eb18ee",
    "metadata": {},
    "outputs": [],
    "source": [
     "import os\n",
-    "import pytest\n",
-    "\n",
+    "import powerfactory as pf\n",
     "from pandapower.converter.powerfactory.validate import validate_pf_conversion\n",
     "from pandapower.converter.powerfactory.export_pfd_to_pp import import_project, from_pfd\n",
     "import logging\n",
     "logger = logging.getLogger(__name__)\n",
-    "logger.setLevel(\"INFO\")\n",
-    "\n",
-    "from pandapower.converter import powerfactory as pf"
+    "logger.setLevel(\"INFO\")"
    ]
   },
   {
@@ -36,22 +33,20 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 16,
-   "id": "b2cc19fe",
+   "cell_type": "markdown",
+   "id": "d602fc6a-3c3e-4b3e-8b97-3b5337a915e8",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'C:\\\\Users\\\\mmilovic\\\\Documents\\\\Python Scripts\\\\pandapower'"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "source": [
+    "For example:\n",
+    "C:\\\\Program Files\\\\DIgSILENT\\\\PowerFactory 2024 SP1\\\\Python\\\\3.12"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9ccfccf-ac55-4cdf-be24-ff430fe3afd1",
+   "metadata": {},
+   "outputs": [],
    "source": [
     "os.environ['PYTHONPATH']"
    ]
@@ -65,33 +60,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "825255c3-615a-45cc-b451-4f5f1fd1f0dc",
+   "metadata": {},
+   "source": [
+    "For this to work, make sure that your PowerFactory desktop app is closed! You can only run engine mode when the desktop app is not open simultaneously!"
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 3,
    "id": "1b0915b0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#app = pf.GetApplication()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 18,
-   "id": "0a52cfae",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#app"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 19,
-   "id": "d0e21c90",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#app.Show()"
+    "app = pf.GetApplication()"
    ]
   },
   {
@@ -103,15 +86,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "36c0db53-8ca9-41c9-8480-edfed971519a",
+   "metadata": {},
+   "source": [
+    "For this example to work, you need to have a PowerFactory project that is called \"14 Bus System\". This is actually a standard demo in PowerFactory, which you can create from its Start Menu \"Beispiele -> 14 Knoten Netz\"."
+   ]
+  },
+  {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 4,
    "id": "abd4de78",
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "#net = from_pfd(app, prj_name=\"PFExample\")"
+    "net = from_pfd(app, prj_name=\"14 Bus System\", handle_us=\"Nothing\", export_controller=True)"
    ]
   },
   {
@@ -123,23 +114,127 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 21,
-   "id": "5a03212c",
+   "cell_type": "markdown",
+   "id": "8e1b40ac-67e0-4bd3-952b-631e3e13cd73",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "#all_diffs=validate_pf_conversion(net, tolerance_mva=1e-9)"
+    "Now we can compare the load flow results between the original PowerFactory model and pandapower by running:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
-   "id": "e3895c0d",
+   "execution_count": 5,
+   "id": "5a03212c",
    "metadata": {},
    "outputs": [],
    "source": [
-    "#all_diffs['diff_vm'].describe()"
+    "all_diffs=validate_pf_conversion(net, tolerance_mva=1e-9)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "e3895c0d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>diff</th>\n",
+       "      <th>vm_pu_pp</th>\n",
+       "      <th>vm_pu_pf</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>1.300000e+01</td>\n",
+       "      <td>13.000000</td>\n",
+       "      <td>13.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>3.625301e-07</td>\n",
+       "      <td>1.047850</td>\n",
+       "      <td>1.047850</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>2.302592e-07</td>\n",
+       "      <td>0.022170</td>\n",
+       "      <td>0.022170</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>8.695965e-09</td>\n",
+       "      <td>1.010000</td>\n",
+       "      <td>1.010000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>2.140296e-07</td>\n",
+       "      <td>1.035795</td>\n",
+       "      <td>1.035796</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>3.369854e-07</td>\n",
+       "      <td>1.051328</td>\n",
+       "      <td>1.051329</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>4.779369e-07</td>\n",
+       "      <td>1.057082</td>\n",
+       "      <td>1.057082</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>7.525142e-07</td>\n",
+       "      <td>1.090000</td>\n",
+       "      <td>1.090000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "               diff   vm_pu_pp   vm_pu_pf\n",
+       "count  1.300000e+01  13.000000  13.000000\n",
+       "mean   3.625301e-07   1.047850   1.047850\n",
+       "std    2.302592e-07   0.022170   0.022170\n",
+       "min    8.695965e-09   1.010000   1.010000\n",
+       "25%    2.140296e-07   1.035795   1.035796\n",
+       "50%    3.369854e-07   1.051328   1.051329\n",
+       "75%    4.779369e-07   1.057082   1.057082\n",
+       "max    7.525142e-07   1.090000   1.090000"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all_diffs['diff_vm'].describe()"
    ]
   }
  ],
@@ -163,7 +258,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.12.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
I fixed an outdated import-call in the ipython-notebook-tutorial of the powerfactory converter, as well as one function (ga) that did not work for zip-loads, because that function was not properly declared in the code. The recent example was tested on the 15-bus and 39-bus grid model in powerfactory.