### PR TITLE
`from_cim` parameter `file_list` can also be a string

### DIFF
--- a/pandapower/converter/cim/cim2pp/from_cim.py
+++ b/pandapower/converter/cim/cim2pp/from_cim.py
@@ -96,7 +96,7 @@ def get_converter_classes():
     return converter_classes
 
 
-def from_cim(file_list: List[str] = None, encoding: str = None, convert_line_to_switch: bool = False,
+def from_cim(file_list: Union[str, List[str]] = None, encoding: str = None, convert_line_to_switch: bool = False,
              line_r_limit: float = 0.1, line_x_limit: float = 0.1,
              repair_cim: Union[str, interfaces.CIMRepair] = None,
              repair_cim_class: Type[interfaces.CIMRepair] = None,
@@ -122,7 +122,7 @@ def from_cim(file_list: List[str] = None, encoding: str = None, convert_line_to_
     - ignore_errors (bool): Option to disable raising of internal errors. Useful if you need to get a network not matter
     if there are errors in the conversion. Default: True.
 
-    :param file_list: The path to the CGMES files as a list.
+    :param file_list: The path to the CGMES files as a string or list.
     :param encoding: The encoding from the files. Optional, default: None
     :param convert_line_to_switch: Set this parameter to True to enable line -> switch conversion. All lines with a
         resistance lower or equal than line_r_limit or a reactance lower or equal than line_x_limit will become a


### PR DESCRIPTION
As shown in the [docs](https://github.com/e2nIEE/pandapower/blob/2fc2e207f30c517b5351a0128527c4886e2cb133/doc/converter/cgmes.rst?plain=1#L37), the parameter `file_list` of `from_cim` can also be a string not only a list.  
The function calls internally [CimParser.parse_files](https://github.com/e2nIEE/pandapower/blob/2fc2e207f30c517b5351a0128527c4886e2cb133/pandapower/converter/cim/cim_classes.py#L38) where the type annotation
```python
file_list: List[str] | str = None
```
indicates that strings are allowed as well.

Due to the currenty wrong type annotation my linter is complaining when passing a string:
<img width="952" height="166" alt="grafik" src="https://github.com/user-attachments/assets/9839d61b-9f01-42b5-9632-4417e6888bd9" />

This PR fixes this issue.