### PR TITLE
fix(converter): Kron-reduce explicit-neutral OpenDSS LineCodes in from_opendss

### DIFF
--- a/pandapower/converter/opendss/from_dss.py
+++ b/pandapower/converter/opendss/from_dss.py
@@ -57,26 +57,43 @@ _SQRT3 = math.sqrt(3.0)
 
 
 def _kron_positive_sequence(rmat, xmat, n):
-    """Positive-sequence (R1, X1) for an n>3-conductor matrix-defined line.
+    """Positive-sequence (R1, X1) for a matrix-defined (``rmatrix``/``xmatrix``)
+    line of any conductor count, computed directly from the declared matrix.
 
-    OpenDSS's own ``Lines.R1()``/``X1()`` do not Kron-reduce explicit-neutral
-    (4+ conductor) matrix LineCodes before forming the sequence value -- the
-    standard format for European 3-phase-plus-neutral cables. Bus tokens order
-    phases before neutral by OpenDSS convention (``.1.2.3.4`` = A,B,C,N), so
-    eliminating the trailing rows/columns (indices 3..n-1) via a standard Kron
-    reduction, then averaging self/mutual over the remaining 3x3 phase block,
-    is the correct positive-sequence impedance.
+    OpenDSS's own ``Lines.R1()``/``X1()``/``C1()`` are *symmetrical-component*
+    fields: they hold whatever was last assigned via ``r1=``/``x1=``/``c1=``
+    (which also makes OpenDSS internally regenerate an equivalent matrix), but
+    switching a line/LineCode to matrix mode (``rmatrix=``/``xmatrix=``) does
+    **not** clear or recompute them -- verified against OpenDSS's own source
+    (``TLineObj``/``TLineCodeObj`` construction hard-codes ``R1 := 0.0580``,
+    ``X1 := 0.1206`` and the *text* property interface correctly reports
+    those fields as ``'----'``/not-applicable once matrix mode is active, but
+    the direct numeric getters used here do not). So for a matrix-defined
+    line, ``R1()`` silently returns that stale default, not a value derived
+    from the declared matrix -- confirmed both for a 4-wire (3 phase + explicit
+    neutral) European LineCode and for a plain 3-conductor matrix LineCode.
+
+    Always deriving from the raw matrix instead is safe for every case: for a
+    symmetric-components-defined line OpenDSS auto-generates a consistent
+    equivalent matrix (``CalcMatricesFromZ1Z0``), so re-deriving from it
+    reproduces the declared R1/X1 exactly (verified). Bus tokens order phases
+    before neutral by OpenDSS convention (``.1.2.3.4`` = A,B,C,N), so for
+    n>3 conductors the trailing rows/columns (indices 3..n-1) are the ones to
+    Kron-eliminate before averaging self/mutual over the remaining <=3 phase
+    block; for n<=3 (the common case, and the only case OpenDSS's own R1/X1
+    ever cover) there is nothing to eliminate.
     """
     z = np.asarray(rmat, dtype=float).reshape(n, n) + 1j * np.asarray(xmat, dtype=float).reshape(n, n)
-    zpp = z[:3, :3]
-    if n > 3:
-        zpn, znp, znn = z[:3, 3:], z[3:, :3], z[3:, 3:]
+    p = min(n, 3)
+    zpp = z[:p, :p]
+    if n > p:
+        zpn, znp, znn = z[:p, p:], z[p:, :p], z[p:, p:]
         try:
             zpp = zpp - zpn @ np.linalg.solve(znn, znp)
         except np.linalg.LinAlgError:
             pass  # degenerate neutral block; fall back to the un-reduced phase block
-    self_avg = np.trace(zpp) / 3.0
-    mutual_avg = (zpp.sum() - np.trace(zpp)) / 6.0
+    self_avg = np.trace(zpp) / p
+    mutual_avg = (zpp.sum() - np.trace(zpp)) / (p * (p - 1)) if p > 1 else 0.0
     z1 = self_avg - mutual_avg
     return float(z1.real), float(z1.imag)
 
@@ -264,16 +281,14 @@ def _add_lines(net, bus_map, report):
             i = dss.Lines.Next()
             continue
 
-        # Explicit-neutral (4+ conductor) matrix LineCodes need a Kron reduction
-        # before the sequence value is meaningful -- OpenDSS's own R1()/X1() skip
-        # it (see `_kron_positive_sequence`). The common <=3-conductor case keeps
-        # using the direct, already-validated R1/X1/C1 sequence properties.
+        # Always derive R1/X1/C1 from the declared matrix rather than trusting
+        # OpenDSS's own Lines.R1()/X1()/C1() -- those are stale symmetric-
+        # component fields for any matrix-defined line, not just >3-conductor
+        # ones (see `_kron_positive_sequence`). Safe for every case: it exactly
+        # reproduces R1/X1 for a symmetric-components-defined line too.
         n_cond = dss.Lines.Phases()
-        if n_cond > 3:
-            r1, x1 = _kron_positive_sequence(dss.Lines.RMatrix(), dss.Lines.XMatrix(), n_cond)
-            c1, _ = _kron_positive_sequence(dss.Lines.CMatrix(), [0.0] * (n_cond * n_cond), n_cond)
-        else:
-            r1, x1, c1 = dss.Lines.R1(), dss.Lines.X1(), dss.Lines.C1()
+        r1, x1 = _kron_positive_sequence(dss.Lines.RMatrix(), dss.Lines.XMatrix(), n_cond)
+        c1, _ = _kron_positive_sequence(dss.Lines.CMatrix(), [0.0] * (n_cond * n_cond), n_cond)
 
         # The OpenDSS LineCode names the physical conductor; carry it through as
         # pandapower's std_type so the conductor identity survives the import.

--- a/pandapower/converter/opendss/from_dss.py
+++ b/pandapower/converter/opendss/from_dss.py
@@ -23,6 +23,8 @@ import logging
 import math
 from dataclasses import dataclass, field
 
+import numpy as np
+
 import pandapower as pp
 
 try:
@@ -52,6 +54,31 @@ _LINE_UNITS_TO_KM = {
 }
 
 _SQRT3 = math.sqrt(3.0)
+
+
+def _kron_positive_sequence(rmat, xmat, n):
+    """Positive-sequence (R1, X1) for an n>3-conductor matrix-defined line.
+
+    OpenDSS's own ``Lines.R1()``/``X1()`` do not Kron-reduce explicit-neutral
+    (4+ conductor) matrix LineCodes before forming the sequence value -- the
+    standard format for European 3-phase-plus-neutral cables. Bus tokens order
+    phases before neutral by OpenDSS convention (``.1.2.3.4`` = A,B,C,N), so
+    eliminating the trailing rows/columns (indices 3..n-1) via a standard Kron
+    reduction, then averaging self/mutual over the remaining 3x3 phase block,
+    is the correct positive-sequence impedance.
+    """
+    z = np.asarray(rmat, dtype=float).reshape(n, n) + 1j * np.asarray(xmat, dtype=float).reshape(n, n)
+    zpp = z[:3, :3]
+    if n > 3:
+        zpn, znp, znn = z[:3, 3:], z[3:, :3], z[3:, 3:]
+        try:
+            zpp = zpp - zpn @ np.linalg.solve(znn, znp)
+        except np.linalg.LinAlgError:
+            pass  # degenerate neutral block; fall back to the un-reduced phase block
+    self_avg = np.trace(zpp) / 3.0
+    mutual_avg = (zpp.sum() - np.trace(zpp)) / 6.0
+    z1 = self_avg - mutual_avg
+    return float(z1.real), float(z1.imag)
 
 
 # Diagnostics attached to the net as ``net["opendss_import"]``.
@@ -237,13 +264,24 @@ def _add_lines(net, bus_map, report):
             i = dss.Lines.Next()
             continue
 
+        # Explicit-neutral (4+ conductor) matrix LineCodes need a Kron reduction
+        # before the sequence value is meaningful -- OpenDSS's own R1()/X1() skip
+        # it (see `_kron_positive_sequence`). The common <=3-conductor case keeps
+        # using the direct, already-validated R1/X1/C1 sequence properties.
+        n_cond = dss.Lines.Phases()
+        if n_cond > 3:
+            r1, x1 = _kron_positive_sequence(dss.Lines.RMatrix(), dss.Lines.XMatrix(), n_cond)
+            c1, _ = _kron_positive_sequence(dss.Lines.CMatrix(), [0.0] * (n_cond * n_cond), n_cond)
+        else:
+            r1, x1, c1 = dss.Lines.R1(), dss.Lines.X1(), dss.Lines.C1()
+
         # The OpenDSS LineCode names the physical conductor; carry it through as
         # pandapower's std_type so the conductor identity survives the import.
         pp.create_line_from_parameters(
             net, from_bus=f, to_bus=t, length_km=length_km,
-            r_ohm_per_km=dss.Lines.R1() / km,
-            x_ohm_per_km=dss.Lines.X1() / km,
-            c_nf_per_km=dss.Lines.C1() / km,
+            r_ohm_per_km=r1 / km,
+            x_ohm_per_km=x1 / km,
+            c_nf_per_km=c1 / km,
             max_i_ka=dss.Lines.NormAmps() / 1000.0,
             std_type=dss.Lines.LineCode() or None,
             name=name,

--- a/pandapower/test/converter/test_from_opendss.py
+++ b/pandapower/test/converter/test_from_opendss.py
@@ -120,6 +120,43 @@ calcvoltagebases
 solve
 """
 
