### PR TITLE
[Fix] `DiscreteTapControl` to work with negative `tap_step_percent`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Change Log
 
 [upcoming release] - 2026-..-..
 -------------------------------
+- [FIXED] `DiscreteTapControl` to work with `negative tap_step_percent`.
 - [CHANGED] updated the contributing file and documentation
 - [ADDED] `allow_duplicate_index` parameter to `reindex_buses` with default to `false`.
 - [ADDED] `add_basic_std_types` parameter to `from_excel`

--- a/pandapower/control/controller/trafo/DiscreteTapControl.py
+++ b/pandapower/control/controller/trafo/DiscreteTapControl.py
@@ -40,7 +40,7 @@ class DiscreteTapControl(TrafoController):
         self.vm_lower_pu = vm_lower_pu
         self.vm_upper_pu = vm_upper_pu
 
-        self.vm_delta_pu = self.tap_step_percent / 100. * .5 + self.tol
+        self.vm_delta_pu = np.abs(self.tap_step_percent) / 100. * .5 + self.tol
         self.vm_set_pu = kwargs.get("vm_set_pu")
         self.hunting_limit = hunting_limit
         self._hunting_taps = np.array([], dtype=np.float64)
@@ -83,7 +83,7 @@ class DiscreteTapControl(TrafoController):
     def initialize_control(self, net):
         super().initialize_control(net)
         if hasattr(self, 'vm_set_pu') and self.vm_set_pu is not None:
-            self.vm_delta_pu = self.tap_step_percent / 100. * .5 + self.tol
+            self.vm_delta_pu = np.abs(self.tap_step_percent) / 100. * .5 + self.tol
         if hasattr(self.element_index, "__iter__"):
             self._hunting_taps = np.full(shape=len(self.element_index), fill_value=np.nan,
                                          dtype=np.float64)

--- a/pandapower/test/control/test_discrete_tap_control.py
+++ b/pandapower/test/control/test_discrete_tap_control.py
@@ -3,6 +3,7 @@
 # Copyright (c) 2016-2026 by University of Kassel and Fraunhofer Institute for Energy Economics
 # and Energy System Technology (IEE), Kassel. All rights reserved.
 
+import math
 from copy import deepcopy
 import numpy as np
 from pandapower.control import DiscreteTapControl
@@ -145,7 +146,6 @@ def test_discrete_tap_control_hv():
         % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
     assert net.trafo.tap_pos.at[0] == -1
 
-
 def test_discrete_tap_control_lv_from_tap_step_percent():
     # --- load system and run power flow
     net = simple_four_bus_system()
@@ -217,7 +217,8 @@ def test_discrete_tap_control_lv_from_tap_step_percent():
     assert net.trafo.tap_pos.at[0] == 1
 
 
-def test_discrete_tap_control_hv_from_tap_step_percent():
+@pytest.mark.parametrize("tap_step_percent", [1.25, -1.25])
+def test_discrete_tap_control_hv_from_tap_step_percent(tap_step_percent):
     # --- load system and run power flow
     net = simple_four_bus_system()
     set_user_pf_options(net, init='dc', calculate_voltage_angles=True)
@@ -226,8 +227,9 @@ def test_discrete_tap_control_hv_from_tap_step_percent():
     net.trafo.tap_neutral = 0
     net.trafo.tap_min = -2
     net.trafo.tap_max = 2
-    net.trafo.tap_step_percent = 1.25
+    net.trafo.tap_step_percent = tap_step_percent
     net.trafo.tap_pos = 0
+    tap_step_sign = int(math.copysign(1, tap_step_percent))
     # --- run loadflow
     runpp(net)
 
@@ -242,7 +244,7 @@ def test_discrete_tap_control_hv_from_tap_step_percent():
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
         % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
-    assert net.trafo.tap_pos.at[0] ==  1
+    assert net.trafo.tap_pos.at[0] ==  (1 * tap_step_sign)
 
     # check if it changes the lower and upper limits
     net.controller.object.at[0].vm_set_pu = 1
@@ -269,7 +271,7 @@ def test_discrete_tap_control_hv_from_tap_step_percent():
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
         % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
-    assert net.trafo.tap_pos.at[0] == 2
+    assert net.trafo.tap_pos.at[0] == (2 * tap_step_sign)
     # reduce voltage from 1.03 pu to 0.969 pu
     net.ext_grid.vm_pu = 0.969
     # switch back tap position
