### PR TITLE
Preserve valid ACLineSegments when some have missing terminals

### DIFF
--- a/pandapower/converter/cim/cim2pp/converter_classes/lines/acLineSegmentsCim16.py
+++ b/pandapower/converter/cim/cim2pp/converter_classes/lines/acLineSegmentsCim16.py
@@ -109,7 +109,14 @@ class AcLineSegmentsCim16:
                 self.cimConverter.report_container.add_log(Report(
                     level=LogLevel.WARNING, code=ReportCode.WARNING_CONVERTING,
                     message="The ACLineSegment with RDF ID %s has %s Terminals!" % (rdfId, count)))
-            ac_line_segments = ac_line_segments[0:0]
+            # Only remove the problematic ACLineSegments, keep the valid ones
+            ac_line_segments = ac_line_segments[~ac_line_segments['rdfId'].isin(dups.index)]
+            self.logger.warning("Removed %s ACLineSegments with invalid Terminals, continuing with %s valid segments." %
+                                (len(dups), ac_line_segments.index.size // 2))
+            self.cimConverter.report_container.add_log(Report(
+                level=LogLevel.WARNING, code=ReportCode.WARNING_CONVERTING,
+                message="Removed %s ACLineSegments with invalid Terminals, continuing with %s valid segments." %
+                        (len(dups), ac_line_segments.index.size // 2)))
         ac_line_segments = ac_line_segments.reset_index()
         # now merge with OperationalLimitSets and CurrentLimits
         eq_operational_limit_sets = self.cimConverter.cim['eq']['OperationalLimitSet'][['rdfId', 'Terminal']]

--- a/pandapower/test/converter/test_from_cim.py
+++ b/pandapower/test/converter/test_from_cim.py
@@ -8,7 +8,8 @@ import pandas as pd
 
 from pandapower.test import test_path
 
-from pandapower.converter.cim.cim2pp.from_cim import from_cim
+from pandapower.converter.cim.cim2pp.from_cim import from_cim, from_cim_dict
+from pandapower.converter.cim.cim_classes import CimParser
 from pandapower.run import runpp
 
 from pandapower.control.util.auxiliary import create_trafo_characteristic_object, create_shunt_characteristic_object
@@ -1396,6 +1397,164 @@ def test_fullgrid_NB_switch(fullgrid_node_breaker):
     assert element_1['terminal_bus'].item() == '_1c134839-5bad-124e-93a4-b11663025232'
     assert element_1['terminal_element'].item() == '_ea6bb748-b513-0947-a59b-abd50155dad2'
     assert element_1['description'].item() == 'BE_LB_1'
+
+
+def test_acline_segment_with_only_rdf_id_should_not_empty_all_lines():
+    """
+    Test that an ACLineSegment with only rdf:id set (no other attributes, no terminals)
+    does not cause all valid lines to be removed from the resulting net.line dataframe.
+
+    This is a regression test for a bug where the converter empties the entire
+    net.line dataframe when any ACLineSegment has missing terminals, instead of
+    just skipping the problematic segment.
+
+    The bug is in _prepare_ac_line_segments_cim16() which sets:
+        ac_line_segments = ac_line_segments[0:0]
+    when ANY ACLineSegment doesn't have exactly 2 terminals, instead of just
+    removing the problematic segments.
+    """
+    # Create CimParser and get an empty cim data structure
+    cim_parser = CimParser(cgmes_version='2.4.15')
+    cim = cim_parser.get_cim_data_structure()
+
+    # Create base voltage
+    cim['eq']['BaseVoltage'] = pd.DataFrame({
+        'rdfId': ['_bv1'],
+        'name': ['110kV'],
+        'nominalVoltage': [110.0]
+    })
+
+    # Create substation and voltage level
+    cim['eq']['GeographicalRegion'] = pd.DataFrame({
+        'rdfId': ['_geo1'],
+        'name': ['Region1']
+    })
+    cim['eq']['SubGeographicalRegion'] = pd.DataFrame({
+        'rdfId': ['_subgeo1'],
+        'name': ['SubRegion1'],
+        'Region': ['_geo1']
+    })
+    cim['eq']['Substation'] = pd.DataFrame({
+        'rdfId': ['_sub1'],
+        'name': ['Substation1'],
+        'Region': ['_subgeo1']
+    })
+    cim['eq']['VoltageLevel'] = pd.DataFrame({
+        'rdfId': ['_vl1'],
+        'name': ['VL1'],
+        'shortName': ['VL1'],
+        'BaseVoltage': ['_bv1'],
+        'Substation': ['_sub1']
+    })
+
+    # Create connectivity nodes (buses)
+    cim['eq']['ConnectivityNode'] = pd.DataFrame({
+        'rdfId': ['_cn1', '_cn2'],
+        'name': ['CN1', 'CN2'],
+        'description': ['Node 1', 'Node 2'],
+        'ConnectivityNodeContainer': ['_vl1', '_vl1']
+    })
+
+    # Create topological nodes
+    cim['tp']['TopologicalNode'] = pd.DataFrame({
+        'rdfId': ['_tn1', '_tn2'],
+        'name': ['TN1', 'TN2'],
+        'description': ['TopNode 1', 'TopNode 2'],
+        'ConnectivityNodeContainer': ['_vl1', '_vl1'],
+        'BaseVoltage': ['_bv1', '_bv1']
+    })
+    cim['tp']['ConnectivityNode'] = pd.DataFrame({
+        'rdfId': ['_cn1', '_cn2'],
+        'TopologicalNode': ['_tn1', '_tn2']
+    })
+
+    # Create one valid ACLineSegment with all required attributes
+    valid_line_id = '_valid_line'
+    # Create one ACLineSegment with only rdf:id (this is the problematic element)
+    invalid_line_id = '_invalid_line_only_rdf_id'
+
+    cim['eq']['ACLineSegment'] = pd.DataFrame({
+        'rdfId': [valid_line_id, invalid_line_id],
+        'name': ['ValidLine', np.nan],
+        'description': ['A valid line', np.nan],
+        'length': [10.0, np.nan],
+        'r': [0.1, np.nan],
+        'x': [0.4, np.nan],
+        'bch': [1e-6, np.nan],
+        'gch': [0.0, np.nan],
+        'r0': [0.3, np.nan],
+        'x0': [1.2, np.nan],
+        'b0ch': [0.5e-6, np.nan],
+        'g0ch': [0.0, np.nan],
+        'shortCircuitEndTemperature': [80.0, np.nan],
+        'BaseVoltage': ['_bv1', np.nan],
+        'EquipmentContainer': ['_vl1', np.nan]
+    })
+
+    # Create terminals ONLY for the valid line (the invalid line has no terminals)
+    cim['eq']['Terminal'] = pd.DataFrame({
+        'rdfId': ['_term1', '_term2'],
+        'name': ['Terminal1', 'Terminal2'],
+        'ConnectivityNode': ['_cn1', '_cn2'],
+        'ConductingEquipment': [valid_line_id, valid_line_id],
+        'sequenceNumber': [1, 2]
+    })
+    cim['ssh']['Terminal'] = pd.DataFrame({
+        'rdfId': ['_term1', '_term2'],
+        'connected': [True, True]
+    })
+    cim['tp']['Terminal'] = pd.DataFrame({
+        'rdfId': ['_term1', '_term2'],
+        'TopologicalNode': ['_tn1', '_tn2']
+    })
+
+    # Create empty operational limit sets and current limits (required by converter)
+    cim['eq']['OperationalLimitSet'] = pd.DataFrame({
+        'rdfId': pd.Series([], dtype='object'),
+        'name': pd.Series([], dtype='object'),
+        'Terminal': pd.Series([], dtype='object')
+    })
+    cim['eq']['CurrentLimit'] = pd.DataFrame({
+        'rdfId': pd.Series([], dtype='object'),
+        'name': pd.Series([], dtype='object'),
+        'OperationalLimitSet': pd.Series([], dtype='object'),
+        'OperationalLimitType': pd.Series([], dtype='object'),
+        'value': pd.Series([], dtype='float64')
+    })
+
+    # Set the cim dict and prepare
+    cim_parser.set_cim_dict(cim)
+    cim_parser.prepare_cim_net()
+    cim_parser.set_cim_data_types()
+
+    # Convert to pandapower - this should NOT raise an exception
+    # and should produce a net with the valid line preserved
+    try:
+        net = from_cim_dict(cim_parser, ignore_errors=True)
+    except Exception as e:
+        # If we get here, the conversion crashed - which is also a bug manifestation
+        pytest.fail(
+            f"Conversion crashed with exception: {e}\n"
+            "This is caused by the bug where all ACLineSegments are removed when any "
+            "single ACLineSegment has invalid terminals, leaving an empty dataframe "
+            "that causes downstream processing errors."
+        )
+
+    # The valid line SHOULD be present in net.line
+    # This assertion will FAIL with the current bug because the entire net.line
+    # dataframe is empty when any ACLineSegment has missing terminals
+    assert len(net.line) >= 1, (
+        f"Expected at least 1 line in net.line, but got {len(net.line)}. "
+        "An ACLineSegment with only rdf:id set should not cause all valid lines to be removed."
+    )
+
+    # Verify the valid line was converted
+    valid_lines = net.line[net.line['origin_id'] == valid_line_id]
+    assert len(valid_lines) == 1, (
+        f"Expected the valid ACLineSegment '{valid_line_id}' to be converted, "
+        f"but it was not found in net.line."
+    )
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-xs"])


### PR DESCRIPTION
## Bug Description

When converting CGMES/CIM data to pandapower, if any `ACLineSegment` element has an incorrect number of terminals (e.g., missing terminals, or only the `rdf:id` is set), the converter removes **all** ACLineSegments from the resulting network, including perfectly valid ones.

## Expected Behavior

The converter should skip only the invalid ACLineSegments and continue processing the valid ones.

## Actual Behavior

The entire `net.line` DataFrame is empty, even when valid ACLineSegments exist in the input data.

## Example

Input CGMES data with 2 ACLineSegments:
- `Line_A`: Valid, with 2 terminals properly connected
- `Line_B`: Invalid, only has `rdf:id` set (no terminals)

```python
from pandapower.converter.cim.cim2pp.from_cim import from_cim

net = from_cim(file_list=['grid_with_incomplete_line.zip'])
print(len(net.line))  # Returns 0, but should return 1 (Line_A)
```

## Root Cause

In `acLineSegmentsCim16.py`, line 112:
```python
ac_line_segments = ac_line_segments[0:0]  # Empties ALL segments
```

This was triggered when the total row count after merging with terminals didn't match `num_segments * 2`.

## Fix

Replace with filtering that removes only the problematic segments:
```python
ac_line_segments = ac_line_segments[~ac_line_segments['rdfId'].isin(dups.index)]
```

## Affected Version

pandapower 3.x (and likely earlier versions)
