### PR TITLE
Fix diagnostic report crashes for overloaded networks

### DIFF
--- a/pandapower/diagnostic/diagnostic_functions.py
+++ b/pandapower/diagnostic/diagnostic_functions.py
@@ -510,35 +510,6 @@ class DisableVoltageDependentLoads(DiagnosticFunction[pandapowerNet, bool]):
 
         return check_result
 
-    # def report(self, error: Exception | None, results: bool | None) -> None:
-    #     # error and success checks
-    #     if error is not None:
-    #         self.out.warning("Check for convergence error failed due to the following error:")
-    #         self.out.warning(error)
-    #         return
-    #     if results is None:
-    #         self.out.info("PASSED: Power flow converges. No line capacitance problems found.")
-    #         return
-
-    #     # message header
-    #     self.out.compact("line problems:\n")
-    #     self.out.detailed("Checking for too high line capacitance...\n")
-
-    #     # message body
-    #     if self.capacitance_scaling_factor is not None:
-    #         capacitance_scaling_factor = self.capacitance_scaling_factor
-    #     else:
-    #         raise RuntimeError('diagnostic was not executed before calling results?')
-
-    #     osf_percent = f"{capacitance_scaling_factor * 100} percent."
-
-    #     if results:
-    #         self.out.warning(
-    #             f"Too high capacitance found: Power flow converges with line.c_nf_per_km scaled down to {osf_percent}")
-    #     else:
-    #         self.out.warning(
-    #             f"Too high capacitance tested: Power flow did not converge with line.c_nf_per_km scaled down to {osf_percent}")
-
 
     def report(self, error: Exception | None, results: bool | None) -> None:
         # error and success checks
@@ -694,35 +665,6 @@ class WrongLineReactance(DiagnosticFunction[pandapowerNet, bool]):
 
         return check_result
 
-    # def report(self, error: Exception | None, results: bool | None) -> None:
-    #     # error and success checks
-    #     if error is not None:
-    #         self.out.warning("Check for convergence error failed due to the following error:")
-    #         self.out.warning(error)
-    #         return
-    #     if results is None:
-    #         self.out.info("PASSED: Power flow converges. No line capacitance problems found.")
-    #         return
-
-    #     # message header
-    #     self.out.compact("line problems:\n")
-    #     self.out.detailed("Checking for too high line capacitance...\n")
-
-    #     # message body
-    #     if self.capacitance_scaling_factor is not None:
-    #         capacitance_scaling_factor = self.capacitance_scaling_factor
-    #     else:
-    #         raise RuntimeError('diagnostic was not executed before calling results?')
-
-    #     osf_percent = f"{capacitance_scaling_factor * 100} percent."
-
-    #     if results:
-    #         self.out.warning(
-    #             f"Too high capacitance found: Power flow converges with line.c_nf_per_km scaled down to {osf_percent}")
-    #     else:
-    #         self.out.warning(
-    #             f"Too high capacitance tested: Power flow did not converge with line.c_nf_per_km scaled down to {osf_percent}")
-
     def report(self, error: Exception | None, results: bool | None) -> None:
         # error and success checks
         if error is not None:
@@ -805,35 +747,6 @@ class WrongLineResistance(DiagnosticFunction[pandapowerNet, bool]):
         net.line.r_ohm_per_km = line_resistance
 
         return check_result
-
-    # def report(self, error: Exception | None, results: bool | None) -> None:
-    #     # error and success checks
-    #     if error is not None:
-    #         self.out.warning("Check for convergence error failed due to the following error:")
-    #         self.out.warning(error)
-    #         return
-    #     if results is None:
-    #         self.out.info("PASSED: Power flow converges. No line capacitance problems found.")
-    #         return
-
-    #     # message header
-    #     self.out.compact("line problems:\n")
-    #     self.out.detailed("Checking for too high line capacitance...\n")
-
-    #     # message body
-    #     if self.capacitance_scaling_factor is not None:
-    #         capacitance_scaling_factor = self.capacitance_scaling_factor
-    #     else:
-    #         raise RuntimeError('diagnostic was not executed before calling results?')
-
-    #     osf_percent = f"{capacitance_scaling_factor * 100} percent."
-
-    #     if results:
-    #         self.out.warning(
-    #             f"Too high capacitance found: Power flow converges with line.c_nf_per_km scaled down to {osf_percent}")
-    #     else:
-    #         self.out.warning(
-    #             f"Too high capacitance tested: Power flow did not converge with line.c_nf_per_km scaled down to {osf_percent}")
 
 
     def report(self, error: Exception | None, results: bool | None) -> None:

--- a/pandapower/diagnostic/diagnostic_functions.py
+++ b/pandapower/diagnostic/diagnostic_functions.py
@@ -520,34 +520,64 @@ class DisableVoltageDependentLoads(DiagnosticFunction[pandapowerNet, bool]):
 
         return check_result
 
