### PR TITLE
Bump lightsim2grid dependency to 0.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ docs = [
 ]
 plotting = ["plotly~=6.3", "matplotlib~=3.10", "igraph", "geopandas~=1.1"]
 test = ["pytest~=8.4", "pytest-xdist~=3.8", "nbmake~=1.5"]
-performance = ["ortools~=9.14", "numba~=0.61", "lightsim2grid~=0.10.3"]
+performance = ["ortools~=9.14", "numba~=0.61", "lightsim2grid~=0.11.0"]
 fileio = ["xlsxwriter~=3.2", "openpyxl~=3.1", "cryptography~=46.0", "geopandas~=1.1", "psycopg~=3.2", "lxml~=6.0"]
 converter = ["matpowercaseframes~=1.1", "lxml~=6.0"]
 pgm = ["power-grid-model-io~=1.2"]


### PR DESCRIPTION
This is currently preventing installation on Python 3.14.