### PR TITLE
Do not open networks from files with older format version than installed pandapower version

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Change Log
 
 [upcoming release] - 2025-..-..
 -------------------------------
+- [ADDED] possibility to directly compare "geo" columns of dataframes (not assume geojson strings)
+- [FIXED] cim2pp: Make sure that the controllable flag is never nan for any generators
 
 [3.1.2] - 2025-06-16
 -------------------------------

--- a/pandapower/_version.py
+++ b/pandapower/_version.py
@@ -1,4 +1,4 @@
 import importlib.metadata
 
 __version__ = importlib.metadata.version("pandapower")
-__format_version__ = "3.0.0"
+__format_version__ = "3.1.2.dev0"

--- a/pandapower/_version.py
+++ b/pandapower/_version.py
@@ -1,4 +1,4 @@
 import importlib.metadata
 
 __version__ = importlib.metadata.version("pandapower")
-__format_version__ = "3.1.2+retoflow.1"
+__format_version__ = "3.1.2+retoflow.2"

--- a/pandapower/_version.py
+++ b/pandapower/_version.py
@@ -1,4 +1,4 @@
 import importlib.metadata
 
 __version__ = importlib.metadata.version("pandapower")
-__format_version__ = "3.1.2.dev0"
+__format_version__ = "3.1.2+retoflow.1"

--- a/pandapower/control/controller/DERController/der_control.py
+++ b/pandapower/control/controller/DERController/der_control.py
@@ -129,7 +129,8 @@ class DERController(PQController):
         # --- init DER Model params
         self.q_model = q_model
         self.pqv_area = pqv_area
-        self.saturate_sn_mva = saturate_sn_mva
+        self.saturate_sn_mva = np.array(ensure_iterability(saturate_sn_mva))
+        self.saturate_sn_mva_active = isinstance(self.saturate_sn_mva, np.ndarray) 
         self.q_prio = q_prio
         self.damping_coef = damping_coef
 
@@ -141,7 +142,7 @@ class DERController(PQController):
         if n_nan_sn := sum(self.sn_mva.isnull()):
             logger.error(f"The DERController relates to sn_mva, but for {n_nan_sn} elements "
                          "sn_mva is NaN.")
