### PR TITLE
Fix diagnostic implausible impedance report: output implausible values for trafo

### DIFF
--- a/pandapower/diagnostic/diagnostic_functions.py
+++ b/pandapower/diagnostic/diagnostic_functions.py
@@ -1456,7 +1456,7 @@ class ImplausibleImpedanceValues(DiagnosticFunction[pandapowerNet, list[dict]]):
             element_counter += len(value)
             min_r_type = ""
             min_x_type = ""
-            if key in ("line", "line_dc", "xward", "vsc"):
+            if key in ("line", "line_dc", "xward", "vsc", "ward", "trafo", "trafo3w"):
                 min_r_type = self.params["min_r_ohm"]
                 min_x_type = self.params["min_x_ohm"]
             elif key == "impedance":


### PR DESCRIPTION
Right, in diagnostic report, if `trafo` has implausible impedance values, the report prints something like this:

> Checking for impedance values close to zero...
> 
> trafo 1: r_ <=  or x_ <= 

this PR fixes this by correctly including the implausible values for `trafo`, `trafo3w`, `ward`.