### PR TITLE
added some config for black users

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,3 +113,7 @@ exclude_lines = [
     "def __str__",
     "if __name__ == .__main__.:"
 ]
+
+# styeling information for black formatter
+[tool.black]
+line-length = 120


### PR DESCRIPTION
added a tools.black section to the toml for any black config. So that all users using black have a consistent config.

This does not force anyone to use black, nor does it change anything in the pipelines! It only affects the behavior of black if it is used by the individual developer.