### PR TITLE
OpenDSS converter: import series Reactor elements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Change Log
 
 [upcoming release] - 2026-..-..
 -------------------------------
+- [ADDED] OpenDSS converter: series (bus-to-bus) ``Reactor`` elements are now imported as a fixed-impedance ``line``, the pattern some feeder libraries (e.g. EPRI's Ckt5/Ckt7) use to model the substation's Thevenin-equivalent source impedance instead of a ``Transformer``.
 
 [3.5.4] - 2026-07-08
 -------------------------------

--- a/doc/converter/opendss.rst
+++ b/doc/converter/opendss.rst
@@ -8,9 +8,10 @@ The following function imports an `OpenDSS <https://www.epri.com/pages/sa/opends
 feeder into a **balanced (positive-sequence)** pandapower net. It reads the circuit
 through ``OpenDSSDirect.py`` (an optional dependency, ``pip install pandapower[opendss]``),
 mapping buses, lines (with their LineCode carried through as ``std_type``),
-two-winding transformers (at their solved tap), center-tapped split-phase service
-transformers (collapsed to a two-winding equivalent), loads, shunt capacitors,
-switches and the source.
+series (bus-to-bus) reactors (the pattern some feeder libraries use to model the
+substation's source impedance), two-winding transformers (at their solved tap),
+center-tapped split-phase service transformers (collapsed to a two-winding
+equivalent), loads, shunt capacitors, switches and the source.
 
 Positive-sequence is exact for symmetric (e.g. European 3-phase 4-wire) feeders and
 a documented approximation for unsymmetrical North-American topology (single-phase

--- a/pandapower/converter/opendss/from_dss.py
+++ b/pandapower/converter/opendss/from_dss.py
@@ -103,6 +103,7 @@ def _kron_positive_sequence(rmat, xmat, n):
 class _ImportReport:
     n_buses: int = 0
     n_lines: int = 0
+    n_reactors: int = 0
     n_switches: int = 0
     n_transformers: int = 0
     n_split_phase_transformers: int = 0
@@ -154,6 +155,8 @@ def from_opendss(path: str, solve: bool=True):
     * Bus -> ``bus``: ``vn_kv`` = base kV (line-to-line)
     * Line + LineCode -> ``line``: r/x/c from ``R1/X1/C1``; ``LineCode`` -> std_type
     * Line (switch / 0 km) -> ``switch``: open status respected
+    * Reactor (series, bus-to-bus) -> ``line``: fixed impedance from ``R``/``X``;
+      a shunt reactor (single bus) is not a branch and is skipped
     * Transformer (2W) -> ``trafo``: imported at the solved tap
     * Transformer (3W CT) -> ``trafo``: center-tapped split-phase mapped to a 2W equivalent
     * Load -> ``load``: kW/kvar -> p_mw/q_mvar
@@ -204,6 +207,7 @@ def from_opendss(path: str, solve: bool=True):
 
     _add_source(net, bus_map, report)
     _add_lines(net, bus_map, report)
+    _add_reactors(net, bus_map, report)
     _add_transformers(net, bus_map, report)
     _add_loads(net, bus_map, report)
     _add_capacitors(net, bus_map, report)
@@ -303,6 +307,44 @@ def _add_lines(net, bus_map, report):
         )
         report.n_lines += 1
         i = dss.Lines.Next()
+
+
+def _add_reactors(net, bus_map, report):
+    """Series (bus-to-bus) Reactor elements as a fixed-impedance pandapower line.
+
+    Some feeder libraries (e.g. EPRI's Ckt5/Ckt7 test circuits) model the
+    substation's Thevenin-equivalent source impedance as a ``Reactor`` between
+    ``SourceBus`` and the feeder head bus rather than a ``Transformer`` -- this
+    picks that pattern up as an ordinary series impedance so the link is
+    carried into the pandapower net. A shunt reactor (single bus, to ground)
+    is a different physical element (not a branch) and is out of scope here.
+    """
+    i = dss.Reactors.First()
+    while i:
+        name = dss.Reactors.Name()
+        dss.Circuit.SetActiveElement("Reactor." + name)
+        buses = dss.CktElement.BusNames()
+        if len(buses) < 2 or _busname(buses[0]) == _busname(buses[1]):
+            report.warn(f"reactor {name!r} is a shunt (single bus); skipped")
+            i = dss.Reactors.Next()
+            continue
+
+        f = bus_map.get(_busname(buses[0]))
+        t = bus_map.get(_busname(buses[1]))
+        if f is None or t is None:
+            report.warn(f"reactor {name!r} references an unknown bus; skipped")
+            i = dss.Reactors.Next()
+            continue
+
+        max_i_ka = dss.CktElement.NormalAmps() / 1000.0
+        pp.create_line_from_parameters(
+            net, from_bus=f, to_bus=t, length_km=1.0,
+            r_ohm_per_km=dss.Reactors.R(), x_ohm_per_km=dss.Reactors.X(), c_nf_per_km=0.0,
+            max_i_ka=max_i_ka if max_i_ka > 0 else 10.0,
+            name=name,
+        )
+        report.n_reactors += 1
+        i = dss.Reactors.Next()
 
 
 def _add_transformers(net, bus_map, report):

--- a/pandapower/test/converter/test_from_opendss.py
+++ b/pandapower/test/converter/test_from_opendss.py
@@ -186,6 +186,31 @@ def one_wire_matrix_net(tmp_path):
     return from_opendss(str(p))
 
 
+# A series Reactor bridging sourcebus to the rest of the feeder -- some feeder
+# libraries (e.g. EPRI's Ckt5/Ckt7) model the substation's Thevenin-equivalent
+# source impedance this way rather than as a Transformer. A shunt reactor
+# (single bus, to ground) is a different element and must be skipped, not
+# misread as a second bus-to-bus branch.
+REACTOR_FEEDER = """
+clear
+new circuit.rx basekv=12.47 pu=1.05 phases=3 bus1=sourcebus
+new reactor.subrx bus1=sourcebus bus2=head phases=3 r=0.01 x=5.0
+new reactor.shuntrx bus1=head phases=3 kvar=100
+new line.l1 bus1=head bus2=b1 r1=0.1 x1=0.2 c1=0 length=1.0 units=km normamps=400 phases=3
+new load.load1 bus1=b1 phases=3 kv=12.47 kw=500 kvar=150
+set voltagebases=[12.47]
+calcvoltagebases
+solve
+"""
+
+
+@pytest.fixture
+def reactor_net(tmp_path):
+    p = tmp_path / "rx.dss"
+    p.write_text(REACTOR_FEEDER)
+    return from_opendss(str(p))
+
+
 def test_element_counts(net):
     assert len(net.bus) == 4          # sourcebus, b1, b2, b3
     assert len(net.line) == 2         # l1, l2
@@ -314,3 +339,32 @@ def test_three_and_one_wire_matrix_feeders_converge(three_wire_matrix_net, one_w
     assert three_wire_matrix_net["converged"]
     pp.runpp(one_wire_matrix_net)
     assert one_wire_matrix_net["converged"]
+
+
+def test_series_reactor_imported_as_a_branch(reactor_net):
+    # subrx bridges sourcebus->head; one series reactor -> one extra line
+    # (l1 is the only OTHER line), and the shunt reactor must not add a second.
+    assert reactor_net["opendss_import"]["n_reactors"] == 1
+    assert len(reactor_net.line) == 2  # l1 + the series reactor's branch
+    reactor_line = reactor_net.line[reactor_net.line["name"] == "subrx"].iloc[0]
+    assert reactor_line["r_ohm_per_km"] == pytest.approx(0.01, rel=1e-6)
+    assert reactor_line["x_ohm_per_km"] == pytest.approx(5.0, rel=1e-6)
+
+
+def test_shunt_reactor_is_skipped_not_misread_as_a_branch(reactor_net):
+    warnings = reactor_net["opendss_import"]["warnings"]
+    assert any("shuntrx" in w and "shunt" in w for w in warnings)
+
+
+def test_reactor_feeder_reaches_every_bus(reactor_net):
+    import pandapower.topology as top
+    assert top.unsupplied_buses(reactor_net) == set()
+
+
+def test_reactor_feeder_converges_with_real_voltage_drop(reactor_net):
+    pp.runpp(reactor_net)
+    assert reactor_net["converged"]
+    # without the series reactor, every bus would stay at exactly the source's
+    # 1.05 pu (no power flowing past sourcebus) -- guard against that regression.
+    assert reactor_net.res_bus.vm_pu.nunique() > 1
+    assert reactor_net.res_bus.vm_pu.min() < 1.05


### PR DESCRIPTION
Follow-up to #3056/#3058.

While test-importing a few more real feeder libraries for validation beyond the four families in the original PR, I ran EPRI's Ckt5/Ckt7 test circuits through `from_opendss`. EPRI models the substation's Thevenin-equivalent source impedance as a bus-to-bus `Reactor` (`SourceBus` -> feeder head) rather than a `Transformer` -- a topology the converter didn't cover yet, so that link was silently absent from the resulting net.

### What this adds

- `_add_reactors`: a series (two-bus) `Reactor` is imported as a fixed-impedance `line` (R/X from `dss.Reactors.R()`/`X()`, rated at `CktElement.NormalAmps()`).
- A shunt reactor (single bus, to ground) is a different physical element (not a branch), so it's recognized and skipped with a warning rather than misread as a second branch.
- `net["opendss_import"]["n_reactors"]` added to the report, alongside the existing element counts.

### Changes

- `pandapower/converter/opendss/from_dss.py` -- `_add_reactors`, wired into `from_opendss` right after `_add_lines`.
- `pandapower/test/converter/test_from_opendss.py` -- 4 new inline-feeder tests (series reactor imported as a branch, shunt reactor skipped, full feeder reachability, and a converging power flow with real voltage drop).
- `CHANGELOG.rst` + `doc/converter/opendss.rst` updated.

All 19 tests in the module pass locally (15 existing + 4 new).