### PR TITLE
pf_res_plotly throws error when no ext_grid element in net obj

### DIFF
--- a/pandapower/plotting/plotly/pf_res_plotly.py
+++ b/pandapower/plotting/plotly/pf_res_plotly.py
@@ -159,11 +159,13 @@ def pf_res_plotly(net, cmap="Jet", use_line_geo=None, on_map=False, projection=N
                                       cmap=cmap_lines, cmin=0, cmax=100)
 
     # ----- Ext grid ------
+    ext_grid_trace = []
     # get external grid from create_bus_trace
-    marker_type = 'circle' if on_map else 'square'
-    ext_grid_trace = create_bus_trace(net, buses=net.ext_grid.bus,
-                                      color='grey', size=bus_size * 2, trace_name='external_grid',
-                                      patch_type=marker_type)
+    if 'ext_grid' in net and len(net.ext_grid):
+        marker_type = 'circle' if on_map else 'square'
+        ext_grid_trace = create_bus_trace(net, buses=net.ext_grid.bus,
+                                          color='grey', size=bus_size * 2, trace_name='external_grid',
+                                          patch_type=marker_type)
 
     return draw_traces(line_traces + trafo_traces + ext_grid_trace + bus_trace,
                        showlegend=False, aspectratio=aspectratio, on_map=on_map,


### PR DESCRIPTION
Pf_res_plotly function has no checks if net element has ext_grid element or not. Creates an error when no ext_grid Element is in network.

Easy fix for more robustness 