-        if self.saturate_sn_mva <= 0:
+        if self.saturate_sn_mva_active and (self.saturate_sn_mva <= 0).any():
             raise ValueError(f"saturate_sn_mva cannot be <= 0 but is {self.saturate_sn_mva}")
         if self.q_model is not None and not isinstance(self.q_model, QModel):
             logger.warning(f"The Q model is expected of type QModel, however {type(self.q_model)} "
@@ -190,7 +191,7 @@ class DERController(PQController):
         q_pu = self._step_q(p_series_mw=p_series_mw, q_series_mvar=q_series_mvar, vm_pu=vm_pu)
 
         # --- Second Step: Saturates P, Q according to SnMVA and PQV_AREA
-        if self.saturate_sn_mva or (self.pqv_area is not None):
+        if self.saturate_sn_mva_active or (self.pqv_area is not None):
             p_pu, q_pu = self._saturate(p_pu, q_pu, vm_pu)
 
         # --- Third Step: Convert relative P, Q to p_mw, q_mvar
@@ -225,7 +226,7 @@ class DERController(PQController):
                 q_pu[~in_area] = np.minimum(np.maximum(
                     q_pu[~in_area], min_max_q_pu[:, 0]), min_max_q_pu[:, 1])
 
-        if not np.isnan(self.saturate_sn_mva):
+        if self.saturate_sn_mva_active:
             p_pu, q_pu = self._saturate_sn_mva_step(p_pu, q_pu, vm_pu)
         return p_pu, q_pu
 
@@ -238,7 +239,7 @@ class DERController(PQController):
                 if (
                         isinstance(self.pqv_area, PQVArea4110) or isinstance(self.pqv_area, QVArea4110)
                 ) and any(
-                    (0.95 < vm[to_saturate]) & (vm[to_saturate] < 1.05) &
+                    (0.95 < vm_pu[to_saturate]) & (vm_pu[to_saturate] < 1.05) &
                     (-0.328684 < q_pu[to_saturate]) & any(q_pu[to_saturate] < 0.328684)
                 ):
                     logger.warning(f"Such kind of saturation is performed that is not in line with"

--- a/pandapower/convert_format.py
+++ b/pandapower/convert_format.py
@@ -20,7 +20,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def convert_format(net, elements_to_deserialize=None, drop_invalid_geodata=True):
+def convert_format(net, elements_to_deserialize=None, drop_invalid_geodata=True, donot_open_newer=True):
     """
     Converts old nets to new format to ensure consistency. The converted net is returned.
     """
@@ -28,8 +28,16 @@ def convert_format(net, elements_to_deserialize=None, drop_invalid_geodata=True)
     if not isinstance(net.version, str) or not hasattr(net, 'format_version') or \
             Version(net.format_version) > Version(net.version):
         net.format_version = net.version
-    if isinstance(net.format_version, str) and Version(net.format_version) >= Version(__format_version__):
+    if isinstance(net.format_version, str) and Version(net.format_version) == Version(__format_version__):
         return net
+    if isinstance(net.format_version, str) and Version(net.format_version) > Version(__format_version__):
+        msg1 = (f"The network format version {net.format_version} is newer than the current "
+                f"pandapower version {__format_version__}. ")
+        if donot_open_newer:
+            msg = msg1 + "Please update pandapower to the latest version."
+            raise ValueError(msg)
+        else:
+            logger.warning(msg1 + "Some features may not work as expected. ")
     _add_nominal_power(net)
     _add_missing_tables(net)
     _rename_columns(net, elements_to_deserialize)

--- a/pandapower/convert_format.py
+++ b/pandapower/convert_format.py
@@ -20,7 +20,8 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def convert_format(net, elements_to_deserialize=None, drop_invalid_geodata=True, donot_open_newer=True):
+def convert_format(net, elements_to_deserialize=None, drop_invalid_geodata=True,
+                   donot_open_newer=True):
     """
     Converts old nets to new format to ensure consistency. The converted net is returned.
     """
@@ -34,10 +35,13 @@ def convert_format(net, elements_to_deserialize=None, drop_invalid_geodata=True,
         msg1 = (f"The network format version {net.format_version} is newer than the current "
                 f"pandapower version {__format_version__}. ")
         if donot_open_newer:
-            msg = msg1 + "Please update pandapower to the latest version."
+            msg = msg1 + ("Please update pandapower to the latest version (e.g. by using `pip "
+                          "install --upgrade pandapower`).")
             raise ValueError(msg)
         else:
-            logger.warning(msg1 + "Some features may not work as expected. ")
+            logger.warning(msg1 + "Some features may not work as expected. You should consider "
+                                  "updating pandapower to the latest version (e.g. by using `pip "
+                                  "install --upgrade pandapower`).")
     _add_nominal_power(net)
     _add_missing_tables(net)
     _rename_columns(net, elements_to_deserialize)

--- a/pandapower/estimation/algorithm/base.py
+++ b/pandapower/estimation/algorithm/base.py
@@ -16,6 +16,7 @@ from pandapower.pypower.idx_bus import bus_cols
 
 import logging
 std_logger = logging.getLogger(__name__)
+std_logger.setLevel(logging.DEBUG)
 
 __all__ = ["WLSAlgorithm", "WLSZeroInjectionConstraintsAlgorithm", "IRWLSAlgorithm"]
 
@@ -75,7 +76,6 @@ class WLSAlgorithm(BaseAlgorithm):
         self.hx = None
         self.iterations = None
         self.obj_func = None
-        logging.basicConfig(level=logging.DEBUG)
 
     def estimate(self, eppci: ExtendedPPCI, debug_mode=False, **kwargs):
         self.initialize(eppci)

--- a/pandapower/file_io.py
+++ b/pandapower/file_io.py
@@ -243,7 +243,7 @@ def _from_excel_old(xls):
 
 def from_json(filename, convert=True, encryption_key=None, elements_to_deserialize=None,
               keep_serialized_elements=True, add_basic_std_types=False, replace_elements=None,
-              empty_dict_like_object=None, ignore_unknown_objects=False):
+              empty_dict_like_object=None, ignore_unknown_objects=False, drop_invalid_geodata=False):
     """
     Load a pandapower network from a JSON file.
     The index of the returned network is not necessarily in the same order as the original network.
@@ -303,12 +303,14 @@ def from_json(filename, convert=True, encryption_key=None, elements_to_deseriali
         add_basic_std_types=add_basic_std_types,
         replace_elements=replace_elements,
         empty_dict_like_object=empty_dict_like_object,
-        ignore_unknown_objects=ignore_unknown_objects)
+        ignore_unknown_objects=ignore_unknown_objects,
+        drop_invalid_geodata=drop_invalid_geodata)
 
 
 def from_json_string(json_string, convert=False, encryption_key=None, elements_to_deserialize=None,
                      keep_serialized_elements=True, add_basic_std_types=False,
-                     replace_elements=None, empty_dict_like_object=None, ignore_unknown_objects=False):
+                     replace_elements=None, empty_dict_like_object=None, ignore_unknown_objects=False,
+                     drop_invalid_geodata=False):
     """
     Load a pandapower network from a JSON string.
     The index of the returned network is not necessarily in the same order as the original network.
@@ -400,7 +402,7 @@ def from_json_string(json_string, convert=False, encryption_key=None, elements_t
         net = from_json_dict(net)
 
     if convert:
-        convert_format(net, elements_to_deserialize=elements_to_deserialize)
+        convert_format(net, elements_to_deserialize=elements_to_deserialize, drop_invalid_geodata=drop_invalid_geodata)
 
         # compare pandapowerNet-format_version and package-version
         check_net_version(net)

--- a/pandapower/file_io.py
+++ b/pandapower/file_io.py
@@ -4,16 +4,15 @@
 # and Energy System Technology (IEE), Kassel. All rights reserved.
 
 
-import pickle
-
-import os
-import sys
 import json
+import os
+import pickle
+import sys
 from warnings import warn
+
 import numpy
 import pandas as pd
 from packaging.version import Version
-
 
 try:
     import xlsxwriter
@@ -33,7 +32,7 @@ from pandapower.std_types import basic_std_types
 from pandapower.create import create_empty_network
 from pandapower.convert_format import convert_format
 from pandapower.io_utils import to_dict_with_coord_transform, to_dict_of_dfs, PPJSONEncoder, encrypt_string, \
-    get_raw_data_from_pickle, transform_net_with_df_and_geo, check_net_version, from_dict_of_dfs, decrypt_string, \
+    get_raw_data_from_pickle, transform_net_with_df_and_geo, from_dict_of_dfs, decrypt_string, \
     PPJSONDecoder
 
 import logging
@@ -146,7 +145,7 @@ def to_json(net, filename=None, encryption_key=None, store_index_names=None):
             fp.write(json_string)
 
 
-def from_pickle(filename, convert=True):
+def from_pickle(filename, convert=True, drop_invalid_geodata=True, ignore_version_conflicts=False):
     """
     Load a pandapower format Network from pickle file
 
@@ -156,6 +155,13 @@ def from_pickle(filename, convert=True):
 
         **convert** (bool, True) - If True, converts the format of the net loaded from pickle
         from the older version of pandapower to the newer version format
+
+        **drop_invalid_geodata** (bool, True) - If set to True, drop geodata entries with invalid\
+        coordinates instead of raising an error
+
+        **ignore_version_conflicts** (bool, False) - If set to True, ignore version conflicts \
+        between the net being loaded and the pandapower version. This can lead to errors when \
+        loading nets saved in older formats. Use with caution!
 
     OUTPUT:
         **net** (dict) - The pandapower format network
@@ -172,14 +178,12 @@ def from_pickle(filename, convert=True):
     transform_net_with_df_and_geo(net, ["bus_geodata"], ["line_geodata"])
 
     if convert:
-        convert_format(net)
-
-        # compare pandapowerNet-format_version and package-version
-        check_net_version(net)
+        convert_format(net, drop_invalid_geodata=drop_invalid_geodata,
+                       donot_open_newer=not ignore_version_conflicts)
     return net
 
 
-def from_excel(filename, convert=True):
+def from_excel(filename, convert=True, drop_invalid_geodata=True, ignore_version_conflicts=False):
     """
     Load a pandapower network from an excel file
 
@@ -188,6 +192,13 @@ def from_excel(filename, convert=True):
 
         **convert** (bool, True) - If True, converts the format of the net loaded from excel from
             the older version of pandapower to the newer version format
+
+        **drop_invalid_geodata** (bool, True) - If set to True, drop geodata entries with invalid\
+        coordinates instead of raising an error
+
+        **ignore_version_conflicts** (bool, False) - If set to True, ignore version conflicts \
+        between the net being loaded and the pandapower version. This can lead to errors when \
+        loading nets saved in older formats. Use with caution!
 
     OUTPUT:
         **net** (dict) - The pandapower format network
@@ -211,10 +222,8 @@ def from_excel(filename, convert=True):
     except:
         net = _from_excel_old(xls)
     if convert:
-        convert_format(net)
-
-        # compare pandapowerNet-format_version and package-version
-        check_net_version(net)
+        convert_format(net, drop_invalid_geodata=True,
+                       donot_open_newer=not ignore_version_conflicts)
     return net
 
 
@@ -243,7 +252,8 @@ def _from_excel_old(xls):
 
 def from_json(filename, convert=True, encryption_key=None, elements_to_deserialize=None,
               keep_serialized_elements=True, add_basic_std_types=False, replace_elements=None,
-              empty_dict_like_object=None, ignore_unknown_objects=False, drop_invalid_geodata=False):
+              empty_dict_like_object=None, ignore_unknown_objects=False, drop_invalid_geodata=False,
+              ignore_version_conflicts=False):
     """
     Load a pandapower network from a JSON file.
     The index of the returned network is not necessarily in the same order as the original network.
@@ -278,6 +288,13 @@ def from_json(filename, convert=True, encryption_key=None, elements_to_deseriali
         **ignore_unknown_objects** (bool, False) - If set to True, ignore any objects that cannot be
          deserialized instead of raising an error
 
+        **drop_invalid_geodata** (bool, False) - If set to True, drop geodata entries with invalid \
+        coordinates instead of raising an error
+
+        **ignore_version_conflicts** (bool, False) - If set to True, ignore version conflicts \
+        between the net being loaded and the pandapower version. This can lead to errors when \
+        loading nets saved in older formats. Use with caution!
+
     OUTPUT:
         **net** (dict) - The pandapower format network
 
@@ -304,13 +321,15 @@ def from_json(filename, convert=True, encryption_key=None, elements_to_deseriali
         replace_elements=replace_elements,
         empty_dict_like_object=empty_dict_like_object,
         ignore_unknown_objects=ignore_unknown_objects,
-        drop_invalid_geodata=drop_invalid_geodata)
+        drop_invalid_geodata=drop_invalid_geodata,
+        ignore_version_conflicts=ignore_version_conflicts
+    )
 
 
 def from_json_string(json_string, convert=False, encryption_key=None, elements_to_deserialize=None,
                      keep_serialized_elements=True, add_basic_std_types=False,
                      replace_elements=None, empty_dict_like_object=None, ignore_unknown_objects=False,
-                     drop_invalid_geodata=False):
+                     drop_invalid_geodata=False, ignore_version_conflicts=False):
     """
     Load a pandapower network from a JSON string.
     The index of the returned network is not necessarily in the same order as the original network.
@@ -343,6 +362,13 @@ def from_json_string(json_string, convert=False, encryption_key=None, elements_t
 
         **ignore_unknown_objects** (bool, False) - If set to True, ignore any objects that cannot be
          deserialized instead of raising an error
+
+        **drop_invalid_geodata** (bool, False) - If set to True, drop geodata entries with invalid \
+        coordinates instead of raising an error
+
+        **ignore_version_conflicts** (bool, False) - If set to True, ignore version conflicts \
+        between the net being loaded and the pandapower version. This can lead to errors when \
+        loading nets saved in older formats. Use with caution!
 
     OUTPUT:
         **net** (dict) - The pandapower format network
@@ -402,10 +428,9 @@ def from_json_string(json_string, convert=False, encryption_key=None, elements_t
         net = from_json_dict(net)
 
     if convert:
-        convert_format(net, elements_to_deserialize=elements_to_deserialize, drop_invalid_geodata=drop_invalid_geodata)
-
-        # compare pandapowerNet-format_version and package-version
-        check_net_version(net)
+        convert_format(net, elements_to_deserialize=elements_to_deserialize,
+                       drop_invalid_geodata=drop_invalid_geodata,
+                       donot_open_newer=not ignore_version_conflicts)
     if add_basic_std_types:
         # get std-types and add only new keys ones
         for key, std_types in basic_std_types().items():

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -379,13 +379,6 @@ def isinstance_partial(obj, cls):
     return isinstance(obj, cls)
 
 
-def check_net_version(net):
-    if Version(net["format_version"]) > Version(__version__):
-        logger.warning(f"pandapowerNet-version ({net['format_version']}) is newer than your "
-                       f"pandapower version ({__version__}). Please update pandapower "
-                       "`pip install --upgrade pandapower`.")
-
-
 class PPJSONEncoder(json.JSONEncoder):
     def __init__(self, isinstance_func=isinstance_partial, **kwargs):
         super(PPJSONEncoder, self).__init__(**kwargs)

--- a/pandapower/plotting/collections.py
+++ b/pandapower/plotting/collections.py
@@ -517,15 +517,6 @@ def create_line_collection(net: pandapowerNet, lines=None,
     OUTPUT:
         **lc** - line collection
     """
-    if line_table == "line":
-        dc = False
-        line_geodata_table = "line_geodata"
-    elif line_table == "line_dc":
-        dc = True
-        line_geodata_table = "line_dc_geodata"
-    else:
-        raise NotImplementedError(f"line table {line_table} not implemented!")
-
     if not MATPLOTLIB_INSTALLED:
         soft_dependency_error(str(sys._getframe().f_code.co_name) + "()", "matplotlib")
 

--- a/pandapower/plotting/geo.py
+++ b/pandapower/plotting/geo.py
@@ -3,13 +3,10 @@
 # Copyright (c) 2016-2023 by University of Kassel and Fraunhofer Institute for Energy Economics
 # and Energy System Technology (IEE), Kassel. All rights reserved.
 
-from typing import List, Tuple, TYPE_CHECKING, Dict, Any, Union
+from typing import List, Union
 
 import numpy as np
 
-# TYPE_CHECKING is used to avoid circular imports, see https://stackoverflow.com/a/39757388
-if TYPE_CHECKING:
-    import pandapipes
 from typing_extensions import deprecated
 
 import sys
@@ -17,7 +14,7 @@ import math
 import pandas as pd
 from numpy import array
 
-from pandapower.auxiliary import soft_dependency_error, pandapowerNet
+from pandapower.auxiliary import soft_dependency_error, pandapowerNet, ADict
 
 # get logger (same as in simple_plot)
 import logging
@@ -227,23 +224,20 @@ def convert_epsg_bus_geodata(net, epsg_in=4326, epsg_out=31467):
     return net
 
 
-def convert_crs(net: pandapowerNet or 'pandapipes.pandapipesNet', epsg_in=4326, epsg_out=31467):
-    """
-    This function works for pandapowerNet and pandapipesNet. Documentation will refer to names from pandapower.
-    Converts bus and line geodata in net from epsg_in to epsg_out
-    if GeoDataFrame data is present convert_geodata_to_gis should be used to update geometries after crs conversion
-    Supported geojson geometries are Point and LineString. Although Conversion away from WGS84 is highly discouraged.
-
-    :param net: The pandapower network
-    :type net: pandapowerNet|pandapipesNet
-    :param epsg_in: current epsg projection
-    :type epsg_in: int, default 4326 (= WGS84)
-    :param epsg_out: epsg projection to be transformed to
-    :type epsg_out: int, default 31467 (= Gauss-Krüger Zone 3)
-    :return: net - the given pandapower network (no copy!)
-    """
-    is_pandapower = net.__class__.__name__ == 'pandapowerNet'
+def abstract_convert_crs(net: ADict,
+                         node_name: str = 'bus',
+                         branch_name: str = 'line',
+                         epsg_in: int = 4326,
+                         epsg_out: int = 31467):
     if epsg_in == epsg_out:
+        return
+
+    node_geo_name = node_name + "_geodata"
+    branch_geo_name = branch_name + "_geodata"
+    if ('geo' in net[node_name] and not all(net[node_name].geo.isna()) and
+            'geo' in net[branch_name] and not all(net[branch_name].geo.isna()) and
+            epsg_out == 4326):
+        # by definition geojson is in wgs84
         return
 
     if not pyproj_INSTALLED:
@@ -271,50 +265,108 @@ def convert_crs(net: pandapowerNet or 'pandapipes.pandapipesNet', epsg_in=4326, 
                 geometry['coordinates'] = new_coordinates
             return geojson.dumps(geometry)
 
-        if is_pandapower:
-            net.line.geo = net.line.geo.apply(_geojson_transformer)
-            net.bus.geo = net.bus.geo.apply(_geojson_transformer)
-        else:
-            net.pipe.geo = net.pipe.geo.apply(_geojson_transformer)
-            net.junction.geo = net.junction.geo.apply(_geojson_transformer)
+        net.line.geo = net.line.geo.apply(_geojson_transformer)
+        net.bus.geo = net.bus.geo.apply(_geojson_transformer)
         return
 
     def _geo_node_transformer(r):
         (x, y) = transformer.transform(r.x, r.y)
-        if is_pandapower:
-            coords = r.coords
-            if coords and not pd.isna(coords):
-                coords = _geo_branch_transformer(coords)
-            return pd.Series([x, y, coords], ["x", "y", "coords"])
-        else:
-            return pd.Series([x, y], ["x", "y"])
+        coords = r.coords
+        if coords and not pd.isna(coords):
+            coords = _geo_branch_transformer(coords)
+        return pd.Series([x, y, coords], ["x", "y", "coords"])
 
     def _geo_branch_transformer(r):
         return list(transformer.itransform(r))
 
-    if is_pandapower:
-        net.bus_geodata = net.bus_geodata.apply(lambda r: _geo_node_transformer(r), axis=1)
-        net.line_geodata.coords = net.line_geodata.coords.apply(lambda r: _geo_branch_transformer(r))
-        net.bus_geodata.attrs = {"crs": f"EPSG:{epsg_out}"}
-        net.line_geodata.attrs = {"crs": f"EPSG:{epsg_out}"}
-    else:
-        net.junction_geodata = net.junction_geodata.apply(lambda r: _geo_node_transformer(r), axis=1)
-        net.pipe_geodata.coords = net.pipe_geodata.coords.apply(lambda r: _geo_branch_transformer(r))
-        net.junction_geodata.attrs = {"crs": f"EPSG:{epsg_out}"}
-        net.pipe_geodata.attrs = {"crs": f"EPSG:{epsg_out}"}
+    net[node_geo_name] = net[node_geo_name].apply(lambda r: _geo_node_transformer(r), axis=1)
+    net[branch_geo_name].coords = net[branch_geo_name].coords.apply(lambda r: _geo_branch_transformer(r))
+    net[node_geo_name].attrs = {"crs": f"EPSG:{epsg_out}"}
+    net[branch_geo_name].attrs = {"crs": f"EPSG:{epsg_out}"}
+
+
+def convert_crs(net: pandapowerNet,
+                epsg_in: int = 4326,
+                epsg_out: int = 31467):
+    """
+    This function works for pandapower network. Documentation will refer to names from pandapower.
+    Converts bus and line geodata in net from epsg_in to epsg_out
+    if GeoDataFrame data is present convert_geodata_to_gis should be used to update geometries after crs conversion
+    Supported geojson geometries are Point and LineString. Although Conversion away from WGS84 is highly discouraged.
+
+    :param net: network
+    :type net: ADict
+    :param epsg_in: current epsg projection
+    :type epsg_in: int, default 4326 (= WGS84)
+    :param epsg_out: epsg projection to be transformed to
+    :type epsg_out: int, default 31467 (= Gauss-Krüger Zone 3)
+    :return: net - the given pandapower network (no copy!)
+    """
+    abstract_convert_crs(net, 'bus', 'line', epsg_in, epsg_out)
+
+
+def dump_to_geojson_node_branch(
+        net: ADict,
+        node_geodata: pd.Series,
+        branch_geodata: pd.Series,
+        node_name: str = 'bus',
+        branch_name: str = 'line',
+        nodes: Union[bool, List[int]] = False,
+        branches: Union[bool, List[int]] = False,
+        include_type_id: bool = True
+        ):
+
+    def update_props(r: pd.Series) -> None:
+        if r.name not in props:
+            props[r.name] = {}
+        props[r.name].update(r.to_dict())
+
+    features = []
+    elements = {node_name: nodes, branch_name: branches}
+    geodata = {node_name: node_geodata, branch_name: branch_geodata}
+    missing_geom = {node_name: 0, branch_name: 0}
+    # build geojson features for nodes and branches
+
+    for name in [node_name, branch_name]:
+        element = elements[name]
+        if element:
+            props = {}
+            for table in [name, 'res_' + name]:
+                if table not in net.keys():
+                    continue
+
+                tempdf = net[table].copy(deep=True)
+                if include_type_id:
+                    tempdf['pp_type'] = name
+                    tempdf['pp_index'] = tempdf.index
+                tempdf.index = tempdf.apply(lambda r: f"{r['pp_type']}-{r['pp_index']}", axis=1)
+                tempdf.drop(columns=['geo'], inplace=True, axis=1, errors='ignore')
+
+                tempdf.apply(update_props, axis=1)
+            if isinstance(element, bool):
+                iterator = geodata[name].items()
+            else:
+                iterator = geodata[name].loc[element].items()
+            for ind, geom in iterator:
+                if geom is None:
+                    missing_geom[name] += 1
+                    continue
+                uid = f"{name}-{ind}"
+                features.append(geojson.Feature(geometry=geojson.loads(geom), id=uid, properties=props[uid]))
+    return features, missing_geom[node_name], missing_geom[branch_name]
 
 
 def dump_to_geojson(
-        net: pandapowerNet or 'pandapipes.pandapipesNet',
+        net: pandapowerNet,
         nodes: Union[bool, List[int]] = False,
         branches: Union[bool, List[int]] = False,
-        switches: Union[bool,  List[int]] = False,
+        switches: Union[bool, List[int]] = False,
         trafos: Union[bool, List[int]] = False,
         t_is_3w: bool = False,
         include_type_id: bool = True
 ) -> geojson.FeatureCollection:
     """
-    This function works for pandapowerNet and pandapipesNet. Documentation will refer to names from pandapower.
+    This function works for pandapowerNet. Documentation will refer to names from pandapower.
     Dumps all primitive values from bus, bus_geodata, res_bus, line, line_geodata and res_line into a geojson object.
     It is recommended to only dump networks using WGS84 for GeoJSON specification compliance.
 
@@ -324,7 +376,7 @@ def dump_to_geojson(
     to them are located!
 
     :param net: The pandapower network
-    :type net: pandapowerNet|pandapipesNet
+    :type net: pandapowerNet
     :param nodes: if True return contains all bus data, can be a list of bus ids that should be contained
     :type nodes: bool | list, default False
     :param branches: if True return contains all line data, can be a list of line ids that should be contained
@@ -340,29 +392,26 @@ def dump_to_geojson(
     :return: A geojson object.
     :return type: geojson.FeatureCollection
     """
-    is_pandapower = net.__class__.__name__ == 'pandapowerNet'
 
     if not geojson_INSTALLED:
         soft_dependency_error(str(sys._getframe().f_code.co_name) + "()", "geojson")
 
     try:
-        if is_pandapower:
-            if hasattr(net, "bus_geodata") or hasattr(net, "line_geodata"):
-                raise UserWarning("""The supplied network uses an outdated geodata format. Please update your geodata by
-                                     \rrunning `pandapower.plotting.geo.convert_geodata_to_geojson(net)`""")
-            else:
-                node_geodata = net.bus.geo
-                branch_geodata = net.line.geo
+        if hasattr(net, "bus_geodata") or hasattr(net, "line_geodata"):
+            raise UserWarning("""The supplied network uses an outdated geodata format. Please update your geodata by
+                                 \rrunning `pandapower.plotting.geo.convert_geodata_to_geojson(net)`""")
         else:
-            if hasattr(net, "junction_geodata") or hasattr(net, "pipe_geodata"):
-                raise UserWarning("""The supplied network uses an outdated geodata format. Please update your geodata by
-                                     \rrunning `pandapower.plotting.geo.convert_geodata_to_geojson(net)`""")
-            else:
-                node_geodata = net.junction.geo
-                branch_geodata = net.pipe.geo
+            bus_geodata = net.bus.geo
+            line_geodata = net.line.geo
+
     except UserWarning as e:
         logger.warning(e)
         return geojson.FeatureCollection([])
+
+    missing_geom: List[int] = [0, 0, 0, 0]  # missing nodes, branches, switches, trafos
+    features, missing_geom[0], missing_geom[1] = dump_to_geojson_node_branch(
+        net, bus_geodata, line_geodata, 'bus', 'line', nodes, branches,
+        include_type_id=include_type_id)
 
     def _get_props(r, c, p) -> None:
         for col in c:
@@ -373,70 +422,7 @@ def dump_to_geojson(
             except (ValueError, TypeError):
                 p[col] = str(r[col])
 
-    def update_props(r: pd.Series) -> None:
-        if r.name not in props:
-            props[r.name] = {}
-        props[r.name].update(r.to_dict())
-
-    missing_geom: List[int] = [0, 0, 0, 0]  # missing nodes, branches, switches, trafos
-    features = []
-    # build geojson features for nodes
-    if nodes:
-        props = {}
-        for table in (['bus', 'res_bus'] if is_pandapower else ['junction', 'res_junction']):
-            if table not in net.keys():
-                continue
-
-            tempdf = net[table].copy(deep=True)
-            if include_type_id:
-                tempdf['pp_type'] = 'bus' if is_pandapower else 'junction'
-                tempdf['pp_index'] = tempdf.index
-            tempdf.index = tempdf.apply(lambda r: f"{r['pp_type']}-{r['pp_index']}", axis=1)
-            tempdf.drop(columns=['geo'], inplace=True, axis=1, errors='ignore')
-
-            tempdf.apply(update_props, axis=1)
-        if isinstance(nodes, bool):
-            iterator = node_geodata.items()
-        else:
-            iterator = node_geodata.loc[nodes].items()
-        for ind, geom in iterator:
-            if geom is None or pd.isna(geom) or geom == "[]":
-                missing_geom[0] += 1
-                continue
-            uid = f"{'bus' if is_pandapower else 'junction'}-{ind}"
-            features.append(geojson.Feature(geometry=geojson.loads(geom), id=uid, properties=props[uid]))
-
-    # build geojson features for branches
-    if branches:
-        props = {}
-        for table in (['line', 'res_line'] if is_pandapower else ['pipe', 'res_pipe']):
-            if table not in net.keys():
-                continue
-
-            tempdf = net[table].copy(deep=True)
-            if include_type_id:
-                tempdf['pp_type'] = 'line' if is_pandapower else 'pipe'
-                tempdf['pp_index'] = tempdf.index
-            tempdf.index = tempdf.apply(lambda r: f"{r['pp_type']}-{r['pp_index']}", axis=1)
-            tempdf.drop(columns=['geo'], inplace=True, axis=1, errors='ignore')
-
-            tempdf.apply(update_props, axis=1)
-
-        # Iterating over pipe_geodata won't work
-        # pipe_geodata only contains pipes that have inflection points!
-        if isinstance(branches, bool):
-            # if all iterating over pipe
-            iterator = branch_geodata.items()
-        else:
-            iterator = branch_geodata.loc[branches].items()
-        for ind, geom in iterator:
-            if geom is None or pd.isna(geom) or geom == "[]":
-                missing_geom[1] += 1
-                continue
-            uid = f"{'line' if is_pandapower else 'pipe'}-{ind}"
-            features.append(geojson.Feature(geometry=geojson.loads(geom), id=uid, properties=props[uid]))
-
-    if switches and is_pandapower:
+    if switches:
         if isinstance(switches, bool):
             switches = net.switch.index
         if 'switch' in net.keys():
@@ -460,35 +446,35 @@ def dump_to_geojson(
                 if isinstance(geom, geojson.LineString):
                     logger.warning(f"LineString geometry not supported for type 'switch'. Skipping switch {ind}")
                     geom = None
-                if geom is None or geom == "[]":
+                if geom is None:
                     missing_geom[2] += 1
                     continue
                 features.append(geojson.Feature(geometry=geom, id=uid, properties=prop))
 
-        if trafos and is_pandapower:
-            t_type = 'trafo3w' if t_is_3w else 'trafo'
-            if isinstance(trafos, bool):
-                trafos = net[t_type].index
-            if t_type in net.keys():
-                cols = net[t_type].columns
-                for ind, row in net[t_type].loc[trafos].iterrows():
-                    prop = {}
-                    if include_type_id:
-                        prop = {
-                            'pp_type': t_type,
-                            'pp_index': ind,
-                        }
-                    uid = f"{t_type}-{ind}"
-                    _get_props(row, cols, prop)
+    if trafos:
+        t_type = 'trafo3w' if t_is_3w else 'trafo'
+        if isinstance(trafos, bool):
+            trafos = net[t_type].index
+        if t_type in net.keys():
+            cols = net[t_type].columns
+            for ind, row in net[t_type].loc[trafos].iterrows():
+                prop = {}
+                if include_type_id:
+                    prop = {
+                        'pp_type': t_type,
+                        'pp_index': ind,
+                    }
+                uid = f"{t_type}-{ind}"
+                _get_props(row, cols, prop)
 
-                    # getting geodata for switches
-                    geom = geojson.loads(net.bus.geo.at[row.lv_bus])
-                    if isinstance(geom, geojson.LineString):
-                        logger.warning(f"LineString geometry not supported for type '{t_type}'. Skipping trafo {ind}")
-                    if geom is None or geom == "[]":
-                        missing_geom[3] += 1
-                        continue
-                    features.append(geojson.Feature(geometry=geom, id=uid, properties=prop))
+                # getting geodata for trafos
+                geom = geojson.loads(net.bus.geo.at[row.lv_bus])
+                if isinstance(geom, geojson.LineString):
+                    logger.warning(f"LineString geometry not supported for type '{t_type}'. Skipping trafo {ind}")
+                if geom is None:
+                    missing_geom[3] += 1
+                    continue
+                features.append(geojson.Feature(geometry=geom, id=uid, properties=prop))
 
     if any(missing_geom):
         missing_str = []
@@ -504,11 +490,11 @@ def dump_to_geojson(
 
     # find and set crs if available
     crs_node = None
-    if nodes and "crs" in node_geodata.attrs:
-        crs_node = node_geodata.attrs["crs"]
+    if nodes and "crs" in bus_geodata.attrs:
+        crs_node = bus_geodata.attrs["crs"]
     crs_branch = None
-    if branches and "crs" in branch_geodata.attrs:
-        crs_branch = branch_geodata.attrs["crs"]
+    if branches and "crs" in line_geodata.attrs:
+        crs_branch = line_geodata.attrs["crs"]
 
     crs = {
         "type": "name",
@@ -529,13 +515,87 @@ def dump_to_geojson(
     return geojson.FeatureCollection(features)
 
 
+def _geodata_node_check(df, geo_df, lonlat=False, drop_invalid_geodata=True):
+    if not geo_df.empty:
+        df["geo"] = None
+        a, b = "yx" if lonlat else "xy"  # substitute x and y with a and b to reverse them if necessary
+        geo_df = geo_df.astype({"x": float, "y": float})
+        coords_na = geo_df[["x", "y"]].isna().sum(axis=1)
+        if not drop_invalid_geodata and any(coords_na == 1):
+            raise ValueError(f"There exists invalid bus geodata at index "
+                             f"{list(geo_df[coords_na==1].index)}. "
+                             f"Please clean up your data first or "
+                             "set 'drop_invalid_geodata' to True")
+        if any(coords_na == 1):
+            logger.warning(f"bus geodata at index "
+                           f"{list(geo_df[coords_na==1].index)} is invalid and replaced by None")
+        geo_df.dropna(inplace=True)
+        geo_as_json = pd.Series(
+            [
+                f'{{"coordinates": [{x}, {y}], "type": "Point"}}'
+                for x, y in (zip(geo_df[a], geo_df[b]))
+            ],
+            index=geo_df.index,
+            name="geo",
+        )
+        df.loc[geo_df.index, 'geo'] = geo_as_json
+
+
+def _geodata_branch_check(df, geo_df, lonlat=False, drop_invalid_geodata=True):
+    if not geo_df.empty:
+        df["geo"] = None
+        geo_df = geo_df.explode("coords")
+        geo_df.dropna(inplace=True)
+        coords_na = geo_df["coords"].apply(lambda x: sum(pd.isna(list(x))) if isinstance(x, (list, tuple)) else 999)
+        if not drop_invalid_geodata and any(coords_na == 1):
+            raise ValueError(f"There exists invalid bus geodata at index "
+                             f"{list(geo_df[coords_na==1].index)}. "
+                             f"Please clean up your data first or "
+                             "set 'drop_invalid_geodata' to True")
+        if any(coords_na == 1):
+            logger.warning(f"line geodata at index "
+                           f"{list(geo_df[coords_na==1].index)} is invalid and replaced by None")
+        geo_df = geo_df[coords_na == 0]
+        geo_df['coords'] = geo_df['coords'].apply(lambda coord_list: [
+            float(x) for x in (coord_list[::-1] if lonlat else coord_list)])
+        geo_as_json = geo_df.groupby(geo_df.index).apply(
+            lambda x: f'{{"coordinates": {list(x.coords)}, "type": "LineString"}}')
+        coords_na_sum = coords_na.groupby(coords_na.index).sum()
+        geo_df.loc[coords_na_sum != 0] = None
+        df.loc[geo_df.index, 'geo'] = geo_as_json
+
+
+def abstract_convert_geodata_to_geojson(
+    net: ADict,
+    node_name: str = 'bus',
+    branch_name: str = 'line',
+    delete: bool = True,
+    lonlat: bool = False,
+    drop_invalid_geodata: bool = True) -> None:
+    df = net[node_name]
+    ldf = net[branch_name]
+    bus_geo_name = node_name + '_geodata'
+    line_geo_name = branch_name + '_geodata'
+    geo_df = net[bus_geo_name][['x', 'y']] if (
+                hasattr(net, bus_geo_name) and isinstance(net[bus_geo_name], pd.DataFrame)) else pd.DataFrame()
+    geo_ldf = net[line_geo_name] if (
+            hasattr(net, line_geo_name) and isinstance(net[line_geo_name], pd.DataFrame)) else pd.DataFrame()
+
+    _geodata_node_check(df, geo_df, lonlat=lonlat, drop_invalid_geodata=drop_invalid_geodata)
+    _geodata_branch_check(ldf, geo_ldf, lonlat=lonlat, drop_invalid_geodata=drop_invalid_geodata)
+
+    if delete:
+        if hasattr(net, bus_geo_name): del net[bus_geo_name]
+        if hasattr(net, line_geo_name): del net[line_geo_name]
+
+
 def convert_geodata_to_geojson(
-        net: pandapowerNet or 'pandapipes.pandapipesNet',
+        net: pandapowerNet,
         delete: bool = True,
-        lonlat: bool = False) -> None:
+        lonlat: bool = False,
+        drop_invalid_geodata: bool = True) -> None:
     """
     Converts bus_geodata and line_geodata to bus.geo and line.geo column entries.
-    If used on pandapipesNet, the junction_geodata and pipe_geodata are converted.
 
     It is expected that any input network has its coords in WGS84 (epsg:4326) projection.
     If this is not the case use convert_crs to convert the network to WGS84.
@@ -546,56 +606,35 @@ def convert_geodata_to_geojson(
     :type delete: bool, default True
     :param lonlat: If True, the coordinates are expected to be in lonlat format (x=lon, y=lat)
     :type lonlat: bool, default False
+    :param drop_invalid_geodata: If True, entries containing invalid geo coordinates e.g. None, np.nan will be dropped
+    :type drop_invalid_geodata: bool, default True
     """
-    is_pandapower = net.__class__.__name__ == 'pandapowerNet'
+    abstract_convert_geodata_to_geojson(net, 'bus', 'line', delete, lonlat, drop_invalid_geodata)
+    abstract_convert_geodata_to_geojson(net, 'bus_dc', 'line_dc', delete, lonlat, drop_invalid_geodata)
 
-    if is_pandapower:
-        df = net.bus
-        ldf = net.line
-        geo_df = net.bus_geodata if (hasattr(net, 'bus_geodata') and isinstance(net.bus_geodata, pd.DataFrame)) else pd.DataFrame()
-        geo_ldf = net.line_geodata if (hasattr(net, 'line_geodata') and isinstance(net.line_geodata, pd.DataFrame)) else pd.DataFrame()
-    else:
-        df = net.junction
-        ldf = net.pipe
-        geo_df = net.junction_geodata if (hasattr(net, 'junction_geodata') and isinstance(net.junction_geodata, pd.DataFrame)) else pd.DataFrame()
-        geo_ldf = net.pipe_geodata if (hasattr(net, 'pipe_geodata') and isinstance(net.pipe_geodata, pd.DataFrame)) else pd.DataFrame()
+def _is_valid_number(value):
+    try:
+        float_value = float(value)
+        return not (isinstance(value, float) and np.isnan(float_value))
+    except (ValueError, TypeError):
+        return False
 
-    a, b = "yx" if lonlat else "xy"  # substitute x and y with a and b to reverse them if necessary
-    if not geo_df.empty:
-        df["geo"] = geo_df.apply(lambda r: f'{{"coordinates": [{r[a]}, {r[b]}], "type": "Point"}}', axis=1)
 
-    ldf["geo"] = np.nan
-    for l_id in ldf.index:
-        if l_id not in geo_ldf.index:
-            continue
-        # pandapipes currently only stores inflection points for pipes. This function will inject start and end points.
-        if is_pandapower:
-            coords: List[List[float]] = [[y, x] if lonlat else [x, y] for x, y in geo_ldf.coords.at[l_id]]
-        else:
-            coords: List[List[float]] = []
-            from_coords = geo_df.loc[ldf[l_id].from_junction]
-            to_coords = geo_df.loc[ldf[l_id].to_junction]
-            coords.append([float(from_coords.x), float(from_coords.y)])
-            if l_id in net.pipe_geodata:
-                coords.append(geo_ldf.loc[l_id].coords)
-            coords.append([float(to_coords.x), float(to_coords.y)])
-        if not coords:
-            continue
-        ls = f'{{"coordinates": {coords}, "type": "LineString"}}'
-        ldf["geo"] = ldf["geo"].astype(object)
-        ldf.geo.at[l_id] = ls
+def abstract_convert_gis_to_geojson(
+        net: pandapowerNet,
+        node_name: str = 'bus',
+        branch_name: str = 'line',
+        delete: bool = True) -> None:
+    net[node_name]["geo"] = _transform_node_geometry_to_geojson(net[node_name + "_geodata"])
+    net[branch_name]["geo"] = _transform_branch_geometry_to_geojson(net[branch_name + "_geodata"])
 
     if delete:
-        if is_pandapower:
-            if hasattr(net, 'bus_geodata'):del net.bus_geodata
-            if hasattr(net, 'line_geodata'): del net.line_geodata
-        else:
-            if hasattr(net, 'junction_geodata'): del net.junction_geodata
-            if hasattr(net, 'pipe_geodata'): del net.pipe_geodata
+        del net[node_name + "_geodata"]
+        del net[branch_name + "_geodata"]
 
 
 def convert_gis_to_geojson(
-        net: pandapowerNet or 'pandapipes.pandapipesNet',
+        net: pandapowerNet,
         delete: bool = True) -> None:
     """
     Transforms the bus and line geodataframes of a net into a geojson object.
@@ -606,20 +645,4 @@ def convert_gis_to_geojson(
     :type delete: bool, default True
     :return: No output.
     """
-
-    is_pandapower = net.__class__.__name__ == 'pandapowerNet'
-
-    if is_pandapower:
-        net.bus["geo"] = _transform_node_geometry_to_geojson(net["bus_geodata"])
-        net.line["geo"] = _transform_branch_geometry_to_geojson(net["line_geodata"])
-
-        if delete:
-            del net.bus_geodata
-            del net.line_geodata
-    else:
-        net.junction["geo"] = _transform_node_geometry_to_geojson(net["junction_geodata"])
-        net.pipe["geo"] = _transform_branch_geometry_to_geojson(net["pipe_geodata"])
-
-        if delete:
-            del net.junction_geodata
-            del net.pipe_geodata
+    abstract_convert_crs(net, 'bus', 'line', delete)

--- a/pandapower/plotting/plotly/traces.py
+++ b/pandapower/plotting/plotly/traces.py
@@ -856,7 +856,6 @@ def create_weighted_marker_trace(net, elm_type="load", elm_ids=None, column_to_p
                                  scale_legend_unit=None, trace_kwargs=None):
     """Create a single-color plotly trace markers/patches (e.g., bubbles) of value-dependent size.
 
-    Can be used with pandapipes.plotting.plotly.simple_plotly (pass as "additional_trace").
     If present in the respective pandapower-net table, the "in_service" and "scaling" column will be
     taken into account as factors to calculate the markers' weights.
     Negative values might lead to unexpected results, especially when pos. and neg. values are
@@ -894,7 +893,7 @@ def create_weighted_marker_trace(net, elm_type="load", elm_ids=None, column_to_p
         **infofunc** (pd.Series, default None): hover-infofuction to overwrite the internal infofunction
 
         **node_element** (str, default "bus") - the name of node elements in the net. "bus" for
-        pandapower networks, "junction" for pandapipes networks
+        pandapower networks
 
         **show_scale_legend** (bool, default True): display a marker legend at the top right of the
          plot
@@ -986,8 +985,6 @@ def create_weighted_marker_trace(net, elm_type="load", elm_ids=None, column_to_p
 def create_scale_trace(net, weighted_trace, down_shift=0):
     """Create a scale (marker size legend) for a weighted_marker_trace.
 
-    Will be used with pandapipes.plotting.plotly.simple_plotly, when "additional_trace" contains
-    a trace created by :func:`create_weighted_marker_trace` with :code:`show_scale_legend=True`.
     The default reference marker is of average size of all weighted markers, rounded to the next 5,
     and comes with a string with the respective reference value and unit.
 

--- a/pandapower/test/api/test_auxiliary.py
+++ b/pandapower/test/api/test_auxiliary.py
@@ -98,8 +98,8 @@ def test_get_indices():
 
 def test_net_deepcopy():
     net = example_simple()
-    net.line.at[0, 'geo'] = geojson.LineString([(0., 1.), (1., 2.)])
-    net.bus.at[0, 'geo'] = geojson.Point((0., 1.))
+    net.line.at[0, 'geo'] = geojson.dumps(geojson.LineString([(0., 1.), (1., 2.)]))
+    net.bus.at[0, 'geo'] = geojson.dumps(geojson.Point((0., 1.)))
 
     ContinuousTapControl(net, element_index=0, vm_set_pu=1)
     ds = DFData(pd.DataFrame(data=[[0, 1, 2], [3, 4, 5]]))
@@ -113,8 +113,8 @@ def test_net_deepcopy():
 
     if GEOPANDAS_INSTALLED:
         for tab in ('bus', 'line'):
-            net[f'{tab}_geodata'] = gpd.GeoDataFrame(net[tab].geo.dropna().apply(
-                lambda x: x["coordinates"]), geometry=net[tab].geo.dropna())
+            net[f'{tab}_geodata'] = gpd.GeoDataFrame(net[tab].geo.dropna().apply(geojson.loads).apply(
+                lambda x: x["coordinates"] if x is not None else x), geometry=net[tab].geo.dropna().apply(geojson.loads))
         net1 = net.deepcopy()
         assert isinstance(net1.line_geodata, gpd.GeoDataFrame)
         assert isinstance(net1.bus_geodata, gpd.GeoDataFrame)

--- a/pandapower/test/plotting/test_geo.py
+++ b/pandapower/test/plotting/test_geo.py
@@ -381,9 +381,9 @@ def test_convert_geodata_to_geojson():
     convert_geodata_to_geojson(_net)
 
     # Überprüfe die Ergebnisse
-    assert _net.bus.at[0, "geo"] == geojson.dumps(geojson.Point((10, 20)), sort_keys=True)
-    assert _net.bus.at[1, "geo"] == geojson.dumps(geojson.Point((30, 40)), sort_keys=True)
-    assert _net.line.at[0, "geo"] == geojson.dumps(geojson.LineString([(10, 20), (30, 40)]), sort_keys=True)
+    assert _net.bus.at[0, "geo"] == geojson.dumps(geojson.Point((10., 20.)), sort_keys=True)
+    assert _net.bus.at[1, "geo"] == geojson.dumps(geojson.Point((30., 40.)), sort_keys=True)
+    assert _net.line.at[0, "geo"] == geojson.dumps(geojson.LineString([(10., 20.), (30., 40.)]), sort_keys=True)
     # TODO: Test could be more exhaustive (e.g. test delete=False, lonlat=True, geo_str=False)
 
 

--- a/pandapower/test/toolbox/test_comparison.py
+++ b/pandapower/test/toolbox/test_comparison.py
@@ -5,6 +5,7 @@
 
 import copy
 
+import pandas as pd
 import pytest
 
 from pandapower.control.controller.trafo.ContinuousTapControl import ContinuousTapControl
@@ -66,6 +67,15 @@ def test_nets_equal():
     assert c1 != c2
     assert nets_equal(net1, net2, exclude_elms=["controller"])
     assert not nets_equal(net1, net2)
+
+    # check geo
+    net1 = copy.deepcopy(original)
+    net2 = copy.deepcopy(original)
+    net1.bus["geo"] = pd.Series(index=net1.bus.index, data=[100] * len(net1.bus.index))
+    net2.bus["geo"] = pd.Series(index=net2.bus.index, data=[100] * len(net2.bus.index))
+    assert nets_equal(
+        net1, net2, assume_geojson_strings=False, exclude_elms=set(net.keys()) - {"bus"}
+    )
 
 
 if __name__ == '__main__':

--- a/pandapower/toolbox/comparison.py
+++ b/pandapower/toolbox/comparison.py
@@ -18,7 +18,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def dataframes_equal(df1, df2, ignore_index_order=True, **kwargs):
+def dataframes_equal(df1, df2, ignore_index_order=True, assume_geojson_strings=True, **kwargs):
     """
     Returns a boolean whether the given two dataframes are equal or not.
     """
@@ -34,12 +34,18 @@ def dataframes_equal(df1, df2, ignore_index_order=True, **kwargs):
         df2 = df2.sort_index().sort_index(axis=1)
 
     # geo columns are compared later
-    df1_cols = df1.columns.difference({"geo"})
-    df2_cols = df2.columns.difference({"geo"})
+    if assume_geojson_strings:
+        df1_cols = df1.columns.difference({"geo"})
+        df2_cols = df2.columns.difference({"geo"})
+    else:
+        df1_cols = df1.columns
+        df2_cols = df2.columns
 
     # --- pandas implementation
     try:
         pdt.assert_frame_equal(df1[df1_cols], df2[df2_cols], **kwargs)
+        if not assume_geojson_strings:
+            return True
     except AssertionError:
         return False
 
@@ -103,7 +109,7 @@ def compare_arrays(x, y):
 
 
 def nets_equal(net1, net2, check_only_results=False, check_without_results=False, exclude_elms=None,
-               name_selection=None, **kwargs):
+               name_selection=None, assume_geojson_strings=True, **kwargs):
     """
     Returns a boolean whether the two given pandapower networks are equal.
 
@@ -136,7 +142,7 @@ def nets_equal(net1, net2, check_only_results=False, check_without_results=False
         return False
     not_equal, not_checked_keys = nets_equal_keys(
         net1, net2, check_only_results, check_without_results, exclude_elms, name_selection,
-        **kwargs)
+        assume_geojson_strings, **kwargs)
     if len(not_checked_keys) > 0:
         logger.warning("These keys were ignored by the comparison of the networks: %s" % (', '.join(
             not_checked_keys)))
@@ -149,7 +155,7 @@ def nets_equal(net1, net2, check_only_results=False, check_without_results=False
 
 
 def nets_equal_keys(net1, net2, check_only_results, check_without_results, exclude_elms,
-                     name_selection, **kwargs):
+                     name_selection, assume_geojson_strings, **kwargs):
     """ Returns a lists of keys which are 1) not equal and 2) not checked.
     Used within nets_equal(). """
     if check_without_results and check_only_results:
@@ -188,7 +194,8 @@ def nets_equal_keys(net1, net2, check_only_results, check_without_results, exclu
 
         if isinstance(net1[key], pd.DataFrame):
             if not isinstance(net2[key], pd.DataFrame) or not dataframes_equal(
-                    net1[key], net2[key], **kwargs):
+                    net1[key], net2[key], assume_geojson_strings=assume_geojson_strings,
+                    **kwargs):
                 not_equal.append(key)
 
         elif isinstance(net1[key], np.ndarray):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pandapower"
-version = "3.1.2" # File format version '__format_version__' is tracked in _version.py
+version = "3.1.3.dev0" # File format version '__format_version__' is tracked in _version.py
 authors = [
     { name = "Leon Thurner", email = "leon.thurner@retoflow.de" },
     { name = "Alexander Scheidler", email = "alexander.scheidler@iee.fraunhofer.de" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pandapower"
-version = "3.1.2+retoflow.1" # File format version '__format_version__' is tracked in _version.py
+version = "3.1.2+retoflow.2" # File format version '__format_version__' is tracked in _version.py
 authors = [
     { name = "Leon Thurner", email = "leon.thurner@retoflow.de" },
     { name = "Alexander Scheidler", email = "alexander.scheidler@iee.fraunhofer.de" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pandapower"
-version = "3.1.3.dev0" # File format version '__format_version__' is tracked in _version.py
+version = "3.1.2+retoflow.1" # File format version '__format_version__' is tracked in _version.py
 authors = [
     { name = "Leon Thurner", email = "leon.thurner@retoflow.de" },
     { name = "Alexander Scheidler", email = "alexander.scheidler@iee.fraunhofer.de" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pandapower"
-version = "3.1.2+retoflow.2" # File format version '__format_version__' is tracked in _version.py
+version = "3.1.2+retoflow.3" # File format version '__format_version__' is tracked in _version.py
 authors = [
     { name = "Leon Thurner", email = "leon.thurner@retoflow.de" },
     { name = "Alexander Scheidler", email = "alexander.scheidler@iee.fraunhofer.de" },

--- a/tutorials/plotting_structural.ipynb
+++ b/tutorials/plotting_structural.ipynb
@@ -80,9 +80,9 @@
    "source": [
     "net = nw.mv_oberrhein()\n",
     "# net.bus.geo.drop(net.bus.geo.index, inplace=True)\n",
-    "net.bus.geo = np.nan\n",
+    "net.bus.geo = None\n",
     "# net.line.geo.drop(net.line.geo.index, inplace=True)\n",
-    "net.line.geo = np.nan\n",
+    "net.line.geo = None\n",
     "plot.create_generic_coordinates(net, respect_switches=False) #create artificial coordinates with the igraph package"
    ]
   },
@@ -258,8 +258,8 @@
    ],
    "source": [
     "net = nw.mv_oberrhein()\n",
-    "net.bus.geo = np.nan\n",
-    "net.line.geo = np.nan\n",
+    "net.bus.geo = None\n",
+    "net.line.geo = None\n",
     "plot.create_generic_coordinates(net, respect_switches=True) #create artificial coordinates with the igraph package"
    ]
   },


### PR DESCRIPTION
In convert_format, an error is raised in case a network is converted with newer format version than the currently installed pandapower version. There is a flag in case a user wants to open a newer network, but this must be actively chosen.

- in the version checks within convert_format, an error is raised if a network with newer format version than the currently installed pandapower version shall be opened
- there is an option to ignore this check and only print out a warning
- removal of the check_net_version function, as this was moved to convert_format and is explicitely used to avoid loading newer network formats than pandapower can handle


**Why is this important?**
It should be more user friendly to not let a user open a network with a format that is not supported by his installed pandapower version. If this error is not identified, some functions of pandapower might fail or produce wrong results unnoticed. The user should explicitly accept this risk instead of just printing a warning, as altering the network data could ultimately end in a network model that pandapower cannot handle anymore at all.