### PR TITLE
Fix load polynomial cost signs

### DIFF
--- a/pandapower/opf/make_objective.py
+++ b/pandapower/opf/make_objective.py
@@ -83,7 +83,7 @@ def _fill_gencost_poly(ppci, net, is_quadratic, q_costs):
     c0 = cost["cp0_eur"].values
     c1 = cost["cp1_eur_per_mw"].values
     if is_quadratic:
-        c2 = cost["cp2_eur_per_mw2"].to_numpy()
+        c2 = cost["cp2_eur_per_mw2"]
         ppci["gencost"][gens, NCOST] = 3
         ppci["gencost"][gens, COST] = c2
         ppci["gencost"][gens, COST + 1] = c1 * signs

--- a/pandapower/opf/make_objective.py
+++ b/pandapower/opf/make_objective.py
@@ -83,7 +83,7 @@ def _fill_gencost_poly(ppci, net, is_quadratic, q_costs):
     c0 = cost["cp0_eur"].values
     c1 = cost["cp1_eur_per_mw"].values
     if is_quadratic:
-        c2 = cost["cp2_eur_per_mw2"].values
+        c2 = cost["cp2_eur_per_mw2"].to_numpy()
         ppci["gencost"][gens, NCOST] = 3
         ppci["gencost"][gens, COST] = c2
         ppci["gencost"][gens, COST + 1] = c1 * signs

--- a/pandapower/opf/make_objective.py
+++ b/pandapower/opf/make_objective.py
@@ -82,17 +82,16 @@ def _fill_gencost_poly(ppci, net, is_quadratic, q_costs):
     gens, cost, signs = _map_costs_to_gen(net, net.poly_cost)
     c0 = cost["cp0_eur"].values
     c1 = cost["cp1_eur_per_mw"].values
-    signs = array([-1 if element in ["load", "storage", "dcline"] else 1 for element in cost.et])
     if is_quadratic:
-        c2 = cost["cp2_eur_per_mw2"]
+        c2 = cost["cp2_eur_per_mw2"].values
         ppci["gencost"][gens, NCOST] = 3
-        ppci["gencost"][gens, COST] = c2 * signs
+        ppci["gencost"][gens, COST] = c2
         ppci["gencost"][gens, COST + 1] = c1 * signs
-        ppci["gencost"][gens, COST + 2] = c0 * signs
+        ppci["gencost"][gens, COST + 2] = c0
     else:
         ppci["gencost"][gens, NCOST] = 2
         ppci["gencost"][gens, COST] = c1 * signs
-        ppci["gencost"][gens, COST + 1] = c0 * signs
+        ppci["gencost"][gens, COST + 1] = c0
     if q_costs:
         gens_q = gens + len(ppci["gen"])
         c0 = cost["cq0_eur"].values

--- a/pandapower/test/opf/test_costs_pol.py
+++ b/pandapower/test/opf/test_costs_pol.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2016-2026 by University of Kassel and Fraunhofer Institute for Energy Economics
 # and Energy System Technology (IEE), Kassel. All rights reserved.
 
+from copy import deepcopy
+
 import numpy as np
 import pytest
 
@@ -11,21 +13,12 @@ from pandapower.create import create_empty_network, create_bus, create_gen, crea
 from pandapower.converter.pypower import to_ppc
 from pandapower.pypower.idx_cost import COST, NCOST
 from pandapower.run import runopp
+from pandapower.test.opf.test_basic import simple_opf_test_net
 
 import logging
 
 
