### PR TITLE
PandaModels: support results-based warm starts when exporting to PowerModels and fix radians conversion

### DIFF
--- a/pandapower/converter/pandamodels/to_pm.py
+++ b/pandapower/converter/pandamodels/to_pm.py
@@ -24,7 +24,7 @@ from pandapower.pypower.idx_bus import ZONE, VA, BASE_KV, BS, GS, BUS_I, BUS_TYP
      VM, PD, QD
 from pandapower.pypower.idx_cost import MODEL, NCOST, COST
 from pandapower.pypower.idx_gen import PG, QG, GEN_BUS, VG, GEN_STATUS, QMAX, QMIN, PMIN, PMAX
-from pandapower.results import init_results
+from pandapower.results import init_results, verify_results
 
 
 # const value in branch for tnep
@@ -57,7 +57,7 @@ def convert_pp_to_pm(net, pm_file_path=None, correct_pm_network_data=True,
                      check_connectivity=True, pp_to_pm_callback=None, pm_model="ACPPowerModel",
                      pm_solver="ipopt",
                      pm_mip_solver="cbc", pm_nl_solver="ipopt", opf_flow_lim="S", pm_tol=1e-8,
-                     voltage_depend_loads=False, from_time_step=None, to_time_step=None, **kwargs):
+                     voltage_depend_loads=False, from_time_step=None, to_time_step=None, init_vm_pu="flat", init_va_degree="flat", **kwargs):
     """
     Converts a pandapower net to a PowerModels.jl datastructure and saves it to a json file
     INPUT:
@@ -114,7 +114,7 @@ def convert_pp_to_pm(net, pm_file_path=None, correct_pm_network_data=True,
 
     _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
                      trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu=init_vm_pu, init_va_degree=init_va_degree, enforce_p_lims=False,
                      enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
                      voltage_depend_loads=voltage_depend_loads, delta=delta,
                      trafo3w_losses=trafo3w_losses)
@@ -146,7 +146,10 @@ def convert_to_pm_structure(net, opf_flow_lim="S", from_time_step=None, to_time_
     net["OPF_converged"] = False
     net["converged"] = False
     _add_auxiliary_elements(net)
-    init_results(net)
+    if net["_options"].get("init_results"):
+        verify_results(net, mode=net["_options"]["mode"])
+    else:
+        init_results(net)
     ppc, ppci = _pd2ppc(net)
     ppci = build_ne_branch(net, ppci)
     net["_ppc_opf"] = ppci
@@ -283,7 +286,7 @@ def ppc_to_pm(net, ppci):
         bus["bus_type"] = int(row[BUS_TYPE])
         bus["vmax"] = row[VMAX]
         bus["vmin"] = row[VMIN]
-        bus["va"] = row[VA]
+        bus["va"] = math.radians(row[VA]) # PowerModels uses radians
         bus["vm"] = row[VM]
         bus["base_kv"] = row[BASE_KV]
 

--- a/pandapower/runpm.py
+++ b/pandapower/runpm.py
@@ -3,38 +3,18 @@
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 
-from pandapower.auxiliary import _add_opf_options, _add_ppc_options
+from pandapower.auxiliary import _add_ppc_options, _add_opf_options
 from pandapower.converter.pandamodels.from_pm import read_ots_results, read_tnep_results
 from pandapower.opf.pm_storage import add_storage_opf_settings
 from pandapower.opf.run_pandamodels import _runpm
 
 
-def runpm(
-    net,
-    julia_file=None,
-    pp_to_pm_callback=None,
-    calculate_voltage_angles=True,
-    trafo_model="t",
-    delta=1e-8,
-    trafo3w_losses="hv",
-    check_connectivity=True,
-    correct_pm_network_data=True,
-    silence=True,
-    pm_model="ACPPowerModel",
-    pm_solver="ipopt",
-    pm_mip_solver="highs",
-    pm_nl_solver="ipopt",
-    pm_time_limits=None,
-    pm_log_level=0,
-    delete_buffer_file=True,
-    pm_file_path=None,
-    opf_flow_lim="S",
-    pm_tol=1e-8,
-    pdm_dev_mode=False,
-    init_vm_pu="flat",
-    init_va_degree="flat",
-    **kwargs,
-):  # pragma: no cover
+def runpm(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_angles=True,
+          trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
+          correct_pm_network_data=True, silence=True, pm_model="ACPPowerModel", pm_solver="ipopt",
+          pm_mip_solver="highs", pm_nl_solver="ipopt", pm_time_limits=None, pm_log_level=0,
+          delete_buffer_file=True, pm_file_path = None, opf_flow_lim="S", pm_tol=1e-8,
+          pdm_dev_mode=False, init_vm_pu="flat", init_va_degree="flat", **kwargs):  # pragma: no cover
     """
     Runs  optimal power flow from PowerModels.jl via PandaModels.jl
 
