### PR TITLE
#2999 inheriting  min and max_vm_pu from bus in create_gen and create_gens

### DIFF
--- a/pandapower/create/gen_create.py
+++ b/pandapower/create/gen_create.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 from typing import Iterable, Sequence
 
-from numpy import nan, bool_
+from numpy import nan, bool_,isnan
 import numpy.typing as npt
 
 from pandapower.auxiliary import pandapowerNet
@@ -121,7 +121,10 @@ def create_gen(
         >>> create_gen(net, 1, p_mw=120, vm_pu=1.02)
     """
     _check_element(net, bus)
-
+    if isnan(min_vm_pu):
+        min_vm_pu = net.bus.at[bus, "min_vm_pu"]
+    if isnan(max_vm_pu):
+        max_vm_pu = net.bus.at[bus, "max_vm_pu"]
     index = _get_index_with_check(net, "gen", index, name="generator")
 
     entries = {
@@ -277,7 +280,10 @@ def create_gens(
     _check_multiple_elements(net, buses)
 
     index = _get_multiple_index_with_check(net, "gen", index, len(buses))
-
+    if isinstance(min_vm_pu, float) and isnan(min_vm_pu):
+        min_vm_pu = net.bus.loc[buses, "min_vm_pu"].values
+    if isinstance(max_vm_pu, float) and isnan(max_vm_pu):
+        max_vm_pu = net.bus.loc[buses, "max_vm_pu"].values
     entries = {
         "bus": buses,
         "p_mw": p_mw,

--- a/pandapower/create/gen_create.py
+++ b/pandapower/create/gen_create.py
@@ -121,9 +121,9 @@ def create_gen(
         >>> create_gen(net, 1, p_mw=120, vm_pu=1.02)
     """
     _check_element(net, bus)
-    if isnan(min_vm_pu):
+    if isnan(min_vm_pu) and "min_vm_pu" in net.bus.columns:
         min_vm_pu = net.bus.at[bus, "min_vm_pu"]
-    if isnan(max_vm_pu):
+    if isnan(max_vm_pu) and "max_vm_pu" in net.bus.columns:
         max_vm_pu = net.bus.at[bus, "max_vm_pu"]
     index = _get_index_with_check(net, "gen", index, name="generator")
 
@@ -280,9 +280,9 @@ def create_gens(
     _check_multiple_elements(net, buses)
 
     index = _get_multiple_index_with_check(net, "gen", index, len(buses))
-    if isinstance(min_vm_pu, float) and isnan(min_vm_pu):
+    if isinstance(min_vm_pu, float) and isnan(min_vm_pu) and "min_vm_pu" in net.bus.columns:
         min_vm_pu = net.bus.loc[buses, "min_vm_pu"].values
-    if isinstance(max_vm_pu, float) and isnan(max_vm_pu):
+    if isinstance(max_vm_pu, float) and isnan(max_vm_pu) and "max_vm_pu" in net.bus.columns:
         max_vm_pu = net.bus.loc[buses, "max_vm_pu"].values
     entries = {
         "bus": buses,


### PR DESCRIPTION
addresses issue #2999. It adds to create_gen and create_gens to ensure that if voltage magnitude limits (min_vm_pu, max_vm_pu) are not explicitly provided, they are inherited from the connected bus's limits. This ensures nodal constraints are respected by default in grid simulations.

attatched is the image that shows sucessful inheritance for multiple generators across 2 different buses
<img width="1728" height="1529" alt="image" src="https://github.com/user-attachments/assets/737b74f2-8e06-4147-92d9-2cda4efe41bd" />
