### PR TITLE
Fix DiscreteShuntController controlled_bus reindexing

### DIFF
--- a/pandapower/control/controller/shunt_control.py
+++ b/pandapower/control/controller/shunt_control.py
@@ -45,7 +45,6 @@ class ShuntController(Controller):
         self.tol = tol
         self.shunt_index = shunt_index
         self.element_in_service = net.shunt.loc[self.shunt_index, 'in_service']
-        self.bus_index = bus_index
         self.step = net.shunt.at[shunt_index, 'step']
 
         self.check_step_bounds = check_step_bounds
@@ -59,8 +58,6 @@ class ShuntController(Controller):
             self.set_active(net, False)
 
     def controlled_bus(self, net):
-        if self.bus_index is not None:
-            return self.bus_index
         return net.shunt.at[self.shunt_index, "bus"]
 
 
@@ -111,7 +108,8 @@ class DiscreteShuntController(ShuntController):
             net.shunt.at[self.shunt_index, 'step'] = 0
 
     def control_step(self, net):
-        vm_pu = net.res_bus.at[self.controlled_bus(net), 'vm_pu']
+        controlled_bus = self.controlled_bus(net)
+        vm_pu = net.res_bus.at[controlled_bus, 'vm_pu']
         self.step = net.shunt.at[self.shunt_index, "step"]
 
         sign = np.sign(net.shunt.at[self.shunt_index, 'q_mvar'])
@@ -130,7 +128,8 @@ class DiscreteShuntController(ShuntController):
         if not net.shunt.at[self.shunt_index, 'in_service']:
             return True
 
-        vm_pu = net.res_bus.at[self.controlled_bus(net), "vm_pu"]
+        controlled_bus = self.controlled_bus(net)
+        vm_pu = net.res_bus.at[controlled_bus, "vm_pu"]
         if abs(vm_pu - self.vm_set_pu) < self.tol:
             return True
 

--- a/pandapower/control/controller/shunt_control.py
+++ b/pandapower/control/controller/shunt_control.py
@@ -45,11 +45,7 @@ class ShuntController(Controller):
         self.tol = tol
         self.shunt_index = shunt_index
         self.element_in_service = net.shunt.loc[self.shunt_index, 'in_service']
-        if bus_index is None:
-            self.controlled_bus = net.shunt.at[self.shunt_index, 'bus']
-        else:
-            self.controlled_bus = bus_index
-
+        self.bus_index = bus_index
         self.step = net.shunt.at[shunt_index, 'step']
 
         self.check_step_bounds = check_step_bounds
@@ -58,9 +54,14 @@ class ShuntController(Controller):
             self.step_max = net.shunt.at[self.shunt_index, 'max_step']
 
         ext_grid_buses = net.ext_grid.loc[net.ext_grid.in_service, 'bus'].values
-        if self.controlled_bus in ext_grid_buses:
+        if self.controlled_bus(net) in ext_grid_buses:
             logging.warning("Controlled Bus is Slack Bus - deactivating controller")
             self.set_active(net, False)
+
+    def controlled_bus(self, net):
+        if self.bus_index is not None:
+            return self.bus_index
+        return net.shunt.at[self.shunt_index, "bus"]
 
 
 class DiscreteShuntController(ShuntController):
@@ -110,7 +111,7 @@ class DiscreteShuntController(ShuntController):
             net.shunt.at[self.shunt_index, 'step'] = 0
 
     def control_step(self, net):
-        vm_pu = net.res_bus.at[self.controlled_bus, 'vm_pu']
+        vm_pu = net.res_bus.at[self.controlled_bus(net), 'vm_pu']
         self.step = net.shunt.at[self.shunt_index, "step"]
 
         sign = np.sign(net.shunt.at[self.shunt_index, 'q_mvar'])
@@ -129,7 +130,7 @@ class DiscreteShuntController(ShuntController):
         if not net.shunt.at[self.shunt_index, 'in_service']:
             return True
 
-        vm_pu = net.res_bus.at[self.controlled_bus, "vm_pu"]
+        vm_pu = net.res_bus.at[self.controlled_bus(net), "vm_pu"]
         if abs(vm_pu - self.vm_set_pu) < self.tol:
             return True
 

--- a/pandapower/test/control/test_shunt_control.py
+++ b/pandapower/test/control/test_shunt_control.py
@@ -5,6 +5,7 @@ from pandapower.control.controller.station_control import BinarySearchControl
 from pandapower.create import create_empty_network, create_buses, create_ext_grid, create_line_from_parameters, \
     create_shunt
 from pandapower.run import runpp
+from pandapower.toolbox import create_continuous_bus_index, drop_buses
 
 
 def simple_test_net_shunt_control():
@@ -57,6 +58,31 @@ def test_discrete_shunt_control_with_step_dependency_table(tol=1e-6):
     assert (abs(net.res_bus.loc[1, "vm_pu"] - 1.077258) < tol)
     assert net.shunt.loc[0, "step"] == 4
 
+def test_discrete_shunt_controlled_bus_follows_reindexed_shunt_bus():
+    net = create_empty_network()
+    buses = create_buses(net, 3, vn_kv=[20.0, 10.0, 5.0])
+
+    shunt_index = create_shunt(
+        net,
+        bus=buses[2],
+        q_mvar=-1.0,
+        p_mw=0.0,
+        step=0,
+        max_step=1,
+    )
+    controller = DiscreteShuntController(net, shunt_index, vm_set_pu=1.0)
+
+    assert net.shunt.at[shunt_index, "bus"] == buses[2]
+    assert controller.controlled_bus(net) == buses[2]
+
+    drop_buses(net, [buses[1]])
+    create_continuous_bus_index(net)
+
+    assert net.shunt.at[shunt_index, "bus"] == 1
+    assert controller.controlled_bus(net) == 1
+
+    net.res_bus = pd.DataFrame({"vm_pu": [1.0, 1.0]}, index=net.bus.index)
+    assert controller.is_converged(net)
 
 if __name__ == '__main__':
     pytest.main(['-s', __file__])


### PR DESCRIPTION
Fixes #2946.

This updates controller object bus references during bus reindexing. Previously, `create_continuous_bus_index()` updated element tables such as `net.shunt.bus`, but `DiscreteShuntController.controlled_bus` could remain stale.

A regression test was added for `DiscreteShuntController` after `drop_buses()` followed by `create_continuous_bus_index()`.