### PR TITLE
display logger message only if GetActiveScenario() isn't None

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Change Log
 - [FIXED] jao converter: calculation of trafo parameters is based on primary side (hv) now
 - [ADDED] toolbox: :code:`get_all_elements` returns all elements of a pp.pandapowerNet as a DataFrame
 - [ADDED] highlighting feature and hovering functionality to :code:`simple_plot()`
+- [FIXED] pf2pp: :code:`app.GetActiveScenario().loc_name` can be :code:`None`
 
 [3.4.0] - 2026-02-09
 -------------------------------

--- a/pandapower/converter/powerfactory/export_pfd_to_pp.py
+++ b/pandapower/converter/powerfactory/export_pfd_to_pp.py
@@ -112,7 +112,9 @@ def from_pfd(app, prj_name: str, script_name=None, script_settings=None, path_ds
     if sc_name is not None and sc_name in scenario_name_list:
         sc = app.GetProjectFolder('scen').GetContents(sc_name)[0]
         sc.Activate()
-    logger.info(f"Study Case {app.GetActiveScenario().loc_name} is currently active!")
+        logger.info(f"Study Case {app.GetActiveScenario().loc_name} is currently active!")
+    else:
+        logger.info(f"No Study Case is currently active!")
 
     logger.info('gathering network elements')
     dict_net = create_network_dict(app, flag_graphics)


### PR DESCRIPTION
Only display a logger message if `GetActiveScenario` is not None
Added else case with a info message if no study case / scenario is active.