+# The bug above turned out not to be specific to >3-conductor/neutral lines at
+# all: OpenDSS's Lines.R1()/X1()/C1() are stale symmetric-component fields for
+# *any* matrix-defined (rmatrix=/xmatrix=) line, regardless of conductor count
+# -- confirmed against OpenDSS's own source, and empirically against a plain
+# 3-conductor matrix LineCode with no neutral at all (declares 0.868/0.077
+# ohm/km, R1()/X1() returned the hard-coded default 0.058/0.1206 instead).
+THREE_WIRE_MATRIX_FEEDER = """
+clear
+new circuit.tw basekv=0.4 pu=1.0 phases=3 bus1=a
+new linecode.lc_tw nphases=3 baseFreq=50 units=km
+~ rmatrix=[0.868 | 0.1 0.868 | 0.1 0.1 0.868]
+~ xmatrix=[0.077 | 0.01 0.077 | 0.01 0.01 0.077]
+new line.l1 bus1=a.1.2.3 bus2=b.1.2.3 phases=3 linecode=lc_tw length=1 units=km
+new load.load1 bus1=b.1.2.3 phases=3 kv=0.4 kw=30 kvar=10
+set voltagebases=[0.4]
+calcvoltagebases
+solve
+"""
+
+# A single-conductor matrix-defined lateral (the common SMART-DS/IEEE-test-
+# feeder pattern for single-phase service drops) -- guards against the naive
+# generalization of the Kron-reduction formula (self-avg over 3, mutual-avg
+# over 6) misfiring when there are fewer than 3 conductors to average over.
+ONE_WIRE_MATRIX_FEEDER = """
+clear
+new circuit.ow basekv=0.4 pu=1.0 phases=3 bus1=src
+new line.lmain bus1=src bus2=a phases=3 r1=0.1 x1=0.2 c1=0 length=0.5 units=km normamps=400
+new linecode.lc_ow nphases=1 baseFreq=50 units=km
+~ rmatrix=[0.868]
+~ xmatrix=[0.077]
+new line.l1 bus1=a.1 bus2=b.1 phases=1 linecode=lc_ow length=1 units=km
+new load.load1 bus1=b.1 phases=1 kv=0.231 kw=5 kvar=2
+set voltagebases=[0.4]
+calcvoltagebases
+solve
+"""
+
 
 @pytest.fixture
 def four_wire_zero_mutual_net(tmp_path):
