### PR TITLE
[Fix] unsafe json load

### DIFF
--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -390,6 +390,10 @@ def isinstance_partial(obj, cls):
     return isinstance(obj, cls)
 
 
+class DeserializationNotAllowed(Exception):
+    """Raised when deserialization of a type is blocked by the security allowlist."""
+
+
 # builtins names that pandapower serializes (json_tuple/set/frozenset/complex), excluding unsafe `builtins` like eval, exec, type
 _SAFE_BUILTIN_NAMES = frozenset({"complex", "tuple", "set", "frozenset"})
 
@@ -811,7 +815,7 @@ class FromSerializableRegistry():
             # only permit the specific primitive types pandapower serializes
             if not _is_safe_to_deserialize(self.module_name, self.class_name, class_):
                 msg = f"Deserializing '{self.module_name}.{self.class_name}' is not allowed"
-                raise TypeError(msg)
+                raise DeserializationNotAllowed(msg)
             return class_(self.obj, **self.d)
 
     @from_serializable.register(class_name='GeoDataFrame', module_name='geopandas.geodataframe')

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -391,6 +391,7 @@ def isinstance_partial(obj, cls):
 
 
 class DeserializationNotAllowed(Exception):
+
     """Raised when deserialization of a type is blocked by the security allowlist."""
 
 
@@ -399,7 +400,8 @@ _SAFE_BUILTIN_NAMES = frozenset({"complex", "tuple", "set", "frozenset"})
 
 
 def _is_safe_to_deserialize(module_name, class_name, class_):
-    """True if this (module, name) is an explicitly permitted non-JSONSerializableClass type.
+    """
+    True if this (module, name) is an explicitly permitted non-JSONSerializableClass type.
 
     Covers the types produced by pandapower's to_serializable registry:
       builtins  — complex, tuple, set, frozenset
@@ -416,6 +418,9 @@ def _is_safe_to_deserialize(module_name, class_name, class_):
         return isclass(class_) and issubclass(class_, numpy.generic)
     if module_name.startswith("pandas"):
         return isclass(class_) and issubclass(class_, pd.Index)
+    # Enums from unknown modules could have a custom __new__ that executes arbitrary code.
+    if module_name.startswith("pandapower") and isclass(class_) and issubclass(class_, Enum):
+        return True
     return False
 
 

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -812,16 +812,7 @@ class FromSerializableRegistry():
             if not _is_safe_to_deserialize(self.module_name, self.class_name, class_):
                 msg = f"Deserializing '{self.module_name}.{self.class_name}' is not allowed"
                 raise TypeError(msg)
-            try:
-                return class_(self.obj, **self.d)
-            except ValueError:
-                data = json.loads(self.obj)
-                df = pd.DataFrame(columns=self.d["columns"])
-                for d in data["features"]:
-                    idx = int(d["id"])
-                    for prop, val in d["properties"].items():
-                        df.at[idx, prop] = val
-                return df
+            return class_(self.obj, **self.d)
 
     @from_serializable.register(class_name='GeoDataFrame', module_name='geopandas.geodataframe')
     def geoDataFrame(self):

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -390,6 +390,31 @@ def isinstance_partial(obj, cls):
     return isinstance(obj, cls)
 
 
+# builtins names that pandapower serializes (json_tuple/set/frozenset/complex), excluding unsafe `builtins` like eval, exec, type
+_SAFE_BUILTIN_NAMES = frozenset({"complex", "tuple", "set", "frozenset"})
+
+
+def _is_safe_to_deserialize(module_name, class_name, class_):
+    """True if this (module, name) is an explicitly permitted non-JSONSerializableClass type.
+
+    Covers the types produced by pandapower's to_serializable registry:
+      builtins  — complex, tuple, set, frozenset
+      numpy     — numpy.array constructor (a C function, not a class) + all numpy.generic subclasses
+      pandas    — pd.Index and its subclasses (RangeIndex, Int64Index, DatetimeIndex, …)
+    """
+    if module_name == "builtins":
+        return class_name in _SAFE_BUILTIN_NAMES
+    if module_name == "numpy":
+        # numpy.array is a C function (not a class) used to reconstruct ndarrays
+        if class_name == "array":
+            return True
+        # int8/16/32/64, uint*, float16/32/64, complex64/128, bool_, etc.
+        return isclass(class_) and issubclass(class_, numpy.generic)
+    if module_name.startswith("pandas"):
+        return isclass(class_) and issubclass(class_, pd.Index)
+    return False
+
+
 class PPJSONEncoder(json.JSONEncoder):
     def __init__(self, isinstance_func=isinstance_partial, **kwargs):
         super().__init__(**kwargs)
@@ -593,7 +618,7 @@ class FromSerializableRegistry():
         for col in df_obj:
             df[col] = df[col].apply(partial(
                 self.pp_hook,
-                ignore_unknown_objects=self.ignore_unknown_objects, 
+                ignore_unknown_objects=self.ignore_unknown_objects,
                 omit_modules=self.omit_modules,
                 skip_checks=self.skip_checks
             ))
@@ -720,7 +745,7 @@ class FromSerializableRegistry():
             logger.warning(f"Deserialization of function {self.obj} is blocked, if you trust the source of the json file,"
                            f"set skip_checks=True to allow deserialization of objects.")
             return self.obj
-        
+
     
     @from_serializable.register(class_name='bool', module_name='numpy')
     def bool_handling(self):
@@ -783,7 +808,10 @@ class FromSerializableRegistry():
                 del self.obj["net"]
             return class_.from_dict(self.obj)
         else:
-            # for non-pp objects, e.g. tuple
+            # only permit the specific primitive types pandapower serializes
+            if not _is_safe_to_deserialize(self.module_name, self.class_name, class_):
+                msg = f"Deserializing '{self.module_name}.{self.class_name}' is not allowed"
+                raise TypeError(msg)
             try:
                 return class_(self.obj, **self.d)
             except ValueError:


### PR DESCRIPTION
A proposed fix for https://github.com/e2nIEE/pandapower/issues/3049:
* still imports modules dynamically
* checks the requested classes against a whitelist:
    *  subclass of JSONSerializableClass (custom controllers etc)
    * classes / methods handled by pandapowers json serializer - basic builtins, numpy and pandas
* aborts with an exception if the requested class is not whitelisted

#3050 introduced a new argument "skip_checks=False" for pp.from_json() which should allow opt-in for unsafe deserialization. But the implementation is faulty - instead of blocking unsafe json loads, it just prints a user warning stating (wrongly) that deserialization was blocked. 

With the proposed fix, it's not clear to me at the moment if an argument to load "unsafe" data is really needed, and if so what it should block:
* ANY module not covered by a dedicated deserializer method, i.e. guarding the complete rest() path (this would include simple builtins and subclasses of JSONSerializableClass)
* subclasses of JSONSerializableClass, allowing the other whitelisted classes
* ..?

I can clean up the skip_checks part if you decide what route to take with it.  