### PR TITLE
Update `lightsim2grid` version

### DIFF
--- a/pandapower/contingency/contingency.py
+++ b/pandapower/contingency/contingency.py
@@ -21,7 +21,7 @@ try:
 
     from lightsim2grid.gridmodel.from_pandapower import init as init_ls2g
     from lightsim2grid.contingencyAnalysis import ContingencyAnalysisCPP
-    from lightsim2grid_cpp import SolverType
+    from lightsim2grid.lightsim2grid_cpp import SolverType
 
     lightsim2grid_installed = True
 except ImportError:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ docs = [
 ]
 plotting = ["plotly~=6.3", "matplotlib~=3.10", "igraph", "geopandas~=1.1"]
 test = ["pytest~=9.0", "nbmake~=1.5", "pytest-timeout", "pytest-split"]
-performance = ["ortools~=9.14", "numba~=0.61", "lightsim2grid~=0.12.2"]
+performance = ["ortools~=9.14", "numba~=0.61", "lightsim2grid~=0.13.0"]
 fileio = ["xlsxwriter~=3.2", "openpyxl~=3.1", "cryptography~=46.0", "geopandas~=1.1", "psycopg~=3.2", "lxml~=6.0"]
 converter = ["matpowercaseframes~=1.1", "lxml~=6.0"]
 pgm = ["power-grid-model-io~=1.2"]


### PR DESCRIPTION
Relates Issue #2861 

`lightsim2grid=0.13.0` has fixed remaining COW issues and is now compatible with `pandas 3.0`.
`lightsim2grid 0.13.0` also has breaking changes where `lightsim2grid_cpp` is not directly accessible, instead it's accessible through `lightsim2grid.lightsim2grid_cpp` https://github.com/Grid2op/lightsim2grid/pull/131.