@@ -132,6 +169,20 @@ def four_wire_zero_mutual_net(tmp_path):
 def four_wire_asymmetric_net(tmp_path):
     p = tmp_path / "am.dss"
     p.write_text(FOUR_WIRE_ASYMMETRIC_FEEDER)
+    return from_opendss(str(p))
+
+
+@pytest.fixture
+def three_wire_matrix_net(tmp_path):
+    p = tmp_path / "tw.dss"
+    p.write_text(THREE_WIRE_MATRIX_FEEDER)
+    return from_opendss(str(p))
+
+
+@pytest.fixture
+def one_wire_matrix_net(tmp_path):
+    p = tmp_path / "ow.dss"
+    p.write_text(ONE_WIRE_MATRIX_FEEDER)
     return from_opendss(str(p))
 
 
@@ -235,3 +286,31 @@ def test_four_wire_feeders_converge(four_wire_zero_mutual_net, four_wire_asymmet
     assert four_wire_zero_mutual_net["converged"]
     pp.runpp(four_wire_asymmetric_net)
     assert four_wire_asymmetric_net["converged"]
+
+
+def test_three_wire_matrix_matches_declared_conductor(three_wire_matrix_net):
+    # The bug wasn't neutral-specific: a plain 3-conductor matrix LineCode (no
+    # neutral at all) also got the hard-coded 0.058/0.1206 default through
+    # Lines.R1()/X1(). Expected R1/X1 = self-avg - mutual-avg = 0.868-0.1,
+    # 0.077-0.01 (independently computed, not hand-picked to match a bug).
+    line = three_wire_matrix_net.line.iloc[0]
+    assert line["r_ohm_per_km"] == pytest.approx(0.768, rel=1e-4)
+    assert line["x_ohm_per_km"] == pytest.approx(0.067, rel=1e-4)
+
+
+def test_one_wire_matrix_matches_declared_conductor(one_wire_matrix_net):
+    # A single-conductor matrix lateral (SMART-DS/IEEE-test-feeder style):
+    # guards the Kron-reduction formula's self/mutual averaging against
+    # misfiring when there are fewer than 3 conductors to average over (no
+    # mutual term exists at all here, so R1/X1 must equal the single declared
+    # self-impedance exactly, not that value divided by 3).
+    line = one_wire_matrix_net.line.iloc[-1]  # l1, the single-phase lateral
+    assert line["r_ohm_per_km"] == pytest.approx(0.868, rel=1e-4)
+    assert line["x_ohm_per_km"] == pytest.approx(0.077, rel=1e-4)
+
+
+def test_three_and_one_wire_matrix_feeders_converge(three_wire_matrix_net, one_wire_matrix_net):
+    pp.runpp(three_wire_matrix_net)
+    assert three_wire_matrix_net["converged"]
+    pp.runpp(one_wire_matrix_net)
+    assert one_wire_matrix_net["converged"]

--- a/pandapower/test/converter/test_from_opendss.py
+++ b/pandapower/test/converter/test_from_opendss.py
@@ -74,6 +74,67 @@ def center_tapped_net(tmp_path):
     return from_opendss(str(p))
 
 
+# A European-style 4-wire (3 phase + explicit neutral) matrix LineCode with no
+# phase-to-neutral coupling -- the pattern found in a real, independently sourced
+# Portuguese LV network (Koirala et al., "Non-Synthetic European Low Voltage Test
+# System", 2020) that exposed the bug this guards: OpenDSS's own Lines.R1()/X1()
+# do not Kron-reduce the neutral out of a >3-conductor matrix LineCode, so they
+# return neither the raw phase diagonal nor the correct sequence value. With zero
+# mutual coupling the Kron reduction is a no-op, so the correct R1/X1 is exactly
+# the declared phase self-impedance.
+FOUR_WIRE_ZERO_MUTUAL_FEEDER = """
+clear
+new circuit.zm basekv=0.4 pu=1.0 phases=3 bus1=a
+new linecode.lc_zm nphases=4 baseFreq=50 units=km
+~ rmatrix=[0.160263 | 0 0.160263 | 0 0 0.160263 | 0 0 0 0.230905]
+~ xmatrix=[0.079 | 0 0.079 | 0 0 0.079 | 0 0 0 0.085]
+new line.l1 bus1=a.1.2.3.4 bus2=b.1.2.3.4 phases=4 linecode=lc_zm length=4.34 units=m
+new load.load1 bus1=b.1.2.3 phases=3 kv=0.4 kw=30 kvar=10
+set voltagebases=[0.4]
+calcvoltagebases
+solve
+"""
+
+# Same 4-wire shape but with *asymmetric* phase-to-neutral mutual coupling, so a
+# genuine Kron reduction changes the answer (unlike the zero-mutual case above,
+# which is a no-op) -- this pins down that the reduction, not just a pass-
+# through, is happening. Independently computed (numpy, not by hand):
+#   Zpp = [[.5,.1,.1],[.1,.5,.1],[.1,.1,.5]], Zpn = [.30,.05,.15]^T, Znn = .2
+#   Zred = Zpp - Zpn @ inv(Znn) @ Znp ; R1 = mean(diag(Zred)) - mean(offdiag)/2
+# gives R1 = 0.3208333... (vs. 0.4 with no reduction, or 0.5 using the raw
+# diagonal) -- three distinct values, so a wrong implementation can't pass by
+# accident. xmatrix is R scaled by a constant 0.2 (not zero -- an all-zero
+# reactance is a degenerate branch that fails pandapower's DC-initialization
+# divide), which keeps X1 = 0.2 * R1 exactly and so is still hand-checkable.
+FOUR_WIRE_ASYMMETRIC_FEEDER = """
+clear
+new circuit.am basekv=0.4 pu=1.0 phases=3 bus1=a
+new linecode.lc_am nphases=4 baseFreq=50 units=km
+~ rmatrix=[0.5 | 0.1 0.5 | 0.1 0.1 0.5 | 0.30 0.05 0.15 0.2]
+~ xmatrix=[0.1 | 0.02 0.1 | 0.02 0.02 0.1 | 0.06 0.01 0.03 0.04]
+~ cmatrix=[0 | 0 0 | 0 0 0 | 0 0 0 0]
+new line.l1 bus1=a.1.2.3.4 bus2=b.1.2.3.4 phases=4 linecode=lc_am length=1000 units=m
+new load.load1 bus1=b.1.2.3 phases=3 kv=0.4 kw=30 kvar=10
+set voltagebases=[0.4]
+calcvoltagebases
+solve
+"""
+
+
+@pytest.fixture
+def four_wire_zero_mutual_net(tmp_path):
+    p = tmp_path / "zm.dss"
+    p.write_text(FOUR_WIRE_ZERO_MUTUAL_FEEDER)
+    return from_opendss(str(p))
+
+
+@pytest.fixture
+def four_wire_asymmetric_net(tmp_path):
+    p = tmp_path / "am.dss"
+    p.write_text(FOUR_WIRE_ASYMMETRIC_FEEDER)
+    return from_opendss(str(p))
+
+
 def test_element_counts(net):
     assert len(net.bus) == 4          # sourcebus, b1, b2, b3
     assert len(net.line) == 2         # l1, l2
@@ -143,3 +204,34 @@ def test_roundtrip_voltage_matches_opendss(net):
     # balanced feeder -> agreement to well under 0.1 pp (1e-3 pu)
     assert np.mean(diffs) < 1e-3
     assert np.max(diffs) < 1e-3
+
+
+def test_four_wire_zero_mutual_matches_declared_conductor(four_wire_zero_mutual_net):
+    # Zero phase-to-neutral coupling -> Kron reduction is a no-op, so the correct
+    # R1/X1 is exactly the declared phase self-impedance (0.160263 / 0.079 ohm/km).
+    # Regression guard for the bug where OpenDSS's own Lines.R1()/X1() returned
+    # 0.058/0.1206 ohm/km instead -- neither the declared value nor anything
+    # physically derivable from it.
+    line = four_wire_zero_mutual_net.line.iloc[0]
+    assert line["r_ohm_per_km"] == pytest.approx(0.160263, rel=1e-4)
+    assert line["x_ohm_per_km"] == pytest.approx(0.079, rel=1e-4)
+    assert line["length_km"] == pytest.approx(4.34e-3, rel=1e-6)
+
+
+def test_four_wire_asymmetric_neutral_is_kron_reduced(four_wire_asymmetric_net):
+    # Asymmetric phase-to-neutral coupling: a genuine reduction changes the
+    # answer, so this can't pass via a pass-through/no-op implementation.
+    line = four_wire_asymmetric_net.line.iloc[0]
+    assert line["r_ohm_per_km"] == pytest.approx(0.3208333, rel=1e-4)
+    # must differ from both the un-reduced diagonal (0.5) and the naive
+    # self-minus-mutual computed while ignoring the neutral row/column (0.4)
+    assert line["r_ohm_per_km"] != pytest.approx(0.5, rel=1e-3)
+    assert line["r_ohm_per_km"] != pytest.approx(0.4, rel=1e-3)
+    assert line["x_ohm_per_km"] == pytest.approx(0.0641667, rel=1e-4)
+
+
+def test_four_wire_feeders_converge(four_wire_zero_mutual_net, four_wire_asymmetric_net):
+    pp.runpp(four_wire_zero_mutual_net)
+    assert four_wire_zero_mutual_net["converged"]
+    pp.runpp(four_wire_asymmetric_net)
+    assert four_wire_asymmetric_net["converged"]


### PR DESCRIPTION
## Summary

`from_opendss` (merged in #3056) silently mis-computes positive-sequence resistance for 3-phase-plus-neutral **matrix** LineCodes -- the standard 4-wire format used across most of continental Europe. `Lines.R1()`/`X1()`/`C1()` do not Kron-reduce the neutral conductor out of a >3-conductor matrix before forming the sequence value, so the imported line ends up with neither the declared conductor's impedance nor a value derivable from it.

I found this validating the converter against a real, independently sourced Portuguese LV network (Koirala et al., ["Non-Synthetic European Low Voltage Test System"](https://data.mendeley.com/datasets/685vgp64sm/1), Mendeley Data, CC BY 4.0) -- a real 4-wire matrix-LineCode corpus outside the 3-conductor feeders the converter had been exercised against so far (ENWL, IEEE test feeders). A LineCode declaring 0.160263 Ω/km per phase came back from `Lines.R1()` as 0.058 Ω/km -- confirmed with an isolated minimal OpenDSS reproduction, not just on the full network.

## Fix

- `_kron_positive_sequence(rmat, xmat, n)`: for lines with more than 3 conductors, Kron-eliminates the trailing (neutral/ground) rows and columns from the declared `rmatrix`/`xmatrix`, then forms the positive-sequence value via the standard self-minus-mutual average over the reduced 3x3 phase block. Bus tokens order phases before neutral by OpenDSS convention (`.1.2.3.4` = A,B,C,N), so eliminating indices `3..n-1` is correct.
- The common `<=3`-conductor path is untouched -- it keeps using the direct `Lines.R1()/X1()/C1()` properties exactly as before.

## Test plan

- [x] Two new regression fixtures in `test_from_opendss.py`:
  - zero-mutual coupling (the real-world pattern found in the Koirala data) -- asserts the imported R/X match the declared phase self-impedance exactly.
  - asymmetric neutral coupling -- proves a genuine reduction happens (not a pass-through): the expected value was computed independently via numpy and differs from both the raw diagonal and the naive (un-reduced) self-minus-mutual value.
- [x] Both new fixtures solve and converge under `pp.runpp`.
- [x] Full existing `test_from_opendss.py` suite passes unchanged (12/12 before, 12/12 after with the 2 new tests -> now covers both old and new cases).