### PR TITLE
[Fix] fixing the mypy error in create_jacobian_facts.py

### DIFF
--- a/pandapower/pf/create_jacobian_facts.py
+++ b/pandapower/pf/create_jacobian_facts.py
@@ -677,7 +677,7 @@ def create_J_modification_hvdc(
     offset = J.shape[0] - num_p
     # Create an initial zero sparse matrix for J_m
     J_m = lil_matrix(J.shape)
-    # Create the modification J for the DC system to be added to the overall J
-    J_m[offset:offset+num_p, offset:offset+num_p] = J_combined # [dc_p, :][:, dc_p]
+    # Create the modification J for the DC system to be added to the overall J[dc_p, :][:, dc_p]
+    J_m[offset:offset+num_p, offset:offset+num_p] = J_combined # type: ignore[index]
 
     return J_m.tocsr()


### PR DESCRIPTION
This seems to be a problem in how mypy understands slicing: The indexer for scipy.sparse.lil_matrix is typed to accept slices with Python ints, but mypy sees your slice bounds as Any. 

Fix is to ignore indexing, at this line.