+    # def report(self, error: Exception | None, results: bool | None) -> None:
+    #     # error and success checks
+    #     if error is not None:
+    #         self.out.warning("Check for convergence error failed due to the following error:")
+    #         self.out.warning(error)
+    #         return
+    #     if results is None:
+    #         self.out.info("PASSED: Power flow converges. No line capacitance problems found.")
+    #         return
+
+    #     # message header
+    #     self.out.compact("line problems:\n")
+    #     self.out.detailed("Checking for too high line capacitance...\n")
+
+    #     # message body
+    #     if self.capacitance_scaling_factor is not None:
+    #         capacitance_scaling_factor = self.capacitance_scaling_factor
+    #     else:
+    #         raise RuntimeError('diagnostic was not executed before calling results?')
+
+    #     osf_percent = f"{capacitance_scaling_factor * 100} percent."
+
+    #     if results:
+    #         self.out.warning(
+    #             f"Too high capacitance found: Power flow converges with line.c_nf_per_km scaled down to {osf_percent}")
+    #     else:
+    #         self.out.warning(
+    #             f"Too high capacitance tested: Power flow did not converge with line.c_nf_per_km scaled down to {osf_percent}")
+
+
     def report(self, error: Exception | None, results: bool | None) -> None:
         # error and success checks
         if error is not None:
-            self.out.warning("Check for convergence error failed due to the following error:")
+            self.out.warning("Check for voltage dependent loads failed due to the following error:")
             self.out.warning(error)
             return
+
         if results is None:
-            self.out.info("PASSED: Power flow converges. No line capacitance problems found.")
+            self.out.info("PASSED: Power flow converges. No voltage dependent load problem found.")
             return
 
         # message header
-        self.out.compact("line problems:\n")
-        self.out.detailed("Checking for too high line capacitance...\n")
+        self.out.compact("voltage dependent loads:\n")
+        self.out.detailed("Checking power flow with voltage_depend_loads=False...\n")
 
         # message body
-        if self.capacitance_scaling_factor is not None:
-            capacitance_scaling_factor = self.capacitance_scaling_factor
-        else:
-            raise RuntimeError('diagnostic was not executed before calling results?')
-
-        osf_percent = f"{capacitance_scaling_factor * 100} percent."
-
         if results:
             self.out.warning(
-                f"Too high capacitance found: Power flow converges with line.c_nf_per_km scaled down to {osf_percent}")
+                "Power flow converges when voltage dependent loads are disabled "
+                "with voltage_depend_loads=False."
+            )
         else:
             self.out.warning(
-                f"Too high capacitance tested: Power flow did not converge with line.c_nf_per_km scaled down to {osf_percent}")
+                "Power flow still does not converge when voltage dependent loads are disabled "
+                "with voltage_depend_loads=False."
+            )
+
+
 
 
 class WrongLineCapacitance(DiagnosticFunction[pandapowerNet, bool]):
@@ -674,34 +704,69 @@ class WrongLineReactance(DiagnosticFunction[pandapowerNet, bool]):
 
         return check_result
 
+    # def report(self, error: Exception | None, results: bool | None) -> None:
+    #     # error and success checks
+    #     if error is not None:
+    #         self.out.warning("Check for convergence error failed due to the following error:")
+    #         self.out.warning(error)
+    #         return
+    #     if results is None:
+    #         self.out.info("PASSED: Power flow converges. No line capacitance problems found.")
+    #         return
+
+    #     # message header
+    #     self.out.compact("line problems:\n")
+    #     self.out.detailed("Checking for too high line capacitance...\n")
+
+    #     # message body
+    #     if self.capacitance_scaling_factor is not None:
+    #         capacitance_scaling_factor = self.capacitance_scaling_factor
+    #     else:
+    #         raise RuntimeError('diagnostic was not executed before calling results?')
+
+    #     osf_percent = f"{capacitance_scaling_factor * 100} percent."
+
+    #     if results:
+    #         self.out.warning(
+    #             f"Too high capacitance found: Power flow converges with line.c_nf_per_km scaled down to {osf_percent}")
+    #     else:
+    #         self.out.warning(
+    #             f"Too high capacitance tested: Power flow did not converge with line.c_nf_per_km scaled down to {osf_percent}")
+
     def report(self, error: Exception | None, results: bool | None) -> None:
         # error and success checks
         if error is not None:
             self.out.warning("Check for convergence error failed due to the following error:")
             self.out.warning(error)
             return
+
         if results is None:
-            self.out.info("PASSED: Power flow converges. No line capacitance problems found.")
+            self.out.info("PASSED: Power flow converges. No line reactance problems found.")
             return
 
         # message header
         self.out.compact("line problems:\n")