-def _create_controllable_load_and_sgen_cost_net():
-    vm_max = 1.05
-    vm_min = 0.95
-
-    net = create_empty_network()
-    create_bus(net, max_vm_pu=vm_max, min_vm_pu=vm_min, vn_kv=10.)
-    create_bus(net, max_vm_pu=vm_max, min_vm_pu=vm_min, vn_kv=.4)
-    create_ext_grid(net, 0, controllable=False)
-    create_line_from_parameters(net, 0, 1, 1, name="line2", r_ohm_per_km=0.1,
-                                c_nf_per_km=0.0, max_i_ka=1.0, x_ohm_per_km=0.1,
-                                max_loading_percent=100)
+def _add_controllable_load_and_sgen_costs(net):
     load = create_load(net, 1, p_mw=0.5, q_mvar=0.1, controllable=True,
                        min_p_mw=0.1, max_p_mw=1.0, min_q_mvar=-0.5, max_q_mvar=0.5)
     sgen = create_sgen(net, 1, p_mw=0.5, q_mvar=0.1, controllable=True,
@@ -34,7 +27,7 @@ def _create_controllable_load_and_sgen_cost_net():
     create_poly_cost(net, load, "load", cp0_eur=3, cp1_eur_per_mw=1, cp2_eur_per_mw2=2)
     create_poly_cost(net, sgen, "sgen", cp0_eur=30, cp1_eur_per_mw=10, cp2_eur_per_mw2=20)
 
-    return net, load, sgen
+    return load, sgen
 
 
 def test_cost_pol_gen():
@@ -110,9 +103,10 @@ def test_cost_pol_all_elements():
     assert np.isclose(net.res_cost, net.res_gen.p_mw.values ** 2 + net.res_sgen.p_mw.values)
 
 
-def test_controllable_load_polynomial_cost_signs():
+def test_controllable_load_polynomial_cost_signs(simple_opf_test_net):
     """Controllable loads use the opposite active-power sign in PYPOWER."""
-    net, load, sgen = _create_controllable_load_and_sgen_cost_net()
+    net = deepcopy(simple_opf_test_net)
+    load, sgen = _add_controllable_load_and_sgen_costs(net)
     ppci = to_ppc(net, mode="opf", init="flat", calculate_voltage_angles=False)
     load_gen = net._pd2ppc_lookups["load_controllable"][load]
     sgen_gen = net._pd2ppc_lookups["sgen_controllable"][sgen]
@@ -129,6 +123,28 @@ def test_controllable_load_polynomial_cost_signs():
     assert ppci["gencost"][sgen_gen, NCOST] == 2
     assert np.allclose(ppci["gencost"][load_gen, COST:COST + 2], [-1, 3])
     assert np.allclose(ppci["gencost"][sgen_gen, COST:COST + 2], [10, 30])
+
+
+def test_controllable_load_reactive_polynomial_cost_signs(simple_opf_test_net):
+    """Reactive cost rows keep the existing PYPOWER q-cost sign convention."""
+    net = deepcopy(simple_opf_test_net)
+    load, sgen = _add_controllable_load_and_sgen_costs(net)
+
+    load_cost = (net.poly_cost.et == "load") & (net.poly_cost.element == load)
+    sgen_cost = (net.poly_cost.et == "sgen") & (net.poly_cost.element == sgen)
+    net.poly_cost.loc[load_cost, ["cq0_eur", "cq1_eur_per_mvar", "cq2_eur_per_mvar2"]] = [5, 4, 6]
+    net.poly_cost.loc[sgen_cost, ["cq0_eur", "cq1_eur_per_mvar", "cq2_eur_per_mvar2"]] = [50, 40, 60]
+
+    ppci = to_ppc(net, mode="opf", init="flat", calculate_voltage_angles=False)
+    load_gen = net._pd2ppc_lookups["load_controllable"][load]
+    sgen_gen = net._pd2ppc_lookups["sgen_controllable"][sgen]
+    load_q_gen = load_gen + len(ppci["gen"])
+    sgen_q_gen = sgen_gen + len(ppci["gen"])
+
+    assert ppci["gencost"][load_q_gen, NCOST] == 3
+    assert ppci["gencost"][sgen_q_gen, NCOST] == 3
+    assert np.allclose(ppci["gencost"][load_q_gen, COST:COST + 3], [-6, -4, -5])
+    assert np.allclose(ppci["gencost"][sgen_q_gen, COST:COST + 3], [60, 40, 50])
 
 
 def test_cost_pol_q():

--- a/pandapower/test/opf/test_costs_pol.py
+++ b/pandapower/test/opf/test_costs_pol.py
@@ -8,6 +8,8 @@ import pytest
 
 from pandapower.create import create_empty_network, create_bus, create_gen, create_ext_grid, create_load, \
     create_line_from_parameters, create_poly_cost, create_sgen
+from pandapower.converter.pypower import to_ppc
+from pandapower.pypower.idx_cost import COST, NCOST
 from pandapower.run import runopp
 
 import logging
@@ -84,6 +86,44 @@ def test_cost_pol_all_elements():
 
     assert net["OPF_converged"]
     assert np.isclose(net.res_cost, net.res_gen.p_mw.values ** 2 + net.res_sgen.p_mw.values)
+
+
+def test_controllable_load_polynomial_cost_signs():
+    """Controllable loads use the opposite active-power sign in PYPOWER."""
+    vm_max = 1.05
+    vm_min = 0.95
+
+    net = create_empty_network()
+    create_bus(net, max_vm_pu=vm_max, min_vm_pu=vm_min, vn_kv=10.)
+    create_bus(net, max_vm_pu=vm_max, min_vm_pu=vm_min, vn_kv=.4)
+    create_ext_grid(net, 0, controllable=False)
+    create_line_from_parameters(net, 0, 1, 1, name="line2", r_ohm_per_km=0.1,
+                                c_nf_per_km=0.0, max_i_ka=1.0, x_ohm_per_km=0.1,
+                                max_loading_percent=100)
+    load = create_load(net, 1, p_mw=0.5, q_mvar=0.1, controllable=True,
+                       min_p_mw=0.1, max_p_mw=1.0, min_q_mvar=-0.5, max_q_mvar=0.5)
+    sgen = create_sgen(net, 1, p_mw=0.5, q_mvar=0.1, controllable=True,
+                       min_p_mw=0.1, max_p_mw=1.0, min_q_mvar=-0.5, max_q_mvar=0.5)
+
+    create_poly_cost(net, load, "load", cp0_eur=3, cp1_eur_per_mw=1, cp2_eur_per_mw2=2)
+    create_poly_cost(net, sgen, "sgen", cp0_eur=30, cp1_eur_per_mw=10, cp2_eur_per_mw2=20)
+
+    ppci = to_ppc(net, mode="opf", init="flat", calculate_voltage_angles=False)
+    load_gen = net._pd2ppc_lookups["load_controllable"][load]
+    sgen_gen = net._pd2ppc_lookups["sgen_controllable"][sgen]
+
+    assert ppci["gencost"][load_gen, NCOST] == 3
+    assert ppci["gencost"][sgen_gen, NCOST] == 3
+    assert np.allclose(ppci["gencost"][load_gen, COST:COST + 3], [2, -1, 3])
+    assert np.allclose(ppci["gencost"][sgen_gen, COST:COST + 3], [20, 10, 30])
+
+    net.poly_cost.loc[:, "cp2_eur_per_mw2"] = 0
+    ppci = to_ppc(net, mode="opf", init="flat", calculate_voltage_angles=False)
+
+    assert ppci["gencost"][load_gen, NCOST] == 2
+    assert ppci["gencost"][sgen_gen, NCOST] == 2
+    assert np.allclose(ppci["gencost"][load_gen, COST:COST + 2], [-1, 3])
+    assert np.allclose(ppci["gencost"][sgen_gen, COST:COST + 2], [10, 30])
 
 
 def test_cost_pol_q():

--- a/pandapower/test/opf/test_costs_pol.py
+++ b/pandapower/test/opf/test_costs_pol.py
@@ -15,6 +15,28 @@ from pandapower.run import runopp
 import logging
 
 
+def _create_controllable_load_and_sgen_cost_net():
+    vm_max = 1.05
+    vm_min = 0.95
+
+    net = create_empty_network()
+    create_bus(net, max_vm_pu=vm_max, min_vm_pu=vm_min, vn_kv=10.)
+    create_bus(net, max_vm_pu=vm_max, min_vm_pu=vm_min, vn_kv=.4)
+    create_ext_grid(net, 0, controllable=False)
+    create_line_from_parameters(net, 0, 1, 1, name="line2", r_ohm_per_km=0.1,
+                                c_nf_per_km=0.0, max_i_ka=1.0, x_ohm_per_km=0.1,
+                                max_loading_percent=100)
+    load = create_load(net, 1, p_mw=0.5, q_mvar=0.1, controllable=True,
+                       min_p_mw=0.1, max_p_mw=1.0, min_q_mvar=-0.5, max_q_mvar=0.5)
+    sgen = create_sgen(net, 1, p_mw=0.5, q_mvar=0.1, controllable=True,
+                       min_p_mw=0.1, max_p_mw=1.0, min_q_mvar=-0.5, max_q_mvar=0.5)
+
+    create_poly_cost(net, load, "load", cp0_eur=3, cp1_eur_per_mw=1, cp2_eur_per_mw2=2)
+    create_poly_cost(net, sgen, "sgen", cp0_eur=30, cp1_eur_per_mw=10, cp2_eur_per_mw2=20)
+
+    return net, load, sgen
+
+
 def test_cost_pol_gen():
     """ Testing a very simple network for the resulting cost value
     constraints with OPF """
@@ -90,24 +112,7 @@ def test_cost_pol_all_elements():
 
 def test_controllable_load_polynomial_cost_signs():
     """Controllable loads use the opposite active-power sign in PYPOWER."""
-    vm_max = 1.05
-    vm_min = 0.95
-
-    net = create_empty_network()
-    create_bus(net, max_vm_pu=vm_max, min_vm_pu=vm_min, vn_kv=10.)
-    create_bus(net, max_vm_pu=vm_max, min_vm_pu=vm_min, vn_kv=.4)
-    create_ext_grid(net, 0, controllable=False)
-    create_line_from_parameters(net, 0, 1, 1, name="line2", r_ohm_per_km=0.1,
-                                c_nf_per_km=0.0, max_i_ka=1.0, x_ohm_per_km=0.1,
-                                max_loading_percent=100)
-    load = create_load(net, 1, p_mw=0.5, q_mvar=0.1, controllable=True,
-                       min_p_mw=0.1, max_p_mw=1.0, min_q_mvar=-0.5, max_q_mvar=0.5)
-    sgen = create_sgen(net, 1, p_mw=0.5, q_mvar=0.1, controllable=True,
-                       min_p_mw=0.1, max_p_mw=1.0, min_q_mvar=-0.5, max_q_mvar=0.5)
-
-    create_poly_cost(net, load, "load", cp0_eur=3, cp1_eur_per_mw=1, cp2_eur_per_mw2=2)
-    create_poly_cost(net, sgen, "sgen", cp0_eur=30, cp1_eur_per_mw=10, cp2_eur_per_mw2=20)
-
+    net, load, sgen = _create_controllable_load_and_sgen_cost_net()
     ppci = to_ppc(net, mode="opf", init="flat", calculate_voltage_angles=False)
     load_gen = net._pd2ppc_lookups["load_controllable"][load]
     sgen_gen = net._pd2ppc_lookups["sgen_controllable"][sgen]

--- a/pandapower/test/opf/test_pandamodels_converter.py
+++ b/pandapower/test/opf/test_pandamodels_converter.py
@@ -17,7 +17,7 @@ from pandapower.create import create_poly_cost
 from pandapower.pd2ppc import _pd2ppc
 from pandapower.run import runopp
 from pandapower.test.opf.test_basic import simple_opf_test_net, net_3w_trafo_opf
-from pandapower.test.opf.test_costs_pol import _create_controllable_load_and_sgen_cost_net
+from pandapower.test.opf.test_costs_pol import _add_controllable_load_and_sgen_costs
 
 try:
     from juliacall import JuliaError as UnsupportedPythonError # type: ignore
@@ -73,8 +73,9 @@ def test_obj_factors(net_3w_trafo_opf):
     assert pm["user_defined_params"]["gen_and_controllable_sgen"]["3"] == 3
 
 
-def test_controllable_load_polynomial_cost_signs_for_powermodels():
-    net, load, sgen = _create_controllable_load_and_sgen_cost_net()
+def test_controllable_load_polynomial_cost_signs_for_powermodels(simple_opf_test_net):
+    net = deepcopy(simple_opf_test_net)
+    load, sgen = _add_controllable_load_and_sgen_costs(net)
     pm = convert_pp_to_pm(net)
     load_gen = net._pd2ppc_lookups["load_controllable"][load] + 1
     sgen_gen = net._pd2ppc_lookups["sgen_controllable"][sgen] + 1

--- a/pandapower/test/opf/test_pandamodels_converter.py
+++ b/pandapower/test/opf/test_pandamodels_converter.py
@@ -13,7 +13,8 @@ import pytest
 import pandapower.test as test
 from pandapower.converter.pandamodels import convert_pp_to_pm
 from pandapower.converter.pandamodels.from_pm import read_pm_results_to_net
-from pandapower.create import create_poly_cost
+from pandapower.create import create_empty_network, create_bus, create_ext_grid, create_line_from_parameters, \
+    create_load, create_poly_cost, create_sgen
 from pandapower.pd2ppc import _pd2ppc
 from pandapower.run import runopp
 from pandapower.test.opf.test_basic import simple_opf_test_net, net_3w_trafo_opf
@@ -70,6 +71,30 @@ def test_obj_factors(net_3w_trafo_opf):
     assert pm["user_defined_params"]["obj_factors"]["fac_2"] == 0.1
     assert pm["user_defined_params"]["gen_and_controllable_sgen"]["2"] == 2
     assert pm["user_defined_params"]["gen_and_controllable_sgen"]["3"] == 3
+
+
+def test_controllable_load_polynomial_cost_signs_for_powermodels():
+    net = create_empty_network()
+    create_bus(net, max_vm_pu=1.05, min_vm_pu=0.95, vn_kv=10.)
+    create_bus(net, max_vm_pu=1.05, min_vm_pu=0.95, vn_kv=.4)
+    create_ext_grid(net, 0, controllable=False)
+    create_line_from_parameters(net, 0, 1, 1, name="line2", r_ohm_per_km=0.1,
+                                c_nf_per_km=0.0, max_i_ka=1.0, x_ohm_per_km=0.1,
+                                max_loading_percent=100)
+    load = create_load(net, 1, p_mw=0.5, q_mvar=0.1, controllable=True,
+                       min_p_mw=0.1, max_p_mw=1.0, min_q_mvar=-0.5, max_q_mvar=0.5)
+    sgen = create_sgen(net, 1, p_mw=0.5, q_mvar=0.1, controllable=True,
+                       min_p_mw=0.1, max_p_mw=1.0, min_q_mvar=-0.5, max_q_mvar=0.5)
+
+    create_poly_cost(net, load, "load", cp0_eur=3, cp1_eur_per_mw=1, cp2_eur_per_mw2=2)
+    create_poly_cost(net, sgen, "sgen", cp0_eur=30, cp1_eur_per_mw=10, cp2_eur_per_mw2=20)
+
+    pm = convert_pp_to_pm(net)
+    load_gen = net._pd2ppc_lookups["load_controllable"][load] + 1
+    sgen_gen = net._pd2ppc_lookups["sgen_controllable"][sgen] + 1
+
+    assert pm["gen"][str(load_gen)]["cost"] == [2, -1, 3]
+    assert pm["gen"][str(sgen_gen)]["cost"] == [20, 10, 30]
 
 
 if __name__ == '__main__':

--- a/pandapower/test/opf/test_pandamodels_converter.py
+++ b/pandapower/test/opf/test_pandamodels_converter.py
@@ -13,11 +13,11 @@ import pytest
 import pandapower.test as test
 from pandapower.converter.pandamodels import convert_pp_to_pm
 from pandapower.converter.pandamodels.from_pm import read_pm_results_to_net
-from pandapower.create import create_empty_network, create_bus, create_ext_grid, create_line_from_parameters, \
-    create_load, create_poly_cost, create_sgen
+from pandapower.create import create_poly_cost
 from pandapower.pd2ppc import _pd2ppc
 from pandapower.run import runopp
 from pandapower.test.opf.test_basic import simple_opf_test_net, net_3w_trafo_opf
+from pandapower.test.opf.test_costs_pol import _create_controllable_load_and_sgen_cost_net
 
 try:
     from juliacall import JuliaError as UnsupportedPythonError # type: ignore
@@ -74,21 +74,7 @@ def test_obj_factors(net_3w_trafo_opf):
 
 
 def test_controllable_load_polynomial_cost_signs_for_powermodels():
-    net = create_empty_network()
-    create_bus(net, max_vm_pu=1.05, min_vm_pu=0.95, vn_kv=10.)
-    create_bus(net, max_vm_pu=1.05, min_vm_pu=0.95, vn_kv=.4)
-    create_ext_grid(net, 0, controllable=False)
-    create_line_from_parameters(net, 0, 1, 1, name="line2", r_ohm_per_km=0.1,
-                                c_nf_per_km=0.0, max_i_ka=1.0, x_ohm_per_km=0.1,
-                                max_loading_percent=100)
-    load = create_load(net, 1, p_mw=0.5, q_mvar=0.1, controllable=True,
-                       min_p_mw=0.1, max_p_mw=1.0, min_q_mvar=-0.5, max_q_mvar=0.5)
-    sgen = create_sgen(net, 1, p_mw=0.5, q_mvar=0.1, controllable=True,
-                       min_p_mw=0.1, max_p_mw=1.0, min_q_mvar=-0.5, max_q_mvar=0.5)
-
-    create_poly_cost(net, load, "load", cp0_eur=3, cp1_eur_per_mw=1, cp2_eur_per_mw2=2)
-    create_poly_cost(net, sgen, "sgen", cp0_eur=30, cp1_eur_per_mw=10, cp2_eur_per_mw2=20)
-
+    net, load, sgen = _create_controllable_load_and_sgen_cost_net()
     pm = convert_pp_to_pm(net)
     load_gen = net._pd2ppc_lookups["load_controllable"][load] + 1
     sgen_gen = net._pd2ppc_lookups["sgen_controllable"][sgen] + 1


### PR DESCRIPTION
## Summary

This fixes the polynomial active-power cost conversion for controllable loads and other elements that are represented with the opposite active-power sign in PYPOWER.

For a controllable load, pandapower cost coefficients describe the load-side power `P`, while PYPOWER represents it with `-P`. The transformed polynomial should therefore be:

`a * (-P)^2 + b * (-P) + c = a * P^2 - b * P + c`

So only the linear active-power coefficient changes sign. The quadratic and constant terms should keep their original signs.

## Changes

- Keep `cp2_eur_per_mw2` unchanged when filling `gencost`.
- Keep `cp0_eur` unchanged for both quadratic and linear polynomial costs.
- Continue applying the existing sign conversion to `cp1_eur_per_mw`.
- Add a regression test for controllable load polynomial costs, including both quadratic and linear `gencost` layouts.
- Constrain `scipy-stubs` below `1.18` for the typing extra, because the current `1.18` stubs use Python 3.12 `type` statement syntax while `mypy.ini` intentionally checks with `python_version = 3.10`.

Fixes #2954.

## Validation

- `python -m pytest pandapower/test/opf/test_costs_pol.py -q`
- `python -m pytest pandapower/test/opf/test_costs_mixed.py pandapower/test/opf/test_basic.py::test_storage_opf pandapower/test/opf/test_dcline.py -q`
- `python -m mypy`
- `git diff --check`

Remote checks after the second push:

- Passed: Codacy, SonarCloud, all Python 3.10-3.14 build splits, numpy1-support, OPF, docs, linting, postgresql, relying jobs, coverage, typing, and tutorial jobs including `tutorial_warnings_tests`.
- Known baseline failure: the `warnings (3.14, *)` jobs fail with the same `pandapower/test/plotting/test_geo.py` / `tap_dependency_table` `DeprecationWarning` that is present on the current `develop` workflow run. I verified this against `develop` run `27626832854`, job `81693439589`.
