### PR TITLE
Add python 3.13 support

### DIFF
--- a/.github/workflows/github_test_action.yml
+++ b/.github/workflows/github_test_action.yml
@@ -18,7 +18,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         # Reminder: when removing the support of an old python version here, then don't forget to
         # remove it also in pyproject.toml 'requires-python'
         group: [ 1, 2 ]
@@ -133,7 +133,7 @@ jobs:
     timeout-minutes: 30
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.13']
         group: [ 1, 2 ]
     steps:
     - uses: actions/checkout@v4
@@ -158,7 +158,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
     steps:
     - uses: actions/checkout@v4
     - name: Install uv
@@ -240,7 +240,7 @@ jobs:
           --health-retries 5
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.13']
     steps:
     - name: Wait for PostgreSQL database to be ready
       run: |

--- a/.github/workflows/test_release.yml
+++ b/.github/workflows/test_release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os:  [ ubuntu-latest, windows-latest ]
         group: [ 1, 2 ]
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Change Log
 
 [upcoming release] - 2025-..-..
 -------------------------------
+- [ADDED] python: support for version 3.13 added to the test pipelines
 - [ADDED] postgresql: support for setting a port for the connection
 - [FIXED] ensure proper handling of `indent` parameter for PPJSONEncoder, fixing compatibility with Python3.13
 - [ADDED] description for `slack` argument in docstring of create_gen function

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12"
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13"
 ]
 dependencies = [
     "pandas>=1.0",


### PR DESCRIPTION
Add python 3.13 to github workflow files and pyproject.toml

I'm not sure what to do with python version in some jobs: the version is neither the minimal supported nor the latest. Should they also be updated or is there a particular reason to keep them pinned? Versions in question:
* `linting` https://github.com/e2nIEE/pandapower/blob/0260bf693dbbb2ac067e38df5012242bb41b51f6/.github/workflows/github_test_action.yml#L197
* `tutorial_tests` https://github.com/e2nIEE/pandapower/blob/0260bf693dbbb2ac067e38df5012242bb41b51f6/.github/workflows/github_test_action.yml#L296
* `tutorial_warnings_tests` https://github.com/e2nIEE/pandapower/blob/0260bf693dbbb2ac067e38df5012242bb41b51f6/.github/workflows/github_test_action.yml#L320