-        self.out.detailed("Checking for too high line capacitance...\n")
+        self.out.detailed("Checking for too high line reactance...\n")
 
         # message body
-        if self.capacitance_scaling_factor is not None:
-            capacitance_scaling_factor = self.capacitance_scaling_factor
+        if self.reactance_scaling_factor is not None:
+            reactance_scaling_factor = self.reactance_scaling_factor
         else:
-            raise RuntimeError('diagnostic was not executed before calling results?')
+            raise RuntimeError("diagnostic was not executed before calling results?")
 
-        osf_percent = f"{capacitance_scaling_factor * 100} percent."
+        osf_percent = f"{reactance_scaling_factor * 100} percent."
 
         if results:
             self.out.warning(
-                f"Too high capacitance found: Power flow converges with line.c_nf_per_km scaled down to {osf_percent}")
+                f"Too high reactance found: Power flow converges with "
+                f"line.x_ohm_per_km scaled down to {osf_percent}"
+            )
         else:
             self.out.warning(
-                f"Too high capacitance tested: Power flow did not converge with line.c_nf_per_km scaled down to {osf_percent}")
+                f"Too high reactance tested: Power flow did not converge with "
+                f"line.x_ohm_per_km scaled down to {osf_percent}"
+            )
+
 
 
 class WrongLineResistance(DiagnosticFunction[pandapowerNet, bool]):
@@ -751,35 +816,69 @@ class WrongLineResistance(DiagnosticFunction[pandapowerNet, bool]):
 
         return check_result
 
+    # def report(self, error: Exception | None, results: bool | None) -> None:
+    #     # error and success checks
+    #     if error is not None:
+    #         self.out.warning("Check for convergence error failed due to the following error:")
+    #         self.out.warning(error)
+    #         return
+    #     if results is None:
+    #         self.out.info("PASSED: Power flow converges. No line capacitance problems found.")
+    #         return
+
+    #     # message header
+    #     self.out.compact("line problems:\n")
+    #     self.out.detailed("Checking for too high line capacitance...\n")
+
+    #     # message body
+    #     if self.capacitance_scaling_factor is not None:
+    #         capacitance_scaling_factor = self.capacitance_scaling_factor
+    #     else:
+    #         raise RuntimeError('diagnostic was not executed before calling results?')
+
+    #     osf_percent = f"{capacitance_scaling_factor * 100} percent."
+
+    #     if results:
+    #         self.out.warning(
+    #             f"Too high capacitance found: Power flow converges with line.c_nf_per_km scaled down to {osf_percent}")
+    #     else:
+    #         self.out.warning(
+    #             f"Too high capacitance tested: Power flow did not converge with line.c_nf_per_km scaled down to {osf_percent}")
+
+
     def report(self, error: Exception | None, results: bool | None) -> None:
         # error and success checks
         if error is not None:
             self.out.warning("Check for convergence error failed due to the following error:")
             self.out.warning(error)
             return
+
         if results is None:
-            self.out.info("PASSED: Power flow converges. No line capacitance problems found.")
+            self.out.info("PASSED: Power flow converges. No line resistance problems found.")
             return
 
         # message header
         self.out.compact("line problems:\n")
-        self.out.detailed("Checking for too high line capacitance...\n")
+        self.out.detailed("Checking for too high line resistance...\n")
 
         # message body
-        if self.capacitance_scaling_factor is not None:
-            capacitance_scaling_factor = self.capacitance_scaling_factor
+        if self.resistance_scaling_factor is not None:
+            resistance_scaling_factor = self.resistance_scaling_factor
         else:
-            raise RuntimeError('diagnostic was not executed before calling results?')
+            raise RuntimeError("diagnostic was not executed before calling results?")
 