@@ -96,195 +76,71 @@ def runpm(
     """
     ac = True if "DC" not in pm_model else False
     net._options = {}
-    _add_ppc_options(
-        net,
-        calculate_voltage_angles=calculate_voltage_angles,
-        trafo_model=trafo_model,
-        check_connectivity=check_connectivity,
-        mode="opf",
-        switch_rx_ratio=2,
-        init_vm_pu=init_vm_pu,
-        init_va_degree=init_va_degree,
-        enforce_p_lims=False,
-        enforce_q_lims=True,
-        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
-        voltage_depend_loads=False,
-        delta=delta,
-        trafo3w_losses=trafo3w_losses,
-    )
-    _add_opf_options(
-        net,
-        trafo_loading="power",
-        ac=ac,
-        init="flat",
-        numba=True,
-        pp_to_pm_callback=pp_to_pm_callback,
-        julia_file="run_powermodels_opf",
-        pm_solver=pm_solver,
-        pm_model=pm_model,
-        correct_pm_network_data=correct_pm_network_data,
-        silence=silence,
-        pm_mip_solver=pm_mip_solver,
-        pm_nl_solver=pm_nl_solver,
-        pm_time_limits=pm_time_limits,
-        pm_log_level=pm_log_level,
-        opf_flow_lim=opf_flow_lim,
-        pm_tol=pm_tol,
-    )
+    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
+                     trafo_model=trafo_model, check_connectivity=check_connectivity,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu=init_vm_pu, init_va_degree=init_va_degree, enforce_p_lims=False,
+                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
+                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+    _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
+                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_opf", pm_solver=pm_solver, pm_model=pm_model,
+                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_mip_solver=pm_mip_solver,
+                     pm_nl_solver=pm_nl_solver, pm_time_limits=pm_time_limits, pm_log_level=pm_log_level,
+                     opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-def runpm_dc_opf(
-    net,
-    pp_to_pm_callback=None,
-    calculate_voltage_angles=True,
-    trafo_model="t",
-    delta=1e-8,
-    trafo3w_losses="hv",
-    check_connectivity=True,
-    correct_pm_network_data=True,
-    silence=True,
-    pm_model="DCPPowerModel",
-    pm_solver="ipopt",
-    pm_time_limits=None,
-    pm_log_level=0,
-    delete_buffer_file=True,
-    pm_file_path=None,
-    pm_tol=1e-8,
-    pdm_dev_mode=False,
-    init_vm_pu="flat",
-    init_va_degree="flat",
-    **kwargs,
-):
+def runpm_dc_opf(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
+                 trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
+                 correct_pm_network_data=True, silence=True, pm_model="DCPPowerModel", pm_solver="ipopt",
+                 pm_time_limits=None, pm_log_level=0, delete_buffer_file=True, pm_file_path = None,
+                 pm_tol=1e-8, pdm_dev_mode=False, init_vm_pu="flat", init_va_degree="flat", **kwargs):
     """
     Runs linearized optimal power flow from PowerModels.jl via PandaModels.jl
     """
     net._options = {}
-    _add_ppc_options(
-        net,
-        calculate_voltage_angles=calculate_voltage_angles,
-        trafo_model=trafo_model,
-        check_connectivity=check_connectivity,
-        mode="opf",
-        switch_rx_ratio=2,
-        init_vm_pu="flat",
-        init_va_degree="flat",
-        enforce_p_lims=False,
-        enforce_q_lims=True,
-        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
-        voltage_depend_loads=False,
-        delta=delta,
-        trafo3w_losses=trafo3w_losses,
-    )
-    _add_opf_options(
-        net,
-        trafo_loading="power",
-        ac=False,
-        init="flat",
-        numba=True,
-        pp_to_pm_callback=pp_to_pm_callback,
-        julia_file="run_powermodels_opf",
-        correct_pm_network_data=correct_pm_network_data,
-        silence=silence,
-        pm_model=pm_model,
-        pm_solver=pm_solver,
-        pm_time_limits=pm_time_limits,
-        pm_log_level=pm_log_level,
-        opf_flow_lim="S",
-        pm_tol=pm_tol,
-    )
+    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
+                     trafo_model=trafo_model, check_connectivity=check_connectivity,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu=init_vm_pu, init_va_degree=init_va_degree, enforce_p_lims=False,
+                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
+                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+    _add_opf_options(net, trafo_loading='power', ac=False, init="flat", numba=True,
+                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_opf",
+                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_model=pm_model, pm_solver=pm_solver,
+                     pm_time_limits=pm_time_limits, pm_log_level=pm_log_level, opf_flow_lim="S", pm_tol=pm_tol)
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-def runpm_ac_opf(
-    net,
-    pp_to_pm_callback=None,
-    calculate_voltage_angles=True,
-    trafo_model="t",
-    delta=1e-8,
-    trafo3w_losses="hv",
-    check_connectivity=True,
-    pm_solver="ipopt",
-    correct_pm_network_data=True,
-    silence=True,
-    pm_time_limits=None,
-    pm_log_level=0,
-    pm_file_path=None,
-    delete_buffer_file=True,
-    opf_flow_lim="S",
-    pm_tol=1e-8,
-    pdm_dev_mode=False,
-    init_vm_pu="flat",
-    init_va_degree="flat",
-    **kwargs,
-):
+def runpm_ac_opf(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
+                 trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
+                 pm_solver="ipopt", correct_pm_network_data=True, silence=True,
+                 pm_time_limits=None, pm_log_level=0, pm_file_path=None, delete_buffer_file=True,
+                 opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, init_vm_pu="flat", init_va_degree="flat", **kwargs):
     """
     Runs non-linear optimal power flow from PowerModels.jl via PandaModels.jl
     """
     net._options = {}
-    _add_ppc_options(
-        net,
-        calculate_voltage_angles=calculate_voltage_angles,
-        trafo_model=trafo_model,
-        check_connectivity=check_connectivity,
-        mode="opf",
-        switch_rx_ratio=2,
-        init_vm_pu="flat",
-        init_va_degree="flat",
-        enforce_p_lims=False,
-        enforce_q_lims=True,
-        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
-        voltage_depend_loads=False,
-        delta=delta,
-        trafo3w_losses=trafo3w_losses,
-    )
-    _add_opf_options(
-        net,
-        trafo_loading="power",
-        ac=True,
-        init="flat",
-        numba=True,
-        pp_to_pm_callback=pp_to_pm_callback,
-        julia_file="run_powermodels_opf",
-        pm_model="ACPPowerModel",
-        pm_solver=pm_solver,
-        correct_pm_network_data=correct_pm_network_data,
-        silence=silence,
-        pm_time_limits=pm_time_limits,
-        pm_log_level=pm_log_level,
-        opf_flow_lim=opf_flow_lim,
-        pm_tol=pm_tol,
-    )
+    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
+                     trafo_model=trafo_model, check_connectivity=check_connectivity,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu=init_vm_pu, init_va_degree=init_va_degree, enforce_p_lims=False,
+                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
+                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
+                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_opf", pm_model="ACPPowerModel", pm_solver=pm_solver,
+                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
+                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-def runpm_tnep(
-    net,
-    julia_file=None,
-    pp_to_pm_callback=None,
-    calculate_voltage_angles=True,
-    trafo_model="t",
-    delta=1e-8,
-    trafo3w_losses="hv",
-    check_connectivity=True,
-    pm_model="ACPPowerModel",
-    pm_solver="juniper",
-    correct_pm_network_data=True,
-    silence=True,
-    pm_nl_solver="ipopt",
-    pm_mip_solver="highs",
-    pm_time_limits=None,
-    pm_log_level=0,
-    delete_buffer_file=True,
-    pm_file_path=None,
-    opf_flow_lim="S",
-    pm_tol=1e-8,
-    pdm_dev_mode=False,
-    **kwargs,
-):
+
+def runpm_tnep(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_angles=True,
+               trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
+               pm_model="ACPPowerModel", pm_solver="juniper", correct_pm_network_data=True, silence=True,
+               pm_nl_solver="ipopt", pm_mip_solver="highs", pm_time_limits=None, pm_log_level=0,
+               delete_buffer_file=True, pm_file_path=None, opf_flow_lim="S", pm_tol=1e-8,
+               pdm_dev_mode=False, **kwargs):
     """
     Runs transmission network extension planning (tnep) optimization from PowerModels.jl via PandaModels.jl
     """
@@ -298,70 +154,27 @@ def runpm_tnep(
     if "ne_line" not in net:
         raise ValueError("ne_line DataFrame missing in net. Please define to run tnep")
     net._options = {}
-    _add_ppc_options(
-        net,
-        calculate_voltage_angles=calculate_voltage_angles,
-        trafo_model=trafo_model,
-        check_connectivity=check_connectivity,
-        mode="opf",
-        switch_rx_ratio=2,
-        init_vm_pu="flat",
-        init_va_degree="flat",
-        enforce_p_lims=False,
-        enforce_q_lims=True,
-        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
-        voltage_depend_loads=False,
-        delta=delta,
-        trafo3w_losses=trafo3w_losses,
-    )
-    _add_opf_options(
-        net,
-        trafo_loading="power",
-        ac=ac,
-        init="flat",
-        numba=True,
-        pp_to_pm_callback=pp_to_pm_callback,
-        julia_file="run_powermodels_tnep",
-        pm_model=pm_model,
-        pm_solver=pm_solver,
-        correct_pm_network_data=correct_pm_network_data,
-        silence=silence,
-        pm_nl_solver=pm_nl_solver,
-        pm_mip_solver=pm_mip_solver,
-        pm_time_limits=pm_time_limits,
-        pm_log_level=pm_log_level,
-        opf_flow_lim=opf_flow_lim,
-        pm_tol=pm_tol,
-    )
+    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
+                     trafo_model=trafo_model, check_connectivity=check_connectivity,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
+                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
+                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+    _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
+                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_tnep", pm_model=pm_model, pm_solver=pm_solver,
+                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_nl_solver=pm_nl_solver,
+                     pm_mip_solver=pm_mip_solver, pm_time_limits=pm_time_limits, pm_log_level=pm_log_level,
+                     opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
     read_tnep_results(net)
 
 
-def runpm_ots(
-    net,
-    julia_file=None,
-    pp_to_pm_callback=None,
-    calculate_voltage_angles=True,
-    trafo_model="t",
-    delta=1e-8,
-    trafo3w_losses="hv",
-    check_connectivity=True,
-    pm_model="DCPPowerModel",
-    pm_solver="juniper",
-    pm_nl_solver="ipopt",
-    pm_mip_solver="highs",
-    correct_pm_network_data=True,
-    silence=True,
-    pm_time_limits=None,
-    pm_log_level=0,
-    delete_buffer_file=True,
-    pm_file_path=None,
-    opf_flow_lim="S",
-    pm_tol=1e-8,
-    pdm_dev_mode=False,
-    **kwargs,
-):
+def runpm_ots(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_angles=True,
+              trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
+              pm_model="DCPPowerModel", pm_solver="juniper", pm_nl_solver="ipopt",
+              pm_mip_solver="highs", correct_pm_network_data=True, silence=True, pm_time_limits=None,
+              pm_log_level=0, delete_buffer_file=True, pm_file_path=None, opf_flow_lim="S", pm_tol=1e-8,
+              pdm_dev_mode=False, **kwargs):
     """
     Runs optimal transmission switching (OTS) optimization from PowerModels.jl via PandaModels.jl
     """
@@ -370,77 +183,28 @@ def runpm_ots(
         pm_solver = "juniper"
 
     net._options = {}
-    _add_ppc_options(
-        net,
-        calculate_voltage_angles=calculate_voltage_angles,
-        trafo_model=trafo_model,
-        check_connectivity=check_connectivity,
-        mode="opf",
-        switch_rx_ratio=2,
-        init_vm_pu="flat",
-        init_va_degree="flat",
-        enforce_p_lims=False,
-        enforce_q_lims=True,
-        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
-        voltage_depend_loads=False,
-        delta=delta,
-        trafo3w_losses=trafo3w_losses,
-    )
-    _add_opf_options(
-        net,
-        trafo_loading="power",
-        ac=ac,
-        init="flat",
-        numba=True,
-        pp_to_pm_callback=pp_to_pm_callback,
-        julia_file="run_powermodels_ots",
-        pm_model=pm_model,
-        pm_solver=pm_solver,
-        correct_pm_network_data=correct_pm_network_data,
-        silence=silence,
-        pm_mip_solver=pm_mip_solver,
-        pm_nl_solver=pm_nl_solver,
-        pm_time_limits=pm_time_limits,
-        pm_log_level=pm_log_level,
-        opf_flow_lim="S",
-        pm_tol=pm_tol,
-    )
+    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
+                     trafo_model=trafo_model, check_connectivity=check_connectivity,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
+                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
+                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+    _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
+                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_ots", pm_model=pm_model, pm_solver=pm_solver,
+                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_mip_solver=pm_mip_solver,
+                     pm_nl_solver=pm_nl_solver, pm_time_limits=pm_time_limits, pm_log_level=pm_log_level,
+                     opf_flow_lim="S", pm_tol=pm_tol)
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
     read_ots_results(net)
 
-
-def runpm_storage_opf(
-    net,
-    from_time_step,
-    to_time_step,
-    calculate_voltage_angles=True,
-    trafo_model="t",
-    delta=1e-8,
-    trafo3w_losses="hv",
-    check_connectivity=True,
-    n_timesteps=24,
-    time_elapsed=1.0,
-    correct_pm_network_data=True,
-    silence=True,
-    pm_solver="juniper",
-    pm_mip_solver="highs",
-    pm_nl_solver="ipopt",
-    pm_model="ACPPowerModel",
-    pm_time_limits=None,
-    pm_log_level=0,
-    opf_flow_lim="S",
-    charge_efficiency=1.0,
-    discharge_efficiency=1.0,
-    standby_loss=1e-8,
-    p_loss=1e-8,
-    q_loss=1e-8,
-    pm_tol=1e-4,
-    pdm_dev_mode=False,
-    delete_buffer_file=True,
-    pm_file_path=None,
-    **kwargs,
-):
+def runpm_storage_opf(net, from_time_step, to_time_step, calculate_voltage_angles=True,
+                      trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
+                      n_timesteps=24, time_elapsed=1., correct_pm_network_data=True, silence=True,
+                      pm_solver="juniper", pm_mip_solver="highs", pm_nl_solver="ipopt",
+                      pm_model="ACPPowerModel", pm_time_limits=None, pm_log_level=0,
+                      opf_flow_lim="S", charge_efficiency=1., discharge_efficiency=1.,
+                      standby_loss=1e-8, p_loss=1e-8, q_loss=1e-8, pm_tol=1e-4, pdm_dev_mode=False,
+                      delete_buffer_file=True, pm_file_path = None, **kwargs):
     """
     Runs a non-linear power system optimization with storages and time series using PandaModels.jl.
     """
@@ -449,42 +213,16 @@ def runpm_storage_opf(
 
     ac = True if "DC" not in pm_model else False
     net._options = {}
-    _add_ppc_options(
-        net,
-        calculate_voltage_angles=calculate_voltage_angles,
-        trafo_model=trafo_model,
-        check_connectivity=check_connectivity,
-        mode="opf",
-        switch_rx_ratio=2,
-        init_vm_pu="flat",
-        init_va_degree="flat",
-        enforce_p_lims=False,
-        enforce_q_lims=True,
-        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
-        voltage_depend_loads=False,
-        delta=delta,
-        trafo3w_losses=trafo3w_losses,
-    )
-    _add_opf_options(
-        net,
-        trafo_loading="power",
-        ac=ac,
-        init="flat",
-        numba=True,
-        pp_to_pm_callback=add_storage_opf_settings,
-        julia_file="run_powermodels_multi_storage",
-        correct_pm_network_data=correct_pm_network_data,
-        silence=silence,
-        pm_model=pm_model,
-        pm_solver=pm_solver,
-        pm_time_limits=pm_time_limits,
-        pm_mip_solver=pm_mip_solver,
-        pm_nl_solver=pm_nl_solver,
-        pm_log_level=pm_log_level,
-        opf_flow_lim=opf_flow_lim,
-        pm_tol=pm_tol,
-        pdm_dev_mode=pdm_dev_mode,
-    )
+    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
+                     trafo_model=trafo_model, check_connectivity=check_connectivity,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
+                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
+                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+    _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
+                     pp_to_pm_callback=add_storage_opf_settings, julia_file="run_powermodels_multi_storage",
+                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_model=pm_model,
+                     pm_solver=pm_solver, pm_time_limits=pm_time_limits, pm_mip_solver=pm_mip_solver, pm_nl_solver=pm_nl_solver,
+                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol, pdm_dev_mode=pdm_dev_mode)
 
     net._options["n_time_steps"] = to_time_step - from_time_step
     net._options["time_elapsed"] = time_elapsed
@@ -492,89 +230,34 @@ def runpm_storage_opf(
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode, **kwargs)
 
 
-def runpm_vstab(
-    net,
-    pp_to_pm_callback=None,
-    calculate_voltage_angles=True,
-    trafo_model="t",
-    delta=1e-8,
-    trafo3w_losses="hv",
-    check_connectivity=True,
-    pm_model="ACPPowerModel",
-    pm_solver="ipopt",
-    correct_pm_network_data=True,
-    silence=True,
-    pm_time_limits=None,
-    pm_log_level=0,
-    pm_file_path=None,
-    delete_buffer_file=True,
-    opf_flow_lim="S",
-    pm_tol=1e-8,
-    pdm_dev_mode=False,
-    **kwargs,
-):
+
+def runpm_vstab(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
+                trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
+                pm_model="ACPPowerModel", pm_solver="ipopt", correct_pm_network_data=True, silence=True,
+                pm_time_limits=None, pm_log_level=0, pm_file_path = None, delete_buffer_file=True,
+                opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
     """
     Runs non-linear problem for voltage deviation minimization from PandaModels.jl.
     """
     net._options = {}
-    _add_ppc_options(
-        net,
-        calculate_voltage_angles=calculate_voltage_angles,
-        trafo_model=trafo_model,
-        check_connectivity=check_connectivity,
-        mode="opf",
-        switch_rx_ratio=2,
-        init_vm_pu="flat",
-        init_va_degree="flat",
-        enforce_p_lims=False,
-        enforce_q_lims=True,
-        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
-        voltage_depend_loads=False,
-        delta=delta,
-        trafo3w_losses=trafo3w_losses,
-    )
-    _add_opf_options(
-        net,
-        trafo_loading="power",
-        ac=True,
-        init="flat",
-        numba=True,
-        pp_to_pm_callback=pp_to_pm_callback,
-        julia_file="run_pandamodels_vstab",
-        pm_model=pm_model,
-        pm_solver=pm_solver,
-        correct_pm_network_data=correct_pm_network_data,
-        silence=silence,
-        pm_time_limits=pm_time_limits,
-        pm_log_level=pm_log_level,
-        opf_flow_lim=opf_flow_lim,
-        pm_tol=pm_tol,
-    )
+    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
+                     trafo_model=trafo_model, check_connectivity=check_connectivity,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
+                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
+                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
+                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_pandamodels_vstab", pm_model=pm_model, pm_solver=pm_solver,
+                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
+                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-def runpm_multi_vstab(
-    net,
-    pp_to_pm_callback=None,
-    calculate_voltage_angles=True,
-    trafo_model="t",
-    delta=1e-8,
-    trafo3w_losses="hv",
-    check_connectivity=True,
-    pm_model="ACPPowerModel",
-    pm_solver="ipopt",
-    correct_pm_network_data=True,
-    silence=True,
-    pm_time_limits=None,
-    pm_log_level=0,
-    pm_file_path=None,
-    delete_buffer_file=True,
-    opf_flow_lim="S",
-    pm_tol=1e-8,
-    pdm_dev_mode=False,
-    **kwargs,
-):
+def runpm_multi_vstab(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
+                      trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
+                      pm_model="ACPPowerModel", pm_solver="ipopt", correct_pm_network_data=True, silence=True,
+                      pm_time_limits=None, pm_log_level=0, pm_file_path = None, delete_buffer_file=True,
+                      opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
     """
     Runs non-linear problem for time-series voltage deviation minimization from PandaModels.jl.
     """
@@ -582,131 +265,49 @@ def runpm_multi_vstab(
         assert isinstance(kwargs["from_time_step"], int)
         assert isinstance(kwargs["from_time_step"], int)
     except (KeyError, AssertionError):
-        raise ValueError(
-            "For time series optimization, you need define 'from_time_step' and 'to_time_step', e.g.,"
-            + " 'from_time_step = 0', 'to_time_step = 15'."
-        )
+        raise ValueError ("For time series optimization, you need define 'from_time_step' and 'to_time_step', e.g.," +
+                          " 'from_time_step = 0', 'to_time_step = 15'.")
     net._options = {}
-    _add_ppc_options(
-        net,
-        calculate_voltage_angles=calculate_voltage_angles,
-        trafo_model=trafo_model,
-        check_connectivity=check_connectivity,
-        mode="opf",
-        switch_rx_ratio=2,
-        init_vm_pu="flat",
-        init_va_degree="flat",
-        enforce_p_lims=False,
-        enforce_q_lims=True,
-        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
-        voltage_depend_loads=False,
-        delta=delta,
-        trafo3w_losses=trafo3w_losses,
-    )
-    _add_opf_options(
-        net,
-        trafo_loading="power",
-        ac=True,
-        init="flat",
-        numba=True,
-        pp_to_pm_callback=pp_to_pm_callback,
-        julia_file="run_pandamodels_multi_vstab",
-        pm_model=pm_model,
-        pm_solver=pm_solver,
-        correct_pm_network_data=correct_pm_network_data,
-        silence=silence,
-        pm_time_limits=pm_time_limits,
-        pm_log_level=pm_log_level,
-        opf_flow_lim=opf_flow_lim,
-        pm_tol=pm_tol,
-    )
+    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
+                     trafo_model=trafo_model, check_connectivity=check_connectivity,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
+                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
+                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
+                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_pandamodels_multi_vstab", pm_model=pm_model, pm_solver=pm_solver,
+                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
+                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode, **kwargs)
 
 
-def runpm_qflex(
-    net,
-    pp_to_pm_callback=None,
-    calculate_voltage_angles=True,
-    trafo_model="t",
-    delta=1e-8,
-    trafo3w_losses="hv",
-    check_connectivity=True,
-    pm_model="ACPPowerModel",
-    pm_solver="ipopt",
-    correct_pm_network_data=True,
-    silence=True,
-    pm_time_limits=None,
-    pm_log_level=0,
-    pm_file_path=None,
-    delete_buffer_file=True,
-    opf_flow_lim="S",
-    pm_tol=1e-8,
-    pdm_dev_mode=False,
-    **kwargs,
-):
+def runpm_qflex(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
+                trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
+                pm_model="ACPPowerModel", pm_solver="ipopt", correct_pm_network_data=True, silence=True,
+                pm_time_limits=None, pm_log_level=0, pm_file_path = None, delete_buffer_file=True,
+                opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
     """
     Runs non-linear optimization for maintaining q-setpoint.
     """
     net._options = {}
-    _add_ppc_options(
-        net,
-        calculate_voltage_angles=calculate_voltage_angles,
-        trafo_model=trafo_model,
-        check_connectivity=check_connectivity,
-        mode="opf",
-        switch_rx_ratio=2,
-        init_vm_pu="flat",
-        init_va_degree="flat",
-        enforce_p_lims=False,
-        enforce_q_lims=True,
-        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
-        voltage_depend_loads=False,
-        delta=delta,
-        trafo3w_losses=trafo3w_losses,
-    )
-    _add_opf_options(
-        net,
-        trafo_loading="power",
-        ac=True,
-        init="flat",
-        numba=True,
-        pp_to_pm_callback=pp_to_pm_callback,
-        julia_file="run_pandamodels_qflex",
-        pm_model=pm_model,
-        pm_solver=pm_solver,
-        correct_pm_network_data=correct_pm_network_data,
-        silence=silence,
-        pm_time_limits=pm_time_limits,
-        pm_log_level=pm_log_level,
-        opf_flow_lim=opf_flow_lim,
-        pm_tol=pm_tol,
-    )
+    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
+                     trafo_model=trafo_model, check_connectivity=check_connectivity,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
+                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
+                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
+                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_pandamodels_qflex", pm_model=pm_model, pm_solver=pm_solver,
+                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
+                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-def runpm_multi_qflex(
-    net,
-    pp_to_pm_callback=None,
-    calculate_voltage_angles=True,
-    trafo_model="t",
-    delta=1e-8,
-    trafo3w_losses="hv",
-    check_connectivity=True,
-    pm_model="ACPPowerModel",
-    pm_solver="ipopt",
-    correct_pm_network_data=True,
-    silence=True,
-    pm_time_limits=None,
-    pm_log_level=0,
-    pm_file_path=None,
-    delete_buffer_file=True,
-    opf_flow_lim="S",
-    pm_tol=1e-8,
-    pdm_dev_mode=False,
-    **kwargs,
-):
+def runpm_multi_qflex(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
+                      trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
+                      pm_model="ACPPowerModel", pm_solver="ipopt", correct_pm_network_data=True, silence=True,
+                      pm_time_limits=None, pm_log_level=0, pm_file_path = None, delete_buffer_file=True,
+                      opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
     """
     Runs non-linear optimization for maintaining q-setpoint over a time-series.
     """
@@ -714,245 +315,96 @@ def runpm_multi_qflex(
         assert isinstance(kwargs["from_time_step"], int)
         assert isinstance(kwargs["from_time_step"], int)
     except (KeyError, AssertionError):
-        raise ValueError(
-            "For time series optimization, you need define 'from_time_step' and 'to_time_step', e.g.,"
-            + " 'from_time_step = 0', 'to_time_step = 15'."
-        )
+        raise ValueError ("For time series optimization, you need define 'from_time_step' and 'to_time_step', e.g.," +
+                          " 'from_time_step = 0', 'to_time_step = 15'.")
     net._options = {}
-    _add_ppc_options(
-        net,
-        calculate_voltage_angles=calculate_voltage_angles,
-        trafo_model=trafo_model,
-        check_connectivity=check_connectivity,
-        mode="opf",
-        switch_rx_ratio=2,
-        init_vm_pu="flat",
-        init_va_degree="flat",
-        enforce_p_lims=False,
-        enforce_q_lims=True,
-        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
-        voltage_depend_loads=False,
-        delta=delta,
-        trafo3w_losses=trafo3w_losses,
-    )
-    _add_opf_options(
-        net,
-        trafo_loading="power",
-        ac=True,
-        init="flat",
-        numba=True,
-        pp_to_pm_callback=pp_to_pm_callback,
-        julia_file="run_pandamodels_multi_qflex",
-        pm_model=pm_model,
-        pm_solver=pm_solver,
-        correct_pm_network_data=correct_pm_network_data,
-        silence=silence,
-        pm_time_limits=pm_time_limits,
-        pm_log_level=pm_log_level,
-        opf_flow_lim=opf_flow_lim,
-        pm_tol=pm_tol,
-    )
+    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
+                     trafo_model=trafo_model, check_connectivity=check_connectivity,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
+                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
+                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
+                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_pandamodels_multi_qflex", pm_model=pm_model, pm_solver=pm_solver,
+                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
+                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode, **kwargs)
 
 
-def runpm_ploss(
-    net,
-    pp_to_pm_callback=None,
-    calculate_voltage_angles=True,
-    trafo_model="t",
-    delta=1e-8,
-    trafo3w_losses="hv",
-    check_connectivity=True,
-    pm_model="ACPPowerModel",
-    pm_solver="ipopt",
-    correct_pm_network_data=True,
-    silence=True,
-    pm_time_limits=None,
-    pm_log_level=0,
-    pm_file_path=None,
-    delete_buffer_file=True,
-    opf_flow_lim="S",
-    pm_tol=1e-8,
-    pdm_dev_mode=False,
-    **kwargs,
-):
+def runpm_ploss(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
+                trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
+                pm_model="ACPPowerModel", pm_solver="ipopt", correct_pm_network_data=True, silence=True,
+                pm_time_limits=None, pm_log_level=0, pm_file_path = None, delete_buffer_file=True,
+                opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
     """
     Runs non-linear optimization for active power loss reduction.
     """
     for elm in ["line", "trafo"]:
         if "pm_param/target_branch" in net[elm].columns:
             net[elm]["pm_param/side"] = None
-            net[elm]["pm_param/side"][net[elm]["pm_param/target_branch"] == True] = "from"
+            net[elm]["pm_param/side"][net[elm]["pm_param/target_branch"]==True] = "from"
 
     net._options = {}
-    _add_ppc_options(
-        net,
-        calculate_voltage_angles=calculate_voltage_angles,
-        trafo_model=trafo_model,
-        check_connectivity=check_connectivity,
-        mode="opf",
-        switch_rx_ratio=2,
-        init_vm_pu="flat",
-        init_va_degree="flat",
-        enforce_p_lims=False,
-        enforce_q_lims=True,
-        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
-        voltage_depend_loads=False,
-        delta=delta,
-        trafo3w_losses=trafo3w_losses,
-    )
-    _add_opf_options(
-        net,
-        trafo_loading="power",
-        ac=True,
-        init="flat",
-        numba=True,
-        pp_to_pm_callback=pp_to_pm_callback,
-        julia_file="run_pandamodels_ploss",
-        pm_model=pm_model,
-        pm_solver=pm_solver,
-        correct_pm_network_data=correct_pm_network_data,
-        silence=silence,
-        pm_time_limits=pm_time_limits,
-        pm_log_level=pm_log_level,
-        opf_flow_lim=opf_flow_lim,
-        pm_tol=pm_tol,
-    )
+    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
+                     trafo_model=trafo_model, check_connectivity=check_connectivity,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
+                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
+                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
+                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_pandamodels_ploss", pm_model=pm_model, pm_solver=pm_solver,
+                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
+                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-def runpm_loading(
-    net,
-    pp_to_pm_callback=None,
-    calculate_voltage_angles=True,
-    trafo_model="t",
-    delta=1e-8,
-    trafo3w_losses="hv",
-    check_connectivity=True,
-    pm_model="ACPPowerModel",
-    pm_solver="ipopt",
-    correct_pm_network_data=True,
-    silence=True,
-    pm_time_limits=None,
-    pm_log_level=0,
-    pm_file_path=None,
-    delete_buffer_file=True,
-    opf_flow_lim="S",
-    pm_tol=1e-8,
-    pdm_dev_mode=False,
-    **kwargs,
-):
+def runpm_loading(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
+                trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
+                pm_model="ACPPowerModel", pm_solver="ipopt", correct_pm_network_data=True, silence=True,
+                pm_time_limits=None, pm_log_level=0, pm_file_path = None, delete_buffer_file=True,
+                opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
     """
     Runs non-linear optimization for active power loss reduction.
     """
     for elm in ["line", "trafo"]:
         if "pm_param/target_branch" in net[elm].columns:
             net[elm]["pm_param/side"] = None
-            net[elm]["pm_param/side"][net[elm]["pm_param/target_branch"] == True] = "from"
+            net[elm]["pm_param/side"][net[elm]["pm_param/target_branch"]==True] = "from"
 
     net._options = {}
-    _add_ppc_options(
-        net,
-        calculate_voltage_angles=calculate_voltage_angles,
-        trafo_model=trafo_model,
-        check_connectivity=check_connectivity,
-        mode="opf",
-        switch_rx_ratio=2,
-        init_vm_pu="flat",
-        init_va_degree="flat",
-        enforce_p_lims=False,
-        enforce_q_lims=True,
-        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
-        voltage_depend_loads=False,
-        delta=delta,
-        trafo3w_losses=trafo3w_losses,
-    )
-    _add_opf_options(
-        net,
-        trafo_loading="power",
-        ac=True,
-        init="flat",
-        numba=True,
-        pp_to_pm_callback=pp_to_pm_callback,
-        julia_file="run_pandamodels_loading",
-        pm_model=pm_model,
-        pm_solver=pm_solver,
-        correct_pm_network_data=correct_pm_network_data,
-        silence=silence,
-        pm_time_limits=pm_time_limits,
-        pm_log_level=pm_log_level,
-        opf_flow_lim=opf_flow_lim,
-        pm_tol=pm_tol,
-    )
+    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
+                     trafo_model=trafo_model, check_connectivity=check_connectivity,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
+                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
+                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
+                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_pandamodels_loading", pm_model=pm_model, pm_solver=pm_solver,
+                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
+                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-def runpm_pf(
-    net,
-    julia_file=None,
-    pp_to_pm_callback=None,
-    calculate_voltage_angles=True,
-    trafo_model="t",
-    delta=1e-8,
-    trafo3w_losses="hv",
-    check_connectivity=True,
-    correct_pm_network_data=True,
-    silence=True,
-    pm_model="ACPPowerModel",
-    pm_solver="ipopt",
-    pm_mip_solver="highs",
-    pm_nl_solver="ipopt",
-    pm_time_limits=None,
-    pm_log_level=0,
-    delete_buffer_file=True,
-    pm_file_path=None,
-    opf_flow_lim="S",
-    pm_tol=1e-8,
-    pdm_dev_mode=False,
-    **kwargs,
-):  # pragma: no cover
+def runpm_pf(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_angles=True,
+             trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
+             correct_pm_network_data=True, silence=True, pm_model="ACPPowerModel", pm_solver="ipopt",
+             pm_mip_solver="highs", pm_nl_solver="ipopt", pm_time_limits=None, pm_log_level=0,
+             delete_buffer_file=True, pm_file_path = None, opf_flow_lim="S", pm_tol=1e-8,
+             pdm_dev_mode=False, **kwargs):  # pragma: no cover
     """
     Runs power flow from PowerModels.jl via PandaModels.jl
     """
     ac = True if "DC" not in pm_model else False
     net._options = {}
-    _add_ppc_options(
-        net,
-        calculate_voltage_angles=calculate_voltage_angles,
-        trafo_model=trafo_model,
-        check_connectivity=check_connectivity,
-        mode="opf",
-        switch_rx_ratio=2,
-        init_vm_pu="flat",
-        init_va_degree="flat",
-        enforce_p_lims=False,
-        enforce_q_lims=True,
-        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
-        voltage_depend_loads=False,
-        delta=delta,
-        trafo3w_losses=trafo3w_losses,
-    )
-    _add_opf_options(
-        net,
-        trafo_loading="power",
-        ac=ac,
-        init="flat",
-        numba=True,
-        pp_to_pm_callback=pp_to_pm_callback,
-        julia_file="run_powermodels_pf",
-        pm_solver=pm_solver,
-        pm_model=pm_model,
-        correct_pm_network_data=correct_pm_network_data,
-        silence=silence,
-        pm_mip_solver=pm_mip_solver,
-        pm_nl_solver=pm_nl_solver,
-        pm_time_limits=pm_time_limits,
-        pm_log_level=pm_log_level,
-        opf_flow_lim=opf_flow_lim,
-        pm_tol=pm_tol,
-    )
+    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
+                     trafo_model=trafo_model, check_connectivity=check_connectivity,
+                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
+                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
+                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
+    _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
+                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_pf", pm_solver=pm_solver, pm_model=pm_model,
+                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_mip_solver=pm_mip_solver,
+                     pm_nl_solver=pm_nl_solver, pm_time_limits=pm_time_limits, pm_log_level=pm_log_level,
+                     opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)

--- a/pandapower/runpm.py
+++ b/pandapower/runpm.py
@@ -3,18 +3,38 @@
 # Use of this source code is governed by a BSD-style license that can be found in the LICENSE file.
 
 
-from pandapower.auxiliary import _add_ppc_options, _add_opf_options
+from pandapower.auxiliary import _add_opf_options, _add_ppc_options
 from pandapower.converter.pandamodels.from_pm import read_ots_results, read_tnep_results
 from pandapower.opf.pm_storage import add_storage_opf_settings
 from pandapower.opf.run_pandamodels import _runpm
 
 
-def runpm(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_angles=True,
-          trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-          correct_pm_network_data=True, silence=True, pm_model="ACPPowerModel", pm_solver="ipopt",
-          pm_mip_solver="highs", pm_nl_solver="ipopt", pm_time_limits=None, pm_log_level=0,
-          delete_buffer_file=True, pm_file_path = None, opf_flow_lim="S", pm_tol=1e-8,
-          pdm_dev_mode=False, **kwargs):  # pragma: no cover
+def runpm(
+    net,
+    julia_file=None,
+    pp_to_pm_callback=None,
+    calculate_voltage_angles=True,
+    trafo_model="t",
+    delta=1e-8,
+    trafo3w_losses="hv",
+    check_connectivity=True,
+    correct_pm_network_data=True,
+    silence=True,
+    pm_model="ACPPowerModel",
+    pm_solver="ipopt",
+    pm_mip_solver="highs",
+    pm_nl_solver="ipopt",
+    pm_time_limits=None,
+    pm_log_level=0,
+    delete_buffer_file=True,
+    pm_file_path=None,
+    opf_flow_lim="S",
+    pm_tol=1e-8,
+    pdm_dev_mode=False,
+    init_vm_pu="flat",
+    init_va_degree="flat",
+    **kwargs,
+):  # pragma: no cover
     """
     Runs  optimal power flow from PowerModels.jl via PandaModels.jl
 
@@ -76,71 +96,195 @@ def runpm(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_angles
     """
     ac = True if "DC" not in pm_model else False
     net._options = {}
-    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
-                     trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
-                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
-    _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
-                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_opf", pm_solver=pm_solver, pm_model=pm_model,
-                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_mip_solver=pm_mip_solver,
-                     pm_nl_solver=pm_nl_solver, pm_time_limits=pm_time_limits, pm_log_level=pm_log_level,
-                     opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
+    _add_ppc_options(
+        net,
+        calculate_voltage_angles=calculate_voltage_angles,
+        trafo_model=trafo_model,
+        check_connectivity=check_connectivity,
+        mode="opf",
+        switch_rx_ratio=2,
+        init_vm_pu=init_vm_pu,
+        init_va_degree=init_va_degree,
+        enforce_p_lims=False,
+        enforce_q_lims=True,
+        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
+        voltage_depend_loads=False,
+        delta=delta,
+        trafo3w_losses=trafo3w_losses,
+    )
+    _add_opf_options(
+        net,
+        trafo_loading="power",
+        ac=ac,
+        init="flat",
+        numba=True,
+        pp_to_pm_callback=pp_to_pm_callback,
+        julia_file="run_powermodels_opf",
+        pm_solver=pm_solver,
+        pm_model=pm_model,
+        correct_pm_network_data=correct_pm_network_data,
+        silence=silence,
+        pm_mip_solver=pm_mip_solver,
+        pm_nl_solver=pm_nl_solver,
+        pm_time_limits=pm_time_limits,
+        pm_log_level=pm_log_level,
+        opf_flow_lim=opf_flow_lim,
+        pm_tol=pm_tol,
+    )
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-def runpm_dc_opf(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
-                 trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-                 correct_pm_network_data=True, silence=True, pm_model="DCPPowerModel", pm_solver="ipopt",
-                 pm_time_limits=None, pm_log_level=0, delete_buffer_file=True, pm_file_path = None,
-                 pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
+def runpm_dc_opf(
+    net,
+    pp_to_pm_callback=None,
+    calculate_voltage_angles=True,
+    trafo_model="t",
+    delta=1e-8,
+    trafo3w_losses="hv",
+    check_connectivity=True,
+    correct_pm_network_data=True,
+    silence=True,
+    pm_model="DCPPowerModel",
+    pm_solver="ipopt",
+    pm_time_limits=None,
+    pm_log_level=0,
+    delete_buffer_file=True,
+    pm_file_path=None,
+    pm_tol=1e-8,
+    pdm_dev_mode=False,
+    init_vm_pu="flat",
+    init_va_degree="flat",
+    **kwargs,
+):
     """
     Runs linearized optimal power flow from PowerModels.jl via PandaModels.jl
     """
     net._options = {}
-    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
-                     trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
-                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
-    _add_opf_options(net, trafo_loading='power', ac=False, init="flat", numba=True,
-                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_opf",
-                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_model=pm_model, pm_solver=pm_solver,
-                     pm_time_limits=pm_time_limits, pm_log_level=pm_log_level, opf_flow_lim="S", pm_tol=pm_tol)
+    _add_ppc_options(
+        net,
+        calculate_voltage_angles=calculate_voltage_angles,
+        trafo_model=trafo_model,
+        check_connectivity=check_connectivity,
+        mode="opf",
+        switch_rx_ratio=2,
+        init_vm_pu="flat",
+        init_va_degree="flat",
+        enforce_p_lims=False,
+        enforce_q_lims=True,
+        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
+        voltage_depend_loads=False,
+        delta=delta,
+        trafo3w_losses=trafo3w_losses,
+    )
+    _add_opf_options(
+        net,
+        trafo_loading="power",
+        ac=False,
+        init="flat",
+        numba=True,
+        pp_to_pm_callback=pp_to_pm_callback,
+        julia_file="run_powermodels_opf",
+        correct_pm_network_data=correct_pm_network_data,
+        silence=silence,
+        pm_model=pm_model,
+        pm_solver=pm_solver,
+        pm_time_limits=pm_time_limits,
+        pm_log_level=pm_log_level,
+        opf_flow_lim="S",
+        pm_tol=pm_tol,
+    )
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-def runpm_ac_opf(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
-                 trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-                 pm_solver="ipopt", correct_pm_network_data=True, silence=True,
-                 pm_time_limits=None, pm_log_level=0, pm_file_path=None, delete_buffer_file=True,
-                 opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
+def runpm_ac_opf(
+    net,
+    pp_to_pm_callback=None,
+    calculate_voltage_angles=True,
+    trafo_model="t",
+    delta=1e-8,
+    trafo3w_losses="hv",
+    check_connectivity=True,
+    pm_solver="ipopt",
+    correct_pm_network_data=True,
+    silence=True,
+    pm_time_limits=None,
+    pm_log_level=0,
+    pm_file_path=None,
+    delete_buffer_file=True,
+    opf_flow_lim="S",
+    pm_tol=1e-8,
+    pdm_dev_mode=False,
+    init_vm_pu="flat",
+    init_va_degree="flat",
+    **kwargs,
+):
     """
     Runs non-linear optimal power flow from PowerModels.jl via PandaModels.jl
     """
     net._options = {}
-    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
-                     trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
-                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
-    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
-                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_opf", pm_model="ACPPowerModel", pm_solver=pm_solver,
-                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
-                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
+    _add_ppc_options(
+        net,
+        calculate_voltage_angles=calculate_voltage_angles,
+        trafo_model=trafo_model,
+        check_connectivity=check_connectivity,
+        mode="opf",
+        switch_rx_ratio=2,
+        init_vm_pu="flat",
+        init_va_degree="flat",
+        enforce_p_lims=False,
+        enforce_q_lims=True,
+        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
+        voltage_depend_loads=False,
+        delta=delta,
+        trafo3w_losses=trafo3w_losses,
+    )
+    _add_opf_options(
+        net,
+        trafo_loading="power",
+        ac=True,
+        init="flat",
+        numba=True,
+        pp_to_pm_callback=pp_to_pm_callback,
+        julia_file="run_powermodels_opf",
+        pm_model="ACPPowerModel",
+        pm_solver=pm_solver,
+        correct_pm_network_data=correct_pm_network_data,
+        silence=silence,
+        pm_time_limits=pm_time_limits,
+        pm_log_level=pm_log_level,
+        opf_flow_lim=opf_flow_lim,
+        pm_tol=pm_tol,
+    )
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-
-def runpm_tnep(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_angles=True,
-               trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-               pm_model="ACPPowerModel", pm_solver="juniper", correct_pm_network_data=True, silence=True,
-               pm_nl_solver="ipopt", pm_mip_solver="highs", pm_time_limits=None, pm_log_level=0,
-               delete_buffer_file=True, pm_file_path=None, opf_flow_lim="S", pm_tol=1e-8,
-               pdm_dev_mode=False, **kwargs):
+def runpm_tnep(
+    net,
+    julia_file=None,
+    pp_to_pm_callback=None,
+    calculate_voltage_angles=True,
+    trafo_model="t",
+    delta=1e-8,
+    trafo3w_losses="hv",
+    check_connectivity=True,
+    pm_model="ACPPowerModel",
+    pm_solver="juniper",
+    correct_pm_network_data=True,
+    silence=True,
+    pm_nl_solver="ipopt",
+    pm_mip_solver="highs",
+    pm_time_limits=None,
+    pm_log_level=0,
+    delete_buffer_file=True,
+    pm_file_path=None,
+    opf_flow_lim="S",
+    pm_tol=1e-8,
+    pdm_dev_mode=False,
+    **kwargs,
+):
     """
     Runs transmission network extension planning (tnep) optimization from PowerModels.jl via PandaModels.jl
     """
@@ -154,27 +298,70 @@ def runpm_tnep(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_a
     if "ne_line" not in net:
         raise ValueError("ne_line DataFrame missing in net. Please define to run tnep")
     net._options = {}
-    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
-                     trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
-                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
-    _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
-                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_tnep", pm_model=pm_model, pm_solver=pm_solver,
-                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_nl_solver=pm_nl_solver,
-                     pm_mip_solver=pm_mip_solver, pm_time_limits=pm_time_limits, pm_log_level=pm_log_level,
-                     opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
+    _add_ppc_options(
+        net,
+        calculate_voltage_angles=calculate_voltage_angles,
+        trafo_model=trafo_model,
+        check_connectivity=check_connectivity,
+        mode="opf",
+        switch_rx_ratio=2,
+        init_vm_pu="flat",
+        init_va_degree="flat",
+        enforce_p_lims=False,
+        enforce_q_lims=True,
+        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
+        voltage_depend_loads=False,
+        delta=delta,
+        trafo3w_losses=trafo3w_losses,
+    )
+    _add_opf_options(
+        net,
+        trafo_loading="power",
+        ac=ac,
+        init="flat",
+        numba=True,
+        pp_to_pm_callback=pp_to_pm_callback,
+        julia_file="run_powermodels_tnep",
+        pm_model=pm_model,
+        pm_solver=pm_solver,
+        correct_pm_network_data=correct_pm_network_data,
+        silence=silence,
+        pm_nl_solver=pm_nl_solver,
+        pm_mip_solver=pm_mip_solver,
+        pm_time_limits=pm_time_limits,
+        pm_log_level=pm_log_level,
+        opf_flow_lim=opf_flow_lim,
+        pm_tol=pm_tol,
+    )
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
     read_tnep_results(net)
 
 
-def runpm_ots(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_angles=True,
-              trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-              pm_model="DCPPowerModel", pm_solver="juniper", pm_nl_solver="ipopt",
-              pm_mip_solver="highs", correct_pm_network_data=True, silence=True, pm_time_limits=None,
-              pm_log_level=0, delete_buffer_file=True, pm_file_path=None, opf_flow_lim="S", pm_tol=1e-8,
-              pdm_dev_mode=False, **kwargs):
+def runpm_ots(
+    net,
+    julia_file=None,
+    pp_to_pm_callback=None,
+    calculate_voltage_angles=True,
+    trafo_model="t",
+    delta=1e-8,
+    trafo3w_losses="hv",
+    check_connectivity=True,
+    pm_model="DCPPowerModel",
+    pm_solver="juniper",
+    pm_nl_solver="ipopt",
+    pm_mip_solver="highs",
+    correct_pm_network_data=True,
+    silence=True,
+    pm_time_limits=None,
+    pm_log_level=0,
+    delete_buffer_file=True,
+    pm_file_path=None,
+    opf_flow_lim="S",
+    pm_tol=1e-8,
+    pdm_dev_mode=False,
+    **kwargs,
+):
     """
     Runs optimal transmission switching (OTS) optimization from PowerModels.jl via PandaModels.jl
     """
@@ -183,28 +370,77 @@ def runpm_ots(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_an
         pm_solver = "juniper"
 
     net._options = {}
-    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
-                     trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
-                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
-    _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
-                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_ots", pm_model=pm_model, pm_solver=pm_solver,
-                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_mip_solver=pm_mip_solver,
-                     pm_nl_solver=pm_nl_solver, pm_time_limits=pm_time_limits, pm_log_level=pm_log_level,
-                     opf_flow_lim="S", pm_tol=pm_tol)
+    _add_ppc_options(
+        net,
+        calculate_voltage_angles=calculate_voltage_angles,
+        trafo_model=trafo_model,
+        check_connectivity=check_connectivity,
+        mode="opf",
+        switch_rx_ratio=2,
+        init_vm_pu="flat",
+        init_va_degree="flat",
+        enforce_p_lims=False,
+        enforce_q_lims=True,
+        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
+        voltage_depend_loads=False,
+        delta=delta,
+        trafo3w_losses=trafo3w_losses,
+    )
+    _add_opf_options(
+        net,
+        trafo_loading="power",
+        ac=ac,
+        init="flat",
+        numba=True,
+        pp_to_pm_callback=pp_to_pm_callback,
+        julia_file="run_powermodels_ots",
+        pm_model=pm_model,
+        pm_solver=pm_solver,
+        correct_pm_network_data=correct_pm_network_data,
+        silence=silence,
+        pm_mip_solver=pm_mip_solver,
+        pm_nl_solver=pm_nl_solver,
+        pm_time_limits=pm_time_limits,
+        pm_log_level=pm_log_level,
+        opf_flow_lim="S",
+        pm_tol=pm_tol,
+    )
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
     read_ots_results(net)
 
-def runpm_storage_opf(net, from_time_step, to_time_step, calculate_voltage_angles=True,
-                      trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-                      n_timesteps=24, time_elapsed=1., correct_pm_network_data=True, silence=True,
-                      pm_solver="juniper", pm_mip_solver="highs", pm_nl_solver="ipopt",
-                      pm_model="ACPPowerModel", pm_time_limits=None, pm_log_level=0,
-                      opf_flow_lim="S", charge_efficiency=1., discharge_efficiency=1.,
-                      standby_loss=1e-8, p_loss=1e-8, q_loss=1e-8, pm_tol=1e-4, pdm_dev_mode=False,
-                      delete_buffer_file=True, pm_file_path = None, **kwargs):
+
+def runpm_storage_opf(
+    net,
+    from_time_step,
+    to_time_step,
+    calculate_voltage_angles=True,
+    trafo_model="t",
+    delta=1e-8,
+    trafo3w_losses="hv",
+    check_connectivity=True,
+    n_timesteps=24,
+    time_elapsed=1.0,
+    correct_pm_network_data=True,
+    silence=True,
+    pm_solver="juniper",
+    pm_mip_solver="highs",
+    pm_nl_solver="ipopt",
+    pm_model="ACPPowerModel",
+    pm_time_limits=None,
+    pm_log_level=0,
+    opf_flow_lim="S",
+    charge_efficiency=1.0,
+    discharge_efficiency=1.0,
+    standby_loss=1e-8,
+    p_loss=1e-8,
+    q_loss=1e-8,
+    pm_tol=1e-4,
+    pdm_dev_mode=False,
+    delete_buffer_file=True,
+    pm_file_path=None,
+    **kwargs,
+):
     """
     Runs a non-linear power system optimization with storages and time series using PandaModels.jl.
     """
@@ -213,16 +449,42 @@ def runpm_storage_opf(net, from_time_step, to_time_step, calculate_voltage_angle
 
     ac = True if "DC" not in pm_model else False
     net._options = {}
-    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
-                     trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
-                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
-    _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
-                     pp_to_pm_callback=add_storage_opf_settings, julia_file="run_powermodels_multi_storage",
-                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_model=pm_model,
-                     pm_solver=pm_solver, pm_time_limits=pm_time_limits, pm_mip_solver=pm_mip_solver, pm_nl_solver=pm_nl_solver,
-                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol, pdm_dev_mode=pdm_dev_mode)
+    _add_ppc_options(
+        net,
+        calculate_voltage_angles=calculate_voltage_angles,
+        trafo_model=trafo_model,
+        check_connectivity=check_connectivity,
+        mode="opf",
+        switch_rx_ratio=2,
+        init_vm_pu="flat",
+        init_va_degree="flat",
+        enforce_p_lims=False,
+        enforce_q_lims=True,
+        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
+        voltage_depend_loads=False,
+        delta=delta,
+        trafo3w_losses=trafo3w_losses,
+    )
+    _add_opf_options(
+        net,
+        trafo_loading="power",
+        ac=ac,
+        init="flat",
+        numba=True,
+        pp_to_pm_callback=add_storage_opf_settings,
+        julia_file="run_powermodels_multi_storage",
+        correct_pm_network_data=correct_pm_network_data,
+        silence=silence,
+        pm_model=pm_model,
+        pm_solver=pm_solver,
+        pm_time_limits=pm_time_limits,
+        pm_mip_solver=pm_mip_solver,
+        pm_nl_solver=pm_nl_solver,
+        pm_log_level=pm_log_level,
+        opf_flow_lim=opf_flow_lim,
+        pm_tol=pm_tol,
+        pdm_dev_mode=pdm_dev_mode,
+    )
 
     net._options["n_time_steps"] = to_time_step - from_time_step
     net._options["time_elapsed"] = time_elapsed
@@ -230,34 +492,89 @@ def runpm_storage_opf(net, from_time_step, to_time_step, calculate_voltage_angle
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode, **kwargs)
 
 
-
-def runpm_vstab(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
-                trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-                pm_model="ACPPowerModel", pm_solver="ipopt", correct_pm_network_data=True, silence=True,
-                pm_time_limits=None, pm_log_level=0, pm_file_path = None, delete_buffer_file=True,
-                opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
+def runpm_vstab(
+    net,
+    pp_to_pm_callback=None,
+    calculate_voltage_angles=True,
+    trafo_model="t",
+    delta=1e-8,
+    trafo3w_losses="hv",
+    check_connectivity=True,
+    pm_model="ACPPowerModel",
+    pm_solver="ipopt",
+    correct_pm_network_data=True,
+    silence=True,
+    pm_time_limits=None,
+    pm_log_level=0,
+    pm_file_path=None,
+    delete_buffer_file=True,
+    opf_flow_lim="S",
+    pm_tol=1e-8,
+    pdm_dev_mode=False,
+    **kwargs,
+):
     """
     Runs non-linear problem for voltage deviation minimization from PandaModels.jl.
     """
     net._options = {}
-    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
-                     trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
-                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
-    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
-                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_pandamodels_vstab", pm_model=pm_model, pm_solver=pm_solver,
-                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
-                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
+    _add_ppc_options(
+        net,
+        calculate_voltage_angles=calculate_voltage_angles,
+        trafo_model=trafo_model,
+        check_connectivity=check_connectivity,
+        mode="opf",
+        switch_rx_ratio=2,
+        init_vm_pu="flat",
+        init_va_degree="flat",
+        enforce_p_lims=False,
+        enforce_q_lims=True,
+        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
+        voltage_depend_loads=False,
+        delta=delta,
+        trafo3w_losses=trafo3w_losses,
+    )
+    _add_opf_options(
+        net,
+        trafo_loading="power",
+        ac=True,
+        init="flat",
+        numba=True,
+        pp_to_pm_callback=pp_to_pm_callback,
+        julia_file="run_pandamodels_vstab",
+        pm_model=pm_model,
+        pm_solver=pm_solver,
+        correct_pm_network_data=correct_pm_network_data,
+        silence=silence,
+        pm_time_limits=pm_time_limits,
+        pm_log_level=pm_log_level,
+        opf_flow_lim=opf_flow_lim,
+        pm_tol=pm_tol,
+    )
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-def runpm_multi_vstab(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
-                      trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-                      pm_model="ACPPowerModel", pm_solver="ipopt", correct_pm_network_data=True, silence=True,
-                      pm_time_limits=None, pm_log_level=0, pm_file_path = None, delete_buffer_file=True,
-                      opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
+def runpm_multi_vstab(
+    net,
+    pp_to_pm_callback=None,
+    calculate_voltage_angles=True,
+    trafo_model="t",
+    delta=1e-8,
+    trafo3w_losses="hv",
+    check_connectivity=True,
+    pm_model="ACPPowerModel",
+    pm_solver="ipopt",
+    correct_pm_network_data=True,
+    silence=True,
+    pm_time_limits=None,
+    pm_log_level=0,
+    pm_file_path=None,
+    delete_buffer_file=True,
+    opf_flow_lim="S",
+    pm_tol=1e-8,
+    pdm_dev_mode=False,
+    **kwargs,
+):
     """
     Runs non-linear problem for time-series voltage deviation minimization from PandaModels.jl.
     """
@@ -265,49 +582,131 @@ def runpm_multi_vstab(net, pp_to_pm_callback=None, calculate_voltage_angles=True
         assert isinstance(kwargs["from_time_step"], int)
         assert isinstance(kwargs["from_time_step"], int)
     except (KeyError, AssertionError):
-        raise ValueError ("For time series optimization, you need define 'from_time_step' and 'to_time_step', e.g.," +
-                          " 'from_time_step = 0', 'to_time_step = 15'.")
+        raise ValueError(
+            "For time series optimization, you need define 'from_time_step' and 'to_time_step', e.g.,"
+            + " 'from_time_step = 0', 'to_time_step = 15'."
+        )
     net._options = {}
-    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
-                     trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
-                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
-    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
-                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_pandamodels_multi_vstab", pm_model=pm_model, pm_solver=pm_solver,
-                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
-                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
+    _add_ppc_options(
+        net,
+        calculate_voltage_angles=calculate_voltage_angles,
+        trafo_model=trafo_model,
+        check_connectivity=check_connectivity,
+        mode="opf",
+        switch_rx_ratio=2,
+        init_vm_pu="flat",
+        init_va_degree="flat",
+        enforce_p_lims=False,
+        enforce_q_lims=True,
+        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
+        voltage_depend_loads=False,
+        delta=delta,
+        trafo3w_losses=trafo3w_losses,
+    )
+    _add_opf_options(
+        net,
+        trafo_loading="power",
+        ac=True,
+        init="flat",
+        numba=True,
+        pp_to_pm_callback=pp_to_pm_callback,
+        julia_file="run_pandamodels_multi_vstab",
+        pm_model=pm_model,
+        pm_solver=pm_solver,
+        correct_pm_network_data=correct_pm_network_data,
+        silence=silence,
+        pm_time_limits=pm_time_limits,
+        pm_log_level=pm_log_level,
+        opf_flow_lim=opf_flow_lim,
+        pm_tol=pm_tol,
+    )
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode, **kwargs)
 
 
-def runpm_qflex(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
-                trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-                pm_model="ACPPowerModel", pm_solver="ipopt", correct_pm_network_data=True, silence=True,
-                pm_time_limits=None, pm_log_level=0, pm_file_path = None, delete_buffer_file=True,
-                opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
+def runpm_qflex(
+    net,
+    pp_to_pm_callback=None,
+    calculate_voltage_angles=True,
+    trafo_model="t",
+    delta=1e-8,
+    trafo3w_losses="hv",
+    check_connectivity=True,
+    pm_model="ACPPowerModel",
+    pm_solver="ipopt",
+    correct_pm_network_data=True,
+    silence=True,
+    pm_time_limits=None,
+    pm_log_level=0,
+    pm_file_path=None,
+    delete_buffer_file=True,
+    opf_flow_lim="S",
+    pm_tol=1e-8,
+    pdm_dev_mode=False,
+    **kwargs,
+):
     """
     Runs non-linear optimization for maintaining q-setpoint.
     """
     net._options = {}
-    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
-                     trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
-                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
-    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
-                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_pandamodels_qflex", pm_model=pm_model, pm_solver=pm_solver,
-                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
-                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
+    _add_ppc_options(
+        net,
+        calculate_voltage_angles=calculate_voltage_angles,
+        trafo_model=trafo_model,
+        check_connectivity=check_connectivity,
+        mode="opf",
+        switch_rx_ratio=2,
+        init_vm_pu="flat",
+        init_va_degree="flat",
+        enforce_p_lims=False,
+        enforce_q_lims=True,
+        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
+        voltage_depend_loads=False,
+        delta=delta,
+        trafo3w_losses=trafo3w_losses,
+    )
+    _add_opf_options(
+        net,
+        trafo_loading="power",
+        ac=True,
+        init="flat",
+        numba=True,
+        pp_to_pm_callback=pp_to_pm_callback,
+        julia_file="run_pandamodels_qflex",
+        pm_model=pm_model,
+        pm_solver=pm_solver,
+        correct_pm_network_data=correct_pm_network_data,
+        silence=silence,
+        pm_time_limits=pm_time_limits,
+        pm_log_level=pm_log_level,
+        opf_flow_lim=opf_flow_lim,
+        pm_tol=pm_tol,
+    )
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-def runpm_multi_qflex(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
-                      trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-                      pm_model="ACPPowerModel", pm_solver="ipopt", correct_pm_network_data=True, silence=True,
-                      pm_time_limits=None, pm_log_level=0, pm_file_path = None, delete_buffer_file=True,
-                      opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
+def runpm_multi_qflex(
+    net,
+    pp_to_pm_callback=None,
+    calculate_voltage_angles=True,
+    trafo_model="t",
+    delta=1e-8,
+    trafo3w_losses="hv",
+    check_connectivity=True,
+    pm_model="ACPPowerModel",
+    pm_solver="ipopt",
+    correct_pm_network_data=True,
+    silence=True,
+    pm_time_limits=None,
+    pm_log_level=0,
+    pm_file_path=None,
+    delete_buffer_file=True,
+    opf_flow_lim="S",
+    pm_tol=1e-8,
+    pdm_dev_mode=False,
+    **kwargs,
+):
     """
     Runs non-linear optimization for maintaining q-setpoint over a time-series.
     """
@@ -315,96 +714,245 @@ def runpm_multi_qflex(net, pp_to_pm_callback=None, calculate_voltage_angles=True
         assert isinstance(kwargs["from_time_step"], int)
         assert isinstance(kwargs["from_time_step"], int)
     except (KeyError, AssertionError):
-        raise ValueError ("For time series optimization, you need define 'from_time_step' and 'to_time_step', e.g.," +
-                          " 'from_time_step = 0', 'to_time_step = 15'.")
+        raise ValueError(
+            "For time series optimization, you need define 'from_time_step' and 'to_time_step', e.g.,"
+            + " 'from_time_step = 0', 'to_time_step = 15'."
+        )
     net._options = {}
-    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
-                     trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
-                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
-    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
-                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_pandamodels_multi_qflex", pm_model=pm_model, pm_solver=pm_solver,
-                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
-                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
+    _add_ppc_options(
+        net,
+        calculate_voltage_angles=calculate_voltage_angles,
+        trafo_model=trafo_model,
+        check_connectivity=check_connectivity,
+        mode="opf",
+        switch_rx_ratio=2,
+        init_vm_pu="flat",
+        init_va_degree="flat",
+        enforce_p_lims=False,
+        enforce_q_lims=True,
+        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
+        voltage_depend_loads=False,
+        delta=delta,
+        trafo3w_losses=trafo3w_losses,
+    )
+    _add_opf_options(
+        net,
+        trafo_loading="power",
+        ac=True,
+        init="flat",
+        numba=True,
+        pp_to_pm_callback=pp_to_pm_callback,
+        julia_file="run_pandamodels_multi_qflex",
+        pm_model=pm_model,
+        pm_solver=pm_solver,
+        correct_pm_network_data=correct_pm_network_data,
+        silence=silence,
+        pm_time_limits=pm_time_limits,
+        pm_log_level=pm_log_level,
+        opf_flow_lim=opf_flow_lim,
+        pm_tol=pm_tol,
+    )
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode, **kwargs)
 
 
-def runpm_ploss(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
-                trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-                pm_model="ACPPowerModel", pm_solver="ipopt", correct_pm_network_data=True, silence=True,
-                pm_time_limits=None, pm_log_level=0, pm_file_path = None, delete_buffer_file=True,
-                opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
+def runpm_ploss(
+    net,
+    pp_to_pm_callback=None,
+    calculate_voltage_angles=True,
+    trafo_model="t",
+    delta=1e-8,
+    trafo3w_losses="hv",
+    check_connectivity=True,
+    pm_model="ACPPowerModel",
+    pm_solver="ipopt",
+    correct_pm_network_data=True,
+    silence=True,
+    pm_time_limits=None,
+    pm_log_level=0,
+    pm_file_path=None,
+    delete_buffer_file=True,
+    opf_flow_lim="S",
+    pm_tol=1e-8,
+    pdm_dev_mode=False,
+    **kwargs,
+):
     """
     Runs non-linear optimization for active power loss reduction.
     """
     for elm in ["line", "trafo"]:
         if "pm_param/target_branch" in net[elm].columns:
             net[elm]["pm_param/side"] = None
-            net[elm]["pm_param/side"][net[elm]["pm_param/target_branch"]==True] = "from"
+            net[elm]["pm_param/side"][net[elm]["pm_param/target_branch"] == True] = "from"
 
     net._options = {}
-    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
-                     trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
-                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
-    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
-                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_pandamodels_ploss", pm_model=pm_model, pm_solver=pm_solver,
-                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
-                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
+    _add_ppc_options(
+        net,
+        calculate_voltage_angles=calculate_voltage_angles,
+        trafo_model=trafo_model,
+        check_connectivity=check_connectivity,
+        mode="opf",
+        switch_rx_ratio=2,
+        init_vm_pu="flat",
+        init_va_degree="flat",
+        enforce_p_lims=False,
+        enforce_q_lims=True,
+        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
+        voltage_depend_loads=False,
+        delta=delta,
+        trafo3w_losses=trafo3w_losses,
+    )
+    _add_opf_options(
+        net,
+        trafo_loading="power",
+        ac=True,
+        init="flat",
+        numba=True,
+        pp_to_pm_callback=pp_to_pm_callback,
+        julia_file="run_pandamodels_ploss",
+        pm_model=pm_model,
+        pm_solver=pm_solver,
+        correct_pm_network_data=correct_pm_network_data,
+        silence=silence,
+        pm_time_limits=pm_time_limits,
+        pm_log_level=pm_log_level,
+        opf_flow_lim=opf_flow_lim,
+        pm_tol=pm_tol,
+    )
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-def runpm_loading(net, pp_to_pm_callback=None, calculate_voltage_angles=True,
-                trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-                pm_model="ACPPowerModel", pm_solver="ipopt", correct_pm_network_data=True, silence=True,
-                pm_time_limits=None, pm_log_level=0, pm_file_path = None, delete_buffer_file=True,
-                opf_flow_lim="S", pm_tol=1e-8, pdm_dev_mode=False, **kwargs):
+def runpm_loading(
+    net,
+    pp_to_pm_callback=None,
+    calculate_voltage_angles=True,
+    trafo_model="t",
+    delta=1e-8,
+    trafo3w_losses="hv",
+    check_connectivity=True,
+    pm_model="ACPPowerModel",
+    pm_solver="ipopt",
+    correct_pm_network_data=True,
+    silence=True,
+    pm_time_limits=None,
+    pm_log_level=0,
+    pm_file_path=None,
+    delete_buffer_file=True,
+    opf_flow_lim="S",
+    pm_tol=1e-8,
+    pdm_dev_mode=False,
+    **kwargs,
+):
     """
     Runs non-linear optimization for active power loss reduction.
     """
     for elm in ["line", "trafo"]:
         if "pm_param/target_branch" in net[elm].columns:
             net[elm]["pm_param/side"] = None
-            net[elm]["pm_param/side"][net[elm]["pm_param/target_branch"]==True] = "from"
+            net[elm]["pm_param/side"][net[elm]["pm_param/target_branch"] == True] = "from"
 
     net._options = {}
-    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
-                     trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
-                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
-    _add_opf_options(net, trafo_loading='power', ac=True, init="flat", numba=True,
-                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_pandamodels_loading", pm_model=pm_model, pm_solver=pm_solver,
-                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_time_limits=pm_time_limits,
-                     pm_log_level=pm_log_level, opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
+    _add_ppc_options(
+        net,
+        calculate_voltage_angles=calculate_voltage_angles,
+        trafo_model=trafo_model,
+        check_connectivity=check_connectivity,
+        mode="opf",
+        switch_rx_ratio=2,
+        init_vm_pu="flat",
+        init_va_degree="flat",
+        enforce_p_lims=False,
+        enforce_q_lims=True,
+        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
+        voltage_depend_loads=False,
+        delta=delta,
+        trafo3w_losses=trafo3w_losses,
+    )
+    _add_opf_options(
+        net,
+        trafo_loading="power",
+        ac=True,
+        init="flat",
+        numba=True,
+        pp_to_pm_callback=pp_to_pm_callback,
+        julia_file="run_pandamodels_loading",
+        pm_model=pm_model,
+        pm_solver=pm_solver,
+        correct_pm_network_data=correct_pm_network_data,
+        silence=silence,
+        pm_time_limits=pm_time_limits,
+        pm_log_level=pm_log_level,
+        opf_flow_lim=opf_flow_lim,
+        pm_tol=pm_tol,
+    )
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)
 
 
-def runpm_pf(net, julia_file=None, pp_to_pm_callback=None, calculate_voltage_angles=True,
-             trafo_model="t", delta=1e-8, trafo3w_losses="hv", check_connectivity=True,
-             correct_pm_network_data=True, silence=True, pm_model="ACPPowerModel", pm_solver="ipopt",
-             pm_mip_solver="highs", pm_nl_solver="ipopt", pm_time_limits=None, pm_log_level=0,
-             delete_buffer_file=True, pm_file_path = None, opf_flow_lim="S", pm_tol=1e-8,
-             pdm_dev_mode=False, **kwargs):  # pragma: no cover
+def runpm_pf(
+    net,
+    julia_file=None,
+    pp_to_pm_callback=None,
+    calculate_voltage_angles=True,
+    trafo_model="t",
+    delta=1e-8,
+    trafo3w_losses="hv",
+    check_connectivity=True,
+    correct_pm_network_data=True,
+    silence=True,
+    pm_model="ACPPowerModel",
+    pm_solver="ipopt",
+    pm_mip_solver="highs",
+    pm_nl_solver="ipopt",
+    pm_time_limits=None,
+    pm_log_level=0,
+    delete_buffer_file=True,
+    pm_file_path=None,
+    opf_flow_lim="S",
+    pm_tol=1e-8,
+    pdm_dev_mode=False,
+    **kwargs,
+):  # pragma: no cover
     """
     Runs power flow from PowerModels.jl via PandaModels.jl
     """
     ac = True if "DC" not in pm_model else False
     net._options = {}
-    _add_ppc_options(net, calculate_voltage_angles=calculate_voltage_angles,
-                     trafo_model=trafo_model, check_connectivity=check_connectivity,
-                     mode="opf", switch_rx_ratio=2, init_vm_pu="flat", init_va_degree="flat", enforce_p_lims=False,
-                     enforce_q_lims=True, recycle={'_is_elements': False, 'ppc': False, 'Ybus': False},
-                     voltage_depend_loads=False, delta=delta, trafo3w_losses=trafo3w_losses)
-    _add_opf_options(net, trafo_loading='power', ac=ac, init="flat", numba=True,
-                     pp_to_pm_callback=pp_to_pm_callback, julia_file="run_powermodels_pf", pm_solver=pm_solver, pm_model=pm_model,
-                     correct_pm_network_data=correct_pm_network_data, silence=silence, pm_mip_solver=pm_mip_solver,
-                     pm_nl_solver=pm_nl_solver, pm_time_limits=pm_time_limits, pm_log_level=pm_log_level,
-                     opf_flow_lim=opf_flow_lim, pm_tol=pm_tol)
+    _add_ppc_options(
+        net,
+        calculate_voltage_angles=calculate_voltage_angles,
+        trafo_model=trafo_model,
+        check_connectivity=check_connectivity,
+        mode="opf",
+        switch_rx_ratio=2,
+        init_vm_pu="flat",
+        init_va_degree="flat",
+        enforce_p_lims=False,
+        enforce_q_lims=True,
+        recycle={"_is_elements": False, "ppc": False, "Ybus": False},
+        voltage_depend_loads=False,
+        delta=delta,
+        trafo3w_losses=trafo3w_losses,
+    )
+    _add_opf_options(
+        net,
+        trafo_loading="power",
+        ac=ac,
+        init="flat",
+        numba=True,
+        pp_to_pm_callback=pp_to_pm_callback,
+        julia_file="run_powermodels_pf",
+        pm_solver=pm_solver,
+        pm_model=pm_model,
+        correct_pm_network_data=correct_pm_network_data,
+        silence=silence,
+        pm_mip_solver=pm_mip_solver,
+        pm_nl_solver=pm_nl_solver,
+        pm_time_limits=pm_time_limits,
+        pm_log_level=pm_log_level,
+        opf_flow_lim=opf_flow_lim,
+        pm_tol=pm_tol,
+    )
 
     _runpm(net, delete_buffer_file=delete_buffer_file, pm_file_path=pm_file_path, pdm_dev_mode=pdm_dev_mode)

--- a/pandapower/test/converter/test_to_pm_init_results.py
+++ b/pandapower/test/converter/test_to_pm_init_results.py
@@ -1,0 +1,49 @@
+import math
+
+import pytest
+
+import pandapower as pp
+from pandapower.converter.pandamodels import convert_pp_to_pm
+
+
+def test_convert_pp_to_pm_init_results_propagates_bus_vm_and_va():
+    """Ensures that init_vm_pu/init_va_degree='results' is not wiped by to_pm conversion.
+    """
+
+    net = pp.create_empty_network(sn_mva=100.0)
+    b_slack = pp.create_bus(net, vn_kv=110.0)
+    b_load = pp.create_bus(net, vn_kv=110.0)
+    pp.create_ext_grid(net, b_slack, vm_pu=1.02)
+    pp.create_line_from_parameters(
+        net,
+        from_bus=b_slack,
+        to_bus=b_load,
+        length_km=1.0,
+        r_ohm_per_km=0.01,
+        x_ohm_per_km=0.05,
+        c_nf_per_km=0.0,
+        max_i_ka=1.0,
+    )
+    pp.create_load(net, b_load, p_mw=10.0, q_mvar=2.0)
+
+    pp.runpp(net, calculate_voltage_angles=True)
+    net.res_bus.at[b_load, "vm_pu"] = 0.987
+    net.res_bus.at[b_load, "va_degree"] = 7.123
+
+    pm = convert_pp_to_pm(
+        net,
+        calculate_voltage_angles=True,
+        init_vm_pu="results",
+        init_va_degree="results",
+    )
+
+    pm_bus_slack = int(net._pd2pm_lookups["bus"][b_slack])
+    pm_bus_load = int(net._pd2pm_lookups["bus"][b_load])
+
+    assert pm["bus"][str(pm_bus_slack)]["vm"] == pytest.approx(net.res_bus.at[b_slack, "vm_pu"])
+    assert pm["bus"][str(pm_bus_slack)]["va"] == pytest.approx(
+        math.radians(net.res_bus.at[b_slack, "va_degree"])
+    )
+
+    assert pm["bus"][str(pm_bus_load)]["vm"] == pytest.approx(0.987)
+    assert pm["bus"][str(pm_bus_load)]["va"] == pytest.approx(math.radians(7.123))


### PR DESCRIPTION
- makes it possible to warm-start PowerModels optimizations from existing `net.res_bus` values (voltage magnitude + angle) instead of always setting a flat start and needing to use the julia_file for custom warm-starts.
- adapts the fixed flat start parameters and adds parameters for setting voltage magnitude and angle in the `runpm.py`methods.
- `from_pm.py` assumes PowerModels voltage angles are **radians** (it converts back to degrees), but `to_pm.py` currently copies bus angles without conversion.