### PR TITLE
fix(opendss): restore OpenDSSDirect.py as a dev dependency

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Change Log
 
 [upcoming release] - 2026-..-..
 -------------------------------
+- [FIXED] restored ``OpenDSSDirect.py`` to the ``all``/``dev`` extras so the OpenDSS converter is exercised (and its coverage reported) in CI again; it was dropped in #3062 because installing it alongside ``pytest~=9.1`` crashes the pytest process on Windows (upstream bug, see `dss-extensions/OpenDSSDirect.py#148 <https://github.com/dss-extensions/OpenDSSDirect.py/issues/148>`_). The OpenDSS converter tests now skip on Windows instead of crashing the run; Linux/macOS are unaffected.
 - [ADDED] OpenDSS converter: series (bus-to-bus) ``Reactor`` elements are now imported as a fixed-impedance ``line``, the pattern some feeder libraries (e.g. EPRI's Ckt5/Ckt7) use to model the substation's Thevenin-equivalent source impedance instead of a ``Transformer``.
 
 [3.5.4] - 2026-07-08

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Change Log
 
 [upcoming release] - 2026-..-..
 -------------------------------
-- [FIXED] restored ``OpenDSSDirect.py`` to the ``all``/``dev`` extras so the OpenDSS converter is exercised (and its coverage reported) in CI again; it was dropped in #3062 because installing it alongside ``pytest~=9.1`` crashes the pytest process on Windows (upstream bug, see `dss-extensions/OpenDSSDirect.py#148 <https://github.com/dss-extensions/OpenDSSDirect.py/issues/148>`_). The OpenDSS converter tests now skip on Windows instead of crashing the run; Linux/macOS are unaffected.
+- [FIXED] restored ``OpenDSSDirect.py`` to the ``all``/``dev`` extras so the OpenDSS converter is exercised (and its coverage reported) in CI again; it was dropped in #3062 because installing it alongside ``pytest~=9.1`` crashed the pytest process on Windows. Root cause (see `dss-extensions/OpenDSSDirect.py#148 <https://github.com/dss-extensions/OpenDSSDirect.py/issues/148>`_): pytest enables Python's ``faulthandler`` by default, which intercepts a first-chance Windows structured exception that OpenDSSDirect.py's native backend raises -- and normally handles itself -- during import, and misreports it as fatal. Bracketing the import with ``faulthandler.disable()``/``.enable()`` avoids the false crash while leaving ``faulthandler`` protecting the rest of the test run; the converter now runs on Windows instead of merely skipping there.
 - [ADDED] OpenDSS converter: series (bus-to-bus) ``Reactor`` elements are now imported as a fixed-impedance ``line``, the pattern some feeder libraries (e.g. EPRI's Ckt5/Ckt7) use to model the substation's Thevenin-equivalent source impedance instead of a ``Transformer``.
 
 [3.5.4] - 2026-07-08

--- a/pandapower/converter/opendss/from_dss.py
+++ b/pandapower/converter/opendss/from_dss.py
@@ -19,6 +19,7 @@
 # The circuit is read through the ``OpenDSSDirect.py`` API (lazy-imported), not a
 # text parser, so every OpenDSS-supported master file is understood.
 
+import faulthandler
 import logging
 import math
 from dataclasses import dataclass, field
@@ -28,7 +29,22 @@ import numpy as np
 import pandapower as pp
 
 try:
-    import opendssdirect as dss
+    # On Windows, OpenDSSDirect.py's native backend (dss_python_backend) raises an
+    # internal, first-chance structured exception during its own startup -- one its
+    # Free Pascal runtime normally handles and silences itself. If a Windows crash
+    # handler is already installed (as Python's faulthandler does, and pytest enables
+    # faulthandler by default), it intercepts that exception first and misreports it
+    # as fatal, killing the whole process instead of a clean ImportError. Disable
+    # faulthandler for just this import, then restore it -- it's still needed to
+    # catch genuine crashes elsewhere. See
+    # https://github.com/dss-extensions/OpenDSSDirect.py/issues/148
+    faulthandler_was_enabled = faulthandler.is_enabled()
+    faulthandler.disable()
+    try:
+        import opendssdirect as dss
+    finally:
+        if faulthandler_was_enabled:
+            faulthandler.enable()
 
     opendssdirect_imported = True
 except ImportError:

--- a/pandapower/test/converter/test_from_opendss.py
+++ b/pandapower/test/converter/test_from_opendss.py
@@ -12,27 +12,27 @@ OpenDSS per-bus voltage to a tight tolerance -- exactly what the positive-sequen
 import promises for symmetric feeders.
 """
 
-import sys
+import faulthandler
 
 import numpy as np
 import pytest
 
 import pandapower as pp
 
-# On Windows, OpenDSSDirect.py's native backend crashes the whole pytest process
-# (not a catchable ImportError) when it is loaded through pytest's import machinery,
-# even though a plain `python -c "import opendssdirect"` works fine there. Skip
-# before even attempting the import on that platform.
-# See https://github.com/dss-extensions/OpenDSSDirect.py/issues/148
-if sys.platform.startswith("win"):
-    pytest.skip(
-        "OpenDSSDirect.py crashes the pytest process on Windows, see "
-        "https://github.com/dss-extensions/OpenDSSDirect.py/issues/148",
-        allow_module_level=True,
-    )
-
-# OpenDSSDirect.py is an optional dependency; skip the whole module without it.
-pytest.importorskip("opendssdirect")
+# pytest enables faulthandler by default, which on Windows intercepts a first-chance
+# structured exception that OpenDSSDirect.py's native backend raises (and normally
+# handles itself) during import -- see pandapower/converter/opendss/from_dss.py for
+# the full explanation and https://github.com/dss-extensions/OpenDSSDirect.py/issues/148.
+# Disable faulthandler for this pre-flight import check the same way, so it doesn't
+# crash here before from_dss's own guarded import ever runs.
+faulthandler_was_enabled = faulthandler.is_enabled()
+faulthandler.disable()
+try:
+    # OpenDSSDirect.py is an optional dependency; skip the whole module without it.
+    pytest.importorskip("opendssdirect")
+finally:
+    if faulthandler_was_enabled:
+        faulthandler.enable()
 
 from pandapower.converter.opendss import from_opendss
 

--- a/pandapower/test/converter/test_from_opendss.py
+++ b/pandapower/test/converter/test_from_opendss.py
@@ -12,10 +12,24 @@ OpenDSS per-bus voltage to a tight tolerance -- exactly what the positive-sequen
 import promises for symmetric feeders.
 """
 
+import sys
+
 import numpy as np
 import pytest
 
 import pandapower as pp
+
+# On Windows, OpenDSSDirect.py's native backend crashes the whole pytest process
+# (not a catchable ImportError) when it is loaded through pytest's import machinery,
+# even though a plain `python -c "import opendssdirect"` works fine there. Skip
+# before even attempting the import on that platform.
+# See https://github.com/dss-extensions/OpenDSSDirect.py/issues/148
+if sys.platform.startswith("win"):
+    pytest.skip(
+        "OpenDSSDirect.py crashes the pytest process on Windows, see "
+        "https://github.com/dss-extensions/OpenDSSDirect.py/issues/148",
+        allow_module_level=True,
+    )
 
 # OpenDSSDirect.py is an optional dependency; skip the whole module without it.
 pytest.importorskip("opendssdirect")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ typing = [
 ]
 
 #all = ["pandapower[plotting,performance,fileio,converter,pgm,control,helm,opendss]"]
-all = ["pandapower[plotting,performance,fileio,converter,pgm,control]"]
+all = ["pandapower[plotting,performance,fileio,converter,pgm,control,opendss]"]
 dev = ["pandapower[all,docs,test,typing,pandamodels,tutorials]"]
 # "shapely", "pyproj", "Pyogrio" are dependencies of geopandas and should be already available ("Fiona" got dropped)
 # "hashlib", "zlib", "base64" produce install problems, so they are not included


### PR DESCRIPTION
## Summary
- Restores `OpenDSSDirect.py` to the `all`/`dev` extras in `pyproject.toml`, dropped in #3062 because installing it alongside `pytest~=9.1` crashes the pytest process on Windows. Without it, the OpenDSS converter (#3056, #3067, #3074) has had 0% patch coverage in CI, since `opendssdirect` was never installed to exercise it.
- **Fixes the actual crash** (not a skip): `pandapower/converter/opendss/from_dss.py` and the test module now bracket the `opendssdirect` import with `faulthandler.disable()`/`.enable()`.

## Root cause
Traced on a real `windows-latest` GitHub Actions runner (throwaway diagnostic branch, since removed): `dss_python_backend` (OpenDSSDirect.py's Free-Pascal-compiled native backend) raises an internal, first-chance Windows structured exception during its own module init — one its own Pascal runtime normally catches and handles silently as part of normal startup. `pytest` enables Python's `faulthandler` by default, which installs a Windows vectored exception handler that intercepts that first-chance exception *before* the Pascal runtime's own handler gets it, and reports it as a fatal crash (`Windows fatal exception: code 0xe0465043`) — killing the whole process instead of a clean, catchable `ImportError`. A plain `python -c "import opendssdirect"` never enables faulthandler, so it never sees this, exactly matching the upstream report (dss-extensions/OpenDSSDirect.py#148) that a REPL import works fine but pytest crashes.

Confirmed empirically, both isolated and end-to-end, on `windows-latest`:
- `pytest` with the default `faulthandler` plugin: reproduces the crash every time.
- `pytest -p no:faulthandler`: completely clean, no exception, test passes.
- The proposed fix (bracket only the import with `faulthandler.disable()`/`.enable()`, faulthandler plugin left on for everything else): clean pass, no exception.
- Sanity check: after re-enabling faulthandler post-import, a real segfault elsewhere in the same process is still caught and reported correctly — the fix doesn't blind pytest to genuine crashes.
- **End-to-end**: the actual, unmodified `pandapower/test/converter/test_from_opendss.py` — not a hand-rolled repro — run against a real `pandapower[dev]` install on `windows-latest`: **19 passed**, no skip, no crash.

## Test plan
- [x] `pytest pandapower/test/converter/test_from_opendss.py` passes locally with `opendssdirect.py` installed (Linux, Python 3.14.6) — 19/19
- [x] Real end-to-end run of the unmodified test file on `windows-latest` with `uv sync --extra dev` (this PR's actual `pyproject.toml` + code) — 19/19, no skip, no crash
- [x] Sanity check that `faulthandler` still catches a genuine segfault after being re-enabled
- [x] This repo's own CI (Linux-only for the PR-gating pipeline) — should now actually exercise the OpenDSS converter and report real coverage instead of 0%

cc @vogt31337