### PR TITLE
Improved tests for Trafo 3ph current consistency

### DIFF
--- a/pandapower/test/consistency_checks.py
+++ b/pandapower/test/consistency_checks.py
@@ -21,9 +21,9 @@ def runpp_with_consistency_checks(net, **kwargs):
     consistency_checks(net)
     return True
 
-def runpp_3ph_with_consistency_checks(net, rtol=2e-3, **kwargs):
+def runpp_3ph_with_consistency_checks(net, **kwargs):
     runpp_3ph(net, **kwargs)
-    consistency_checks_3ph(net, rtol)
+    consistency_checks_3ph(net)
     return True
 
 def rundcpp_with_consistency_checks(net, **kwargs):
@@ -168,12 +168,11 @@ def element_power_consistent_with_bus_power(net, rtol=1e-2, test_q=True):
         assert allclose(net.res_bus.q_mvar.values, bus_q.values, equal_nan=True, rtol=rtol)
 
 
-def consistency_checks_3ph(net, rtol):
+def consistency_checks_3ph(net, rtol=2e-3):
     assert net.converged
     indices_consistent_3ph(net)
     branch_loss_consistent_with_bus_feed_in_3ph(net, rtol)
     element_power_consistent_with_bus_power_3ph(net, rtol)
-    trafo_currents_consistent_3ph(net, rtol)
 
 def indices_consistent_3ph(net):
     elements = get_relevant_elements("pf_3ph")

--- a/pandapower/test/consistency_checks.py
+++ b/pandapower/test/consistency_checks.py
@@ -21,9 +21,9 @@ def runpp_with_consistency_checks(net, **kwargs):
     consistency_checks(net)
     return True
 
-def runpp_3ph_with_consistency_checks(net, **kwargs):
+def runpp_3ph_with_consistency_checks(net, rtol=2e-3, **kwargs):
     runpp_3ph(net, **kwargs)
-    consistency_checks_3ph(net)
+    consistency_checks_3ph(net, rtol)
     return True
 
 def rundcpp_with_consistency_checks(net, **kwargs):
@@ -168,11 +168,12 @@ def element_power_consistent_with_bus_power(net, rtol=1e-2, test_q=True):
         assert allclose(net.res_bus.q_mvar.values, bus_q.values, equal_nan=True, rtol=rtol)
 
 
-def consistency_checks_3ph(net, rtol=2e-3):
+def consistency_checks_3ph(net, rtol):
+    assert net.converged
     indices_consistent_3ph(net)
     branch_loss_consistent_with_bus_feed_in_3ph(net, rtol)
     element_power_consistent_with_bus_power_3ph(net, rtol)
-    trafo_currents_consistent_3ph(net)
+    trafo_currents_consistent_3ph(net, rtol)
 
 def indices_consistent_3ph(net):
     elements = get_relevant_elements("pf_3ph")
@@ -330,11 +331,10 @@ def check_ynyn_traformer_currents(i_hv, i_lv, ratio, shift_degree, rtol):
         assert isclose(i_hv[1], -i_lv[1] / ratio, rtol)
         assert isclose(i_hv[2], -i_lv[2] / ratio, rtol)
 
-def trafo_currents_consistent_3ph(net):
+def trafo_currents_consistent_3ph(net, rtol):
     """
     The HV and LV currents of the transformer has to be related in accordance with trafo vector_group and clock
     """
-    rtol = 1e-1
     if "vector_group" not in net.trafo:
         return
     for vector_group, trafo_df in net.trafo.groupby('vector_group'):


### PR DESCRIPTION
PR #2720 fixed the transformer power and current consistency problems. One of the key change was applying negative shift in case of negative sequence. But current tests created in `loadflow/test_runpp_3ph.py::test_trafo_asym__with_shift` only worked with rtol=1e-1 (hardcoded in `trafo_currents_consistent_3ph` function in consistency_checks.py) and also the test worked for both positive and negative shift in negative sequence due to low rtol value.
Now I've updated the test network with a simple network in `test_trafo_asym_currents__high_neg_seq` and made shunt admittance of transformer 0 in both positive and zero sequence so shunt currents do not disturb our consistency checks. With this change, the tests are now working with **rtol=1e-9**, also the test now fails if shift is not reversed for negative sequence in build_branch.py.
Also the `trafo_currents_consistent_3ph` is not run for all tests as it can easily fail with significant shunt admittance.

Consequently this PR will establish proper tests for current consistency of trafo currents.