@@ -285,78 +287,7 @@ def test_discrete_tap_control_hv_from_tap_step_percent():
     logger.info(
         "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
         % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
-    assert net.trafo.tap_pos.at[0] == -1
-
-
-def test_discrete_tap_control_hv_from_tap_step_percent__negative_tap_step():
-    # --- load system and run power flow
-    net = simple_four_bus_system()
-    set_user_pf_options(net, init='dc', calculate_voltage_angles=True)
-    # --- initial tap data
-    net.trafo.tap_side = 'hv'
-    net.trafo.tap_neutral = 0
-    net.trafo.tap_min = -2
-    net.trafo.tap_max = 2
-    net.trafo.tap_step_percent = -1.25
-    net.trafo.tap_pos = 0
-    # --- run loadflow
-    runpp(net)
-
-    DiscreteTapControl.from_tap_step_percent(net, 0, side='lv', vm_set_pu=0.98)
-
-    logger.info("case1: low voltage")
-    logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
-
-    # run control
-    runpp(net, run_control=True)
-    logger.info(
-        "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
-    assert net.trafo.tap_pos.at[0] ==  -1
-
-    # check if it changes the lower and upper limits
-    net.controller.object.at[0].vm_set_pu = 1
-    runpp(net, run_control=True)
-    assert abs(net.controller.object.at[0].vm_upper_pu - 1.00725) < 1e-6
-    assert abs(net.controller.object.at[0].vm_lower_pu - 0.99275) < 1e-6
-    net.controller.object.at[0].vm_set_pu = 0.98
-    runpp(net, run_control=True)
-    assert abs(net.controller.object.at[0].vm_upper_pu - 0.98725) < 1e-6
-    assert abs(net.controller.object.at[0].vm_lower_pu - 0.97275) < 1e-6
-
-    # increase voltage from 1.0 pu to 1.03 pu
-    net.ext_grid.vm_pu = 1.03
-    # switch back tap position
-    net.trafo.at[0, "tap_pos"] = 0
-    runpp(net)
-
-    logger.info("case2: high voltage")
-    logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
-
-    # run control
-    runpp(net, run_control=True)
-    logger.info(
-        "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
-    assert net.trafo.tap_pos.at[0] == -2
-    # reduce voltage from 1.03 pu to 0.969 pu
-    net.ext_grid.vm_pu = 0.969
-    # switch back tap position
-    net.trafo.at[0, "tap_pos"] = 0
-    runpp(net)
-
-    logger.info("case2: high voltage")
-    logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
-                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
-
-    # run control
-    runpp(net, run_control=True)
-    logger.info(
-        "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
-        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
-    assert net.trafo.tap_pos.at[0] == 1
+    assert net.trafo.tap_pos.at[0] == (-1 * tap_step_sign)
 
 
 def test_discrete_tap_control_vectorized_lv():

--- a/pandapower/test/control/test_discrete_tap_control.py
+++ b/pandapower/test/control/test_discrete_tap_control.py
@@ -288,6 +288,77 @@ def test_discrete_tap_control_hv_from_tap_step_percent():
     assert net.trafo.tap_pos.at[0] == -1
 
 
+def test_discrete_tap_control_hv_from_tap_step_percent__negative_tap_step():
+    # --- load system and run power flow
+    net = simple_four_bus_system()
+    set_user_pf_options(net, init='dc', calculate_voltage_angles=True)
+    # --- initial tap data
+    net.trafo.tap_side = 'hv'
+    net.trafo.tap_neutral = 0
+    net.trafo.tap_min = -2
+    net.trafo.tap_max = 2
+    net.trafo.tap_step_percent = -1.25
+    net.trafo.tap_pos = 0
+    # --- run loadflow
+    runpp(net)
+
+    DiscreteTapControl.from_tap_step_percent(net, 0, side='lv', vm_set_pu=0.98)
+
+    logger.info("case1: low voltage")
+    logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
+
+    # run control
+    runpp(net, run_control=True)
+    logger.info(
+        "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
+    assert net.trafo.tap_pos.at[0] ==  -1
+
+    # check if it changes the lower and upper limits
+    net.controller.object.at[0].vm_set_pu = 1
+    runpp(net, run_control=True)
+    assert abs(net.controller.object.at[0].vm_upper_pu - 1.00725) < 1e-6
+    assert abs(net.controller.object.at[0].vm_lower_pu - 0.99275) < 1e-6
+    net.controller.object.at[0].vm_set_pu = 0.98
+    runpp(net, run_control=True)
+    assert abs(net.controller.object.at[0].vm_upper_pu - 0.98725) < 1e-6
+    assert abs(net.controller.object.at[0].vm_lower_pu - 0.97275) < 1e-6
+
+    # increase voltage from 1.0 pu to 1.03 pu
+    net.ext_grid.vm_pu = 1.03
+    # switch back tap position
+    net.trafo.at[0, "tap_pos"] = 0
+    runpp(net)
+
+    logger.info("case2: high voltage")
+    logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
+
+    # run control
+    runpp(net, run_control=True)
+    logger.info(
+        "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
+    assert net.trafo.tap_pos.at[0] == -2
+    # reduce voltage from 1.03 pu to 0.969 pu
+    net.ext_grid.vm_pu = 0.969
+    # switch back tap position
+    net.trafo.at[0, "tap_pos"] = 0
+    runpp(net)
+
+    logger.info("case2: high voltage")
+    logger.info("before control: trafo voltage at low voltage bus is %f, tap position is %u"
+                % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
+
+    # run control
+    runpp(net, run_control=True)
+    logger.info(
+        "after DiscreteTapControl: trafo voltage at low voltage bus is %f, tap position is %f"
+        % (net.res_bus.vm_pu[net.trafo.lv_bus].values.item(), net.trafo.tap_pos.values.item()))
+    assert net.trafo.tap_pos.at[0] == 1
+
+
 def test_discrete_tap_control_vectorized_lv():
     # --- load system and run power flow
     net = create_empty_network()


### PR DESCRIPTION
Fixes Issue #2989 

There are two problems with a negative `tap_step_percent` here,
1. A negative `tap_step_percent` results in a negative `vm_delta_pu`, which then results in `vm_lower_pu` > `vm_upper_pu`
https://github.com/e2nIEE/pandapower/blob/2cd39018f5171903028174f8139936fb9cdd5e0c/pandapower/control/controller/trafo/DiscreteTapControl.py#L80-L81
3. A negative `tap_step_percent` results in a lower `vm_delta_pu` since `tol` is positive, and when added to negative value, results in a lower value of `vm_delta_pu`:
https://github.com/e2nIEE/pandapower/blob/2cd39018f5171903028174f8139936fb9cdd5e0c/pandapower/control/controller/trafo/DiscreteTapControl.py#L43
https://github.com/e2nIEE/pandapower/blob/2cd39018f5171903028174f8139936fb9cdd5e0c/pandapower/control/controller/trafo/DiscreteTapControl.py#L86

Both the above issues make the controller unstable with a negative `tap_step_percent`.