-        osf_percent = f"{capacitance_scaling_factor * 100} percent."
+        osf_percent = f"{resistance_scaling_factor * 100} percent."
 
         if results:
             self.out.warning(
-                f"Too high capacitance found: Power flow converges with line.c_nf_per_km scaled down to {osf_percent}")
+                f"Too high resistance found: Power flow converges with "
+                f"line.r_ohm_per_km scaled down to {osf_percent}"
+            )
         else:
             self.out.warning(
-                f"Too high capacitance tested: Power flow did not converge with line.c_nf_per_km scaled down to {osf_percent}")
-
+                f"Too high resistance tested: Power flow did not converge with "
+                f"line.r_ohm_per_km scaled down to {osf_percent}"
+            )
 
 class SubNetProblemTest(DiagnosticFunction[pandapowerNet, dict[str, bool]]):
     """

--- a/pandapower/diagnostic/diagnostic_functions.py
+++ b/pandapower/diagnostic/diagnostic_functions.py
@@ -684,7 +684,7 @@ class WrongLineReactance(DiagnosticFunction[pandapowerNet, bool]):
         if self.reactance_scaling_factor is not None:
             reactance_scaling_factor = self.reactance_scaling_factor
         else:
-            raise RuntimeError("diagnostic was not executed before calling results?")
+            raise RuntimeError('diagnostic was not executed before calling results?')
 
         osf_percent = f"{reactance_scaling_factor * 100} percent."
 
@@ -768,7 +768,7 @@ class WrongLineResistance(DiagnosticFunction[pandapowerNet, bool]):
         if self.resistance_scaling_factor is not None:
             resistance_scaling_factor = self.resistance_scaling_factor
         else:
-            raise RuntimeError("diagnostic was not executed before calling results?")
+            raise RuntimeError('diagnostic was not executed before calling results?')
 
         osf_percent = f"{resistance_scaling_factor * 100} percent."
 

--- a/pandapower/test/api/test_diagnostic.py
+++ b/pandapower/test/api/test_diagnostic.py
@@ -43,6 +43,7 @@ from pandapower.diagnostic.diagnostic_functions import (
     WrongLineReactance,
     WrongLineResistance,
 )
+from pandapower.diagnostic.diagnostic_functions import DisableVoltageDependentLoads
 
 try:
     import numba
@@ -874,6 +875,13 @@ def test_diagnostic_report_does_not_raise_for_overloaded_example_simple():
 
     Diagnostic().diagnose_network(net, report_style="detailed")
 
+def test_disable_voltage_dependent_loads_report_branches():
+    check = DisableVoltageDependentLoads()
+
+    check.report(RuntimeError("test error"), None)
+    check.report(None, None)
+    check.report(None, True)
+    check.report(None, False)
 
 if __name__ == "__main__":
     pytest.main([__file__, "-xs"])

--- a/pandapower/test/api/test_diagnostic.py
+++ b/pandapower/test/api/test_diagnostic.py
@@ -38,6 +38,11 @@ from pandapower.diagnostic.diagnostic_functions import (
     SubNetProblemTest,
     OptimisticPowerflow
 )
+from pandapower.diagnostic.diagnostic_functions import (
+    DisableVoltageDependentLoads,
+    WrongLineReactance,
+    WrongLineResistance,
+)
 
 try:
     import numba
@@ -846,11 +851,22 @@ def test_runpp_errors(test_net, diag_params, diag_errors):
     Diagnostic().diagnose_network(net, report_style=None)
 
 
-# def test_wrong_line_impedance_reports_do_not_raise():
-#     net = example_simple()
-#     net.load.at[0, "p_mw"] = 1000
+def test_disable_voltage_dependent_loads_report_result_true():
+    check = DisableVoltageDependentLoads()
+    check.report(None, True)
 
-#     Diagnostic().diagnose_network(net, report_style="detailed")
+
+def test_wrong_line_reactance_report_result_true():
+    check = WrongLineReactance()
+    check.reactance_scaling_factor = 0.01
+    check.report(None, True)
+
+
+def test_wrong_line_resistance_report_result_true():
+    check = WrongLineResistance()
+    check.resistance_scaling_factor = 0.01
+    check.report(None, True)
+
 
 def test_diagnostic_report_does_not_raise_for_overloaded_example_simple():
     net = example_simple()

--- a/pandapower/test/api/test_diagnostic.py
+++ b/pandapower/test/api/test_diagnostic.py
@@ -833,5 +833,18 @@ def test_runpp_errors(test_net, diag_params, diag_errors):
     Diagnostic().diagnose_network(net, report_style=None)
 
 
+# def test_wrong_line_impedance_reports_do_not_raise():
+#     net = example_simple()
+#     net.load.at[0, "p_mw"] = 1000
+
+#     Diagnostic().diagnose_network(net, report_style="detailed")
+
+def test_diagnostic_report_does_not_raise_for_overloaded_example_simple():
+    net = example_simple()
+    net.load.at[0, "p_mw"] = 1000
+
+    Diagnostic().diagnose_network(net, report_style="detailed")
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-xs"])


### PR DESCRIPTION
Fixes #3046 

This PR fixes diagnostic report-generation crashes found with an overloaded `example_simple()` network.

Some diagnostic report methods contained copied line-capacitance reporting logic and referenced `capacitance_scaling_factor`, although the corresponding diagnostic classes do not define that attribute. This caused `Diagnostic().diagnose_network(..., report_style="detailed")` to raise an `AttributeError` during report generation.

The affected report methods were updated to use the correct class-specific attributes/messages, and a regression test was added in `pandapower/test/api/test_diagnostic.py`.

Tested with:

```bash
pytest pandapower/test/api/test_diagnostic.py -k diagnostic_report_does_not_raise_for_overloaded_example_simple
```

Result:

```text
1 passed
```


Tested with:

```bash
pytest pandapower/test/api/test_diagnostic.py
```

Result:

```text
23 passed
```