### PR TITLE
Feature/improved tag group validation

### DIFF
--- a/pandapower/create/_utils.py
+++ b/pandapower/create/_utils.py
@@ -76,8 +76,11 @@ def add_tag_group_to_df(net: ADict, table_name: str, tag_name: str) -> None:
         col_info = get_column_info(table_name, col_name)
         if col_info is None:
             logger.warning(f"could not get column information for {table_name}.{col_name}")
-
-        if tag_name in col_info["metadata"]:
+            continue
+        col_metadata = col_info["metadata"]
+        if col_metadata is None:
+            continue
+        if tag_name in col_metadata:
             add_column_to_df(net, table_name, col_name)
 
 

--- a/pandapower/create/_utils.py
+++ b/pandapower/create/_utils.py
@@ -21,7 +21,7 @@ from pandapower.auxiliary import (
 )
 from pandapower.network import pandapowerNet, ADict
 from pandapower.pp_types import Int
-from pandapower.network_structure import get_structure_dict, get_column_info
+from pandapower.network_structure import get_structure_dict, get_column_info, get_default_value
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +52,11 @@ def add_column_to_df(net: ADict, table_name: str, column_name: str) -> None:
     # Add Optional Column:
     net_struct_dict = get_structure_dict(False)
     dtype = net_struct_dict[table_name][column_name]
-    net[table_name][column_name] = pd.Series(dtype=dtype)
+    default_value = get_default_value(table_name, column_name)
+    if net[table_name].empty:
+        net[table_name][column_name] = pd.Series(dtype=dtype)
+    else:  # only add value if table is not empty otherwise a single entry will be generated
+        net[table_name][column_name] = pd.Series(default_value, dtype=dtype)
     # Ensure column order:
     desired_order = list(net_struct_dict[table_name].keys())
     struct_columns = [col for col in desired_order if col in net[table_name].columns]

--- a/pandapower/network_schema/bus.py
+++ b/pandapower/network_schema/bus.py
@@ -22,7 +22,7 @@ _bus_columns = {
     ),
     "max_vm_pu": pa.Column(
         float,
-        pa.Check.gt(0),
+        pa.Check.le(2),
         nullable=False,
         required=False,
         description="Maximum voltage",
@@ -45,10 +45,18 @@ _bus_columns = {
         metadata={"cim": True},
     ),
     "origin_id": pa.Column(
-        pd.StringDtype, nullable=True, required=False, description="element rdfId from CIM", metadata={"cim": True, "doc": False}
+        pd.StringDtype,
+        nullable=True,
+        required=False,
+        description="element rdfId from CIM",
+        metadata={"cim": True, "doc": False},
     ),
     "origin_class": pa.Column(
-        pd.StringDtype, nullable=True, required=False, description="origin_class rdfId from CIM", metadata={"cim": True, "doc": False}
+        pd.StringDtype,
+        nullable=True,
+        required=False,
+        description="origin_class rdfId from CIM",
+        metadata={"cim": True, "doc": False},
     ),
     "origin_profile": pa.Column(
         pd.StringDtype,

--- a/pandapower/network_schema/bus.py
+++ b/pandapower/network_schema/bus.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import create_column_dependency_checks_from_metadata
 from pandapower.network_schema.tools.validation.column_condition import create_lower_equals_column_check
 
 _bus_columns = {
@@ -139,10 +138,7 @@ _bus_columns = {
 bus_schema = pa.DataFrameSchema(
     _bus_columns,
     name="bus",
-    checks=[
-        *create_column_dependency_checks_from_metadata(["opf"], _bus_columns),
-        create_lower_equals_column_check(first_element="min_vm_pu", second_element="max_vm_pu"),
-    ],
+    checks=[create_lower_equals_column_check(first_element="min_vm_pu", second_element="max_vm_pu")],
     strict=False,
 )
 

--- a/pandapower/network_schema/bus_dc.py
+++ b/pandapower/network_schema/bus_dc.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import create_column_dependency_checks_from_metadata
-
 _bus_dc_columns = {
     "name": pa.Column(pd.StringDtype, nullable=True, required=False, description="name of the dc bus"),
     "vn_kv": pa.Column(float, pa.Check.gt(0), description="rated voltage of the dc bus [kV]"),
@@ -39,7 +37,6 @@ _bus_dc_columns = {
 bus_dc_schema = pa.DataFrameSchema(
     _bus_dc_columns,
     name="bus_dc",
-    checks=create_column_dependency_checks_from_metadata(["opf"], _bus_dc_columns),
     strict=False,
 )
 

--- a/pandapower/network_schema/bus_dc.py
+++ b/pandapower/network_schema/bus_dc.py
@@ -1,6 +1,8 @@
 import pandas as pd
 import pandera.pandas as pa
 
+from pandapower.network_schema.tools.validation.column_condition import create_lower_equals_column_check
+
 _bus_dc_columns = {
     "name": pa.Column(pd.StringDtype, nullable=True, required=False, description="name of the dc bus"),
     "vn_kv": pa.Column(float, pa.Check.gt(0), description="rated voltage of the dc bus [kV]"),
@@ -21,6 +23,7 @@ _bus_dc_columns = {
     "geo": pa.Column(pd.StringDtype, nullable=True, required=False, description="geojson.Point as object or string"),
     "max_vm_pu": pa.Column(
         float,
+        pa.Check.le(2),
         nullable=True,
         required=False,
         description="Maximum dc bus voltage in p.u. - necessary for OPF",
@@ -28,6 +31,7 @@ _bus_dc_columns = {
     ),
     "min_vm_pu": pa.Column(
         float,
+        pa.Check.ge(0),
         nullable=True,
         required=False,
         description="Minimum dc bus voltage in p.u. - necessary for OPF",
@@ -37,6 +41,7 @@ _bus_dc_columns = {
 bus_dc_schema = pa.DataFrameSchema(
     _bus_dc_columns,
     name="bus_dc",
+    checks=create_lower_equals_column_check(first_element="min_vm_pu", second_element="max_vm_pu"),
     strict=False,
 )
 

--- a/pandapower/network_schema/dcline.py
+++ b/pandapower/network_schema/dcline.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import create_column_dependency_checks_from_metadata
-
 _dcline_columns = {
     "name": pa.Column(
         pd.StringDtype, nullable=True, required=False, description="name of the generator", metadata={"cim": True}
@@ -101,7 +99,6 @@ _dcline_columns = {
 }
 dcline_schema = pa.DataFrameSchema(
     _dcline_columns,
-    checks=create_column_dependency_checks_from_metadata(["opf"], _dcline_columns),
     name="dcline",
     strict=False,
 )

--- a/pandapower/network_schema/ext_grid.py
+++ b/pandapower/network_schema/ext_grid.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import create_column_dependency_checks_from_metadata
-
 _ext_grid_columns = {
     "name": pa.Column(
         pd.StringDtype, nullable=True, required=False, description="name of the external grid", metadata={"cim": True}
@@ -149,7 +147,6 @@ ext_grid_schema = pa.DataFrameSchema(
     _ext_grid_columns,
     name="ext_grid",
     strict=False,
-    checks=create_column_dependency_checks_from_metadata(["opf", "sc", "3ph"], _ext_grid_columns),
 )
 
 res_ext_grid_schema = pa.DataFrameSchema(

--- a/pandapower/network_schema/gen.py
+++ b/pandapower/network_schema/gen.py
@@ -2,7 +2,6 @@ import pandas as pd
 import pandera.pandas as pa
 
 from pandapower.network_schema.tools.validation.column_condition import create_lower_equals_column_check
-from pandapower.network_schema.tools.validation.group_dependency import create_column_dependency_checks_from_metadata
 
 _gen_columns = {
     "name": pa.Column(
@@ -202,18 +201,12 @@ _gen_columns = {
         metadata={"cim": True, "doc": False},
     ),
 }
-gen_checks = create_column_dependency_checks_from_metadata(
-    [
-        "opf",
-        # "sc",
-        "q_lim_enforced",
-        "qcc",
-    ],
-    _gen_columns,
-)
-gen_checks.append(create_lower_equals_column_check(first_element="min_q_mvar", second_element="max_q_mvar"))
-gen_checks.append(create_lower_equals_column_check(first_element="min_p_mw", second_element="max_p_mw"))
-gen_checks.append(create_lower_equals_column_check(first_element="min_vm_pu", second_element="max_vm_pu"))
+
+gen_checks = [
+    create_lower_equals_column_check(first_element="min_q_mvar", second_element="max_q_mvar"),
+    create_lower_equals_column_check(first_element="min_p_mw", second_element="max_p_mw"),
+    create_lower_equals_column_check(first_element="min_vm_pu", second_element="max_vm_pu"),
+]
 gen_schema = pa.DataFrameSchema(
     _gen_columns,
     name="gen",

--- a/pandapower/network_schema/line.py
+++ b/pandapower/network_schema/line.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import create_column_dependency_checks_from_metadata
-
 _line_columns = {
     "name": pa.Column(
         pd.StringDtype,
@@ -244,15 +242,6 @@ line_schema = pa.DataFrameSchema(
     _line_columns,
     name="line",
     strict=False,
-    checks=create_column_dependency_checks_from_metadata(
-        [
-            "opf",
-            # "sc",
-            "tdpf",
-            # "3ph",
-        ],
-        _line_columns,
-    ),
 )
 
 res_line_schema = res_line_est_schema = pa.DataFrameSchema(

--- a/pandapower/network_schema/line_dc.py
+++ b/pandapower/network_schema/line_dc.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import create_column_dependency_checks_from_metadata
-
 _line_dc_columns = {
     "name": pa.Column(pd.StringDtype, nullable=True, required=False, description="name of the dc line"),
     "std_type": pa.Column(
@@ -151,7 +149,6 @@ _line_dc_columns = {
 }
 line_dc_schema = pa.DataFrameSchema(
     _line_dc_columns,
-    checks=create_column_dependency_checks_from_metadata(["tdpf"], _line_dc_columns),
     name="line_dc",
     strict=False,
 )

--- a/pandapower/network_schema/load.py
+++ b/pandapower/network_schema/load.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import create_column_dependency_checks_from_metadata
-
 _load_columns = {
     "name": pa.Column(
         pd.StringDtype, nullable=True, required=False, description="name of the load", metadata={"cim": True}
@@ -101,7 +99,6 @@ _load_columns = {
 }
 load_schema = pa.DataFrameSchema(
     _load_columns,
-    checks=create_column_dependency_checks_from_metadata(["zip"], _load_columns),
     name="load",
     strict=False,
 )

--- a/pandapower/network_schema/motor.py
+++ b/pandapower/network_schema/motor.py
@@ -44,14 +44,14 @@ _motor_columns = {
         pa.Check.ge(0),
         required=False,
         description="locked rotor current in relation to the rated motor current [pu]",
-        metadata={"sc": True},
+        metadata={"sc": True, "cim": True},
     ),
     "rx": pa.Column(
         float,
         pa.Check.ge(0),
         required=False,
         description="R/X ratio of the motor for short-circuit calculation.",
-        metadata={"sc": True},
+        metadata={"sc": True, "cim": True},
     ),
     "vn_kv": pa.Column(
         float,

--- a/pandapower/network_schema/motor.py
+++ b/pandapower/network_schema/motor.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import create_column_dependency_checks_from_metadata
-
 _motor_columns = {
     "name": pa.Column(
         pd.StringDtype, nullable=True, required=False, description="name of the motor", metadata={"cim": True}
@@ -86,7 +84,6 @@ _motor_columns = {
 }
 motor_schema = pa.DataFrameSchema(
     _motor_columns,
-    checks=create_column_dependency_checks_from_metadata(["sc"], _motor_columns),
     name="motor",
     strict=False,
 )

--- a/pandapower/network_schema/motor.py
+++ b/pandapower/network_schema/motor.py
@@ -13,9 +13,9 @@ _motor_columns = {
     "cos_phi_n": pa.Column(
         float,
         pa.Check.between(min_value=0, max_value=1),
-        nullable=True,
+        required=False,
         description="cosine phi at rated power of the motor for short-circuit calculation",
-        metadata={"sc": True},
+        metadata={"sc": True, "cim": True},
     ),
     "efficiency_percent": pa.Column(
         float,
@@ -26,9 +26,9 @@ _motor_columns = {
     "efficiency_n_percent": pa.Column(
         float,
         pa.Check.between(min_value=0, max_value=100),
-        nullable=True,
+        required=False,
         description="Efficiency in percent at rated power for short-circuit calculation [%]",
-        metadata={"sc": True},
+        metadata={"sc": True, "cim": True},
     ),
     "loading_percent": pa.Column(
         float,
@@ -42,30 +42,38 @@ _motor_columns = {
     "lrc_pu": pa.Column(
         float,
         pa.Check.ge(0),
-        nullable=True,
+        required=False,
         description="locked rotor current in relation to the rated motor current [pu]",
         metadata={"sc": True},
     ),
     "rx": pa.Column(
         float,
         pa.Check.ge(0),
-        nullable=True,
+        required=False,
         description="R/X ratio of the motor for short-circuit calculation.",
         metadata={"sc": True},
     ),
     "vn_kv": pa.Column(
         float,
         pa.Check.ge(0),
-        nullable=True,
+        required=False,
         description="Rated voltage of the motor for short-circuit calculation",
-        metadata={"sc": True},
+        metadata={"sc": True, "cim": True},
     ),
     "in_service": pa.Column(bool, description="specifies if the motor is in service.", metadata={"default": True}),
     "origin_id": pa.Column(
-        pd.StringDtype, nullable=True, required=False, description="element rdfId from CIM", metadata={"cim": True, "doc": False}
+        pd.StringDtype,
+        nullable=True,
+        required=False,
+        description="element rdfId from CIM",
+        metadata={"cim": True, "doc": False},
     ),
     "origin_class": pa.Column(
-        pd.StringDtype, nullable=True, required=False, description="origin_class rdfId from CIM", metadata={"cim": True, "doc": False}
+        pd.StringDtype,
+        nullable=True,
+        required=False,
+        description="origin_class rdfId from CIM",
+        metadata={"cim": True, "doc": False},
     ),
     "terminal": pa.Column(
         pd.StringDtype,

--- a/pandapower/network_schema/sgen.py
+++ b/pandapower/network_schema/sgen.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import create_column_dependency_checks_from_metadata
-
 _sgen_columns = {
     "name": pa.Column(
         pd.StringDtype,
@@ -205,14 +203,6 @@ sgen_schema = pa.DataFrameSchema(
     _sgen_columns,
     name="sgen",
     strict=False,
-    checks=create_column_dependency_checks_from_metadata(
-        [
-            "opf",
-            # "sc",
-            "qcc",
-        ],
-        _sgen_columns,
-    ),
 )
 
 res_sgen_schema = res_sgen_3ph_schema = pa.DataFrameSchema(

--- a/pandapower/network_schema/storage.py
+++ b/pandapower/network_schema/storage.py
@@ -1,8 +1,6 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import create_column_dependency_checks_from_metadata
-
 _storage_columns = {
     "name": pa.Column(pd.StringDtype, nullable=True, required=False, description="Name of the storage unit"),
     "bus": pa.Column(int, pa.Check.ge(0), description="Index of connected bus", metadata={"foreign_key": "bus.index"}),
@@ -80,7 +78,6 @@ _storage_columns = {
 }
 storage_schema = pa.DataFrameSchema(
     _storage_columns,
-    checks=create_column_dependency_checks_from_metadata(["opf"], _storage_columns),
     name="storage",
     strict=False,
 )

--- a/pandapower/network_schema/tools/validation/network_validation.py
+++ b/pandapower/network_schema/tools/validation/network_validation.py
@@ -11,7 +11,7 @@ from pandapower.network_schema.tools.validation.bus_index_validation import _bus
 logger = logging.getLogger()
 
 
-def validate_network(net: pandapowerNet):
+def validate_network(net: pandapowerNet, groups_to_validate: str | set[str] | None = None):
     """
     Validate pandapower network element dataframes using schemas from the schema folder.
 
@@ -24,12 +24,17 @@ def validate_network(net: pandapowerNet):
 
     1. Dynamic import of element-specific schema modules
     2. Schema validation of dataframe structure and data types
-    3. Bus index dependency validation for network consistency
+    3. Optional group dependency validation (e.g., opf, sc, 3ph)
+    4. Bus index dependency validation for network consistency
 
     Args:
         net (pandapowerNet): A pandapower network object containing various
                            electrical network elements (buses, lines, loads, etc.)
                            to be validated.
+        groups_to_validate (str | list[str] | None): Optional group(s) to validate.
+            If provided, validates the specified dependency groups in addition to
+            the base schema. Valid groups depend on the element schema (e.g., "opf",
+            "sc", "3ph" for ext_grid). If None, validates only the base schema.
 
     Raises:
         pa.errors.SchemaError: If validation fails for any network element.
@@ -42,12 +47,15 @@ def validate_network(net: pandapowerNet):
         - Elements without corresponding schema files are skipped
         - Missing or invalid schema modules are logged as warnings but don't raise exceptions
         - Bus index validation is performed after schema validation for each element
+        - When groups_to_validate is specified, validates the base schema AND the specified groups
 
     Example:
         >>> import pandapower as pp
         >>> net = pp.pandapowerNet(name="validate_network")
         >>> # ... populate network with elements
-        >>> validate_network(net)  # Validates all elements
+        >>> validate_network(net)  # Validates base schema only
+        >>> validate_network(net, groups_to_validate="sc")  # Validates + sc group
+        >>> validate_network(net, groups_to_validate=["sc", "3ph"])  # Validates + both groups
     """
 
     def _dynamic_import(element, schema_path):
@@ -64,22 +72,54 @@ def validate_network(net: pandapowerNet):
         loader.exec_module(schema_module)
         return schema_module
 
-    for element in net:
+    # Normalize groups_to_validate to a set
+    if groups_to_validate is None:
+        groups_set = None
+    elif isinstance(groups_to_validate, str):
+        groups_set = {
+            groups_to_validate,
+        }
+    else:
+        groups_set = groups_to_validate
+
+    for element in net.keys():
         schema_path = Path(Path(__file__).parents[2], f"{element}.py")
 
         if not os.path.exists(schema_path):
             continue
 
-        schema = getattr(_dynamic_import(element, schema_path), f"{element}_schema")
+        schema_module = _dynamic_import(element, schema_path)
+        if schema_module is None:
+            continue
 
+        schema = getattr(schema_module, f"{element}_schema", None)
         if schema is None:
             continue
 
-        # validate element schema
+        df = net[element]
+        reset_required: set[str] = set()
         try:
-            schema.validate(net[element])
+            if groups_set is not None:
+                # Get all group checks at once for all specified groups
+                cols = [
+                    name
+                    for name, col in schema.columns.items()
+                    if col.metadata is not None and list(groups_set & set(col.metadata.keys()))
+                ]
+                for col_name in cols:
+                    if not schema.columns[col_name].required:
+                        reset_required.add(col_name)
+                        schema.columns[col_name].required = True
+            schema.validate(df)
         except Exception as e:
-            raise pa.errors.SchemaError(data=e, message=f"Validation failed for {element}", schema=schema)
+            msg = f"Validation failed for {element}"
+            if groups_set is not None:
+                msg += f" (groups: {groups_set})"
+            raise pa.errors.SchemaError(data=e, message=msg, schema=schema)
+        finally:  # ensure the schema is reset even if exception is raised.
+            # reset the schema
+            for col_name in reset_required:
+                schema.columns[col_name].required = False
 
         # validate bus index dependency
         _bus_index_validation(element, schema, net)

--- a/pandapower/network_schema/trafo.py
+++ b/pandapower/network_schema/trafo.py
@@ -1,7 +1,10 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import create_column_group_dependency_validation_func
+from pandapower.network_schema.tools.validation.group_dependency import (
+    create_column_group_dependency_validation_func,
+    create_column_dependency_checks_from_metadata,
+)
 from pandapower.network_schema.tools.validation.column_condition import create_lower_than_column_check
 
 _trafo_columns = {
@@ -401,6 +404,7 @@ trafo_checks = [
         create_column_group_dependency_validation_func(tap2_columns),
         error=f"trafo tap2 configuration columns have dependency violations. Please ensure {tap2_columns} are present in the dataframe.",
     ),
+    *create_column_dependency_checks_from_metadata(["tdt"], _trafo_columns),
     create_lower_than_column_check(first_element="min_angle_degree", second_element="max_angle_degree"),
 ]
 trafo_schema = pa.DataFrameSchema(

--- a/pandapower/network_schema/trafo.py
+++ b/pandapower/network_schema/trafo.py
@@ -1,10 +1,7 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import (
-    create_column_group_dependency_validation_func,
-    create_column_dependency_checks_from_metadata,
-)
+from pandapower.network_schema.tools.validation.group_dependency import create_column_group_dependency_validation_func
 from pandapower.network_schema.tools.validation.column_condition import create_lower_than_column_check
 
 _trafo_columns = {
@@ -404,17 +401,8 @@ trafo_checks = [
         create_column_group_dependency_validation_func(tap2_columns),
         error=f"trafo tap2 configuration columns have dependency violations. Please ensure {tap2_columns} are present in the dataframe.",
     ),
+    create_lower_than_column_check(first_element="min_angle_degree", second_element="max_angle_degree"),
 ]
-trafo_checks += create_column_dependency_checks_from_metadata(
-    [
-        "opf",
-        # "sc",
-        # "3ph",
-        "tdt",
-    ],
-    _trafo_columns,
-)
-trafo_checks.append(create_lower_than_column_check(first_element="min_angle_degree", second_element="max_angle_degree"))
 trafo_schema = pa.DataFrameSchema(
     _trafo_columns,
     checks=trafo_checks,

--- a/pandapower/network_schema/trafo3w.py
+++ b/pandapower/network_schema/trafo3w.py
@@ -1,7 +1,10 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import create_column_group_dependency_validation_func
+from pandapower.network_schema.tools.validation.group_dependency import (
+    create_column_group_dependency_validation_func,
+    create_column_dependency_checks_from_metadata,
+)
 from pandapower.network_schema.tools.validation.column_condition import create_lower_than_column_check
 
 _trafo3w_columns = {
@@ -348,6 +351,7 @@ trafo3w_checks = [
         create_column_group_dependency_validation_func(tap_columns),
         error=f"trafo3w tap configuration columns have dependency violations. Please ensure {tap_columns} are present in the dataframe.",
     ),
+    *create_column_dependency_checks_from_metadata(["tdt"], _trafo3w_columns),
     create_lower_than_column_check(first_element="vkr_hv_percent", second_element="vk_hv_percent"),
     create_lower_than_column_check(first_element="vkr_mv_percent", second_element="vk_mv_percent"),
     create_lower_than_column_check(first_element="vkr_lv_percent", second_element="vk_lv_percent"),

--- a/pandapower/network_schema/trafo3w.py
+++ b/pandapower/network_schema/trafo3w.py
@@ -1,10 +1,7 @@
 import pandas as pd
 import pandera.pandas as pa
 
-from pandapower.network_schema.tools.validation.group_dependency import (
-    create_column_group_dependency_validation_func,
-    create_column_dependency_checks_from_metadata,
-)
+from pandapower.network_schema.tools.validation.group_dependency import create_column_group_dependency_validation_func
 from pandapower.network_schema.tools.validation.column_condition import create_lower_than_column_check
 
 _trafo3w_columns = {
@@ -351,18 +348,10 @@ trafo3w_checks = [
         create_column_group_dependency_validation_func(tap_columns),
         error=f"trafo3w tap configuration columns have dependency violations. Please ensure {tap_columns} are present in the dataframe.",
     ),
+    create_lower_than_column_check(first_element="vkr_hv_percent", second_element="vk_hv_percent"),
+    create_lower_than_column_check(first_element="vkr_mv_percent", second_element="vk_mv_percent"),
+    create_lower_than_column_check(first_element="vkr_lv_percent", second_element="vk_lv_percent"),
 ]
-trafo3w_checks += create_column_dependency_checks_from_metadata(
-    [
-        # "sc",
-        "tdt",
-        "opf",
-    ],
-    _trafo3w_columns,
-)
-trafo3w_checks.append(create_lower_than_column_check(first_element="vkr_hv_percent", second_element="vk_hv_percent"))
-trafo3w_checks.append(create_lower_than_column_check(first_element="vkr_mv_percent", second_element="vk_mv_percent"))
-trafo3w_checks.append(create_lower_than_column_check(first_element="vkr_lv_percent", second_element="vk_lv_percent"))
 trafo3w_schema = pa.DataFrameSchema(
     _trafo3w_columns,
     checks=trafo3w_checks,

--- a/pandapower/network_structure.py
+++ b/pandapower/network_structure.py
@@ -94,8 +94,15 @@ def get_column_info(table: str, column: str) -> dict[str, str | bool | dict] | N
 
 def get_default_value(table: str, column: str) -> Any:
     column_info: dict[str, Any] | None = get_column_info(table, column)
-    if column_info is not None and 'metadata' in column_info and 'default' in column_info['metadata']:
+    if (
+        column_info is not None
+        and "metadata" in column_info
+        and column_info["metadata"] is not None
+        and "default" in column_info["metadata"]
+    ):
         return column_info["metadata"]["default"]
+    if get_structure_dict(False)[table][column] in [float]:  # TODO: get this from the already present column_info?
+        return float("nan")
     return pd.NA
 
 def get_structure_dict(required_only: bool = True, metadata: list | None = None) -> dict:

--- a/pandapower/test/create/test_utils.py
+++ b/pandapower/test/create/test_utils.py
@@ -1,0 +1,25 @@
+from pandera.errors import SchemaError
+import pytest
+
+from pandapower.create._utils import add_tag_group_to_df
+from pandapower.network import pandapowerNet
+from pandapower.network_schema.tools.validation.network_validation import validate_network
+
+
+class TestAddTagGroupToDF:
+    def test_add_sc_group(self):
+        net = pandapowerNet(name="test_add_sc_group")
+        add_tag_group_to_df(net, "ext_grid", "sc")
+
+        validate_network(net)
+        with pytest.raises(SchemaError):
+            validate_network(net, "sc")
+
+        # add remaining sc columns
+        add_tag_group_to_df(net, "gen", "sc")
+        add_tag_group_to_df(net, "line", "sc")
+        add_tag_group_to_df(net, "sgen", "sc")
+        add_tag_group_to_df(net, "trafo", "sc")
+        add_tag_group_to_df(net, "trafo3w", "sc")
+
+        validate_network(net, "sc")

--- a/pandapower/test/create/test_utils.py
+++ b/pandapower/test/create/test_utils.py
@@ -18,6 +18,7 @@ class TestAddTagGroupToDF:
         # add remaining sc columns
         add_tag_group_to_df(net, "gen", "sc")
         add_tag_group_to_df(net, "line", "sc")
+        add_tag_group_to_df(net, "motor", "sc")
         add_tag_group_to_df(net, "sgen", "sc")
         add_tag_group_to_df(net, "trafo", "sc")
         add_tag_group_to_df(net, "trafo3w", "sc")

--- a/pandapower/test/network_schema/elements/test_pandera_bus_dc_elements.py
+++ b/pandapower/test/network_schema/elements/test_pandera_bus_dc_elements.py
@@ -7,6 +7,7 @@ import pandera as pa
 import pytest
 
 from pandapower.create import create_bus_dc
+from pandapower.create._utils import add_tag_group_to_df
 from pandapower.network import pandapowerNet
 from pandapower.network_schema.tools.validation.network_validation import validate_network
 from pandapower.test.network_schema.elements.helper import (
@@ -120,6 +121,12 @@ class TestBusDCOptionalFields:
     def test_invalid_optional_values(self, parameter, invalid_value):
         net = pandapowerNet(name="test_invalid_optional_values")
         create_bus_dc(net, vn_kv=1.0, in_service=True)
+
+        # for OPF columns, add group dependency so only target parameter triggers failure
+        #  otherwise the "min < max" check will fail.
+        if parameter in ["min_vm_pu", "max_vm_pu"]:
+            add_tag_group_to_df(net, "bus_dc", "opf")
+
         net.bus_dc[parameter] = invalid_value
 
         with pytest.raises(pa.errors.SchemaError):

--- a/pandapower/test/network_schema/elements/test_pandera_bus_elements.py
+++ b/pandapower/test/network_schema/elements/test_pandera_bus_elements.py
@@ -5,6 +5,7 @@ import pandera as pa
 import pytest
 
 from pandapower.create import create_bus
+from pandapower.create._utils import add_tag_group_to_df
 from pandapower.network import pandapowerNet
 from pandapower.network_schema.tools.validation.network_validation import validate_network
 from pandapower.test.network_schema.elements.helper import (
@@ -121,6 +122,12 @@ class TestBusOptionalFields:
         """Test: Invalid optional values are rejected"""
         net = pandapowerNet(name="test_invalid_optional_values")
         create_bus(net, 0.4)
+
+        # for OPF columns, add group dependency so only target parameter triggers failure
+        #  otherwise the "min < max" check will fail.
+        if parameter in ["min_vm_pu", "max_vm_pu"]:
+            add_tag_group_to_df(net, "bus", "opf")
+
         net.bus[parameter] = invalid_value
 
         with pytest.raises(pa.errors.SchemaError):

--- a/pandapower/test/network_schema/elements/test_pandera_ext_grid_elements.py
+++ b/pandapower/test/network_schema/elements/test_pandera_ext_grid_elements.py
@@ -204,7 +204,7 @@ class TestExtGridOptionalFields:
         net.ext_grid["max_p_mw"] = 100.0
 
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "opf")
 
     def test_sc_group_partial_missing_invalid(self):
         """Test: SC group must be complete if any SC value is set"""
@@ -216,7 +216,7 @@ class TestExtGridOptionalFields:
         net.ext_grid["s_sc_max_mva"] = 1000.0
 
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "sc")
 
     def test_3ph_group_partial_missing_invalid(self):
         """Test: 3PH group must be complete if any 3PH value is set (and SC group too)"""
@@ -228,7 +228,7 @@ class TestExtGridOptionalFields:
         net.ext_grid["rx_max"] = 0.4
 
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "3ph")
 
     @pytest.mark.parametrize(
         "parameter,invalid_value",

--- a/pandapower/test/network_schema/elements/test_pandera_gen_elements.py
+++ b/pandapower/test/network_schema/elements/test_pandera_gen_elements.py
@@ -281,7 +281,7 @@ class TestGenOptionalFields:
         net.gen["max_p_mw"] = 100.0
 
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "opf")
 
     def test_q_lim_enforced_group_partial_missing_invalid(self):
         """Test: q_lim_enforced group (max_q_mvar/min_q_mvar) must be complete"""
@@ -293,7 +293,7 @@ class TestGenOptionalFields:
         net.gen["max_q_mvar"] = 1.0
 
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "q_lim_enforced")
 
     def test_qcc_group_partial_missing_invalid(self):
         """Test: QCC group must be complete if any value is set"""
@@ -305,19 +305,19 @@ class TestGenOptionalFields:
         # id_q_capability_characteristic only
         net.gen["id_q_capability_characteristic"] = pd.Series([0], dtype="Int64")
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "qcc")
 
         # Reset and set only curve_style
         create_gen(net, bus=b0, p_mw=-1.0, vm_pu=0.5, scaling=1.0, in_service=True, slack=True)
         net.gen["curve_style"] = pd.Series(["straightLineYValues"], dtype="string")
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "qcc")
 
         # Reset and set only reactive_capability_curve
         create_gen(net, bus=b0, p_mw=-1.0, vm_pu=0.5, scaling=1.0, in_service=True, slack=True)
         net.gen["reactive_capability_curve"] = pd.Series([True], dtype="boolean")
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "qcc")
 
     @pytest.mark.parametrize(
         "parameter,invalid_value",

--- a/pandapower/test/network_schema/elements/test_pandera_line_dc_elements.py
+++ b/pandapower/test/network_schema/elements/test_pandera_line_dc_elements.py
@@ -239,11 +239,14 @@ class TestLineDcOptionalFields:
             df=0.5,
             in_service=True,
         )
-        net.line_dc["tdpf"] = pd.Series([True], dtype="boolean")
+        net.line_dc["tdpf"] = pd.Series([True], dtype=pd.BooleanDtype())
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "tdpf")
 
         # Case 2: one tdpf param only -> invalid
+        net = pandapowerNet(name="Case 2")
+        b0 = create_bus_dc(net, 0.4)
+        b1 = create_bus_dc(net, 0.4)
         create_line_dc_from_parameters(
             net,
             from_bus_dc=b0,
@@ -258,9 +261,12 @@ class TestLineDcOptionalFields:
         )
         net.line_dc["wind_speed_m_per_s"] = 3.0
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "tdpf")
 
         # Case 3: another tdpf param only -> invalid
+        net = pandapowerNet(name="Case 3")
+        b0 = create_bus_dc(net, 0.4)
+        b1 = create_bus_dc(net, 0.4)
         create_line_dc_from_parameters(
             net,
             from_bus_dc=b0,
@@ -275,7 +281,7 @@ class TestLineDcOptionalFields:
         )
         net.line_dc["reference_temperature_degree_celsius"] = 20.0
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "tdpf")
 
     @pytest.mark.parametrize(
         "parameter,valid_value",

--- a/pandapower/test/network_schema/elements/test_pandera_line_elements.py
+++ b/pandapower/test/network_schema/elements/test_pandera_line_elements.py
@@ -207,7 +207,7 @@ class TestLineOptionalFields:
         create_line(net, from_bus=b0, to_bus=b1, length_km=1.0, in_service=True, std_type=STD_TYPE)
         net.line["tdpf"] = True
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "tdpf")
 
         # Case 2: one tdpf param only -> invalid
         net = pandapowerNet(name="test_tdpf_group_partial_missing_invalid1")
@@ -216,7 +216,7 @@ class TestLineOptionalFields:
         create_line(net, from_bus=b0, to_bus=b1, length_km=1.0, in_service=True, std_type=STD_TYPE)
         net.line["wind_speed_m_per_s"] = 3.0
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "tdpf")
 
         # Case 3: another tdpf param only -> invalid
         net = pandapowerNet(name="test_tdpf_group_partial_missing_invalid2")
@@ -225,8 +225,8 @@ class TestLineOptionalFields:
         create_line(net, from_bus=b0, to_bus=b1, length_km=1.0, in_service=True, std_type=STD_TYPE)
         net.line["reference_temperature_degree_celsius"] = 20.0
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
-        # TODO sc, 3ph not beeing checked in line.py
+            validate_network(net, "tdpf")
+        # TODO sc, 3ph not being checked in line.py
 
     @pytest.mark.parametrize(
         "parameter,valid_value",

--- a/pandapower/test/network_schema/elements/test_pandera_sgen_elements.py
+++ b/pandapower/test/network_schema/elements/test_pandera_sgen_elements.py
@@ -210,7 +210,7 @@ class TestSgenOptionalFields:
         # Set only one OPF column -> should fail
         net.sgen["max_p_mw"] = 100.0
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "opf")
 
     def test_qcc_group_partial_missing_invalid(self):
         # Only id_q_capability_characteristic
@@ -219,7 +219,7 @@ class TestSgenOptionalFields:
         create_sgen(net, bus=b0, p_mw=1.0, q_mvar=0.0, scaling=1.0, in_service=True)
         net.sgen["id_q_capability_characteristic"] = pd.Series([0], dtype="Int64")
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "qcc")
 
         # Only curve_style
         net = pandapowerNet(name="test_qcc_group_partial_missing_invalid1")
@@ -228,7 +228,7 @@ class TestSgenOptionalFields:
         create_sgen(net, bus=b0, p_mw=1.0, q_mvar=0.0, scaling=1.0, in_service=True)
         net.sgen["curve_style"] = pd.Series([pd.NA, "straightLineYValues"], dtype="string")
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "qcc")
 
         # Only reactive_capability_curve
         net = pandapowerNet(name="test_qcc_group_partial_missing_invalid2")
@@ -237,7 +237,7 @@ class TestSgenOptionalFields:
         create_sgen(net, bus=b0, p_mw=1.0, q_mvar=0.0, scaling=1.0, in_service=True)
         net.sgen["reactive_capability_curve"] = pd.Series([pd.NA, pd.NA, True], dtype="boolean")
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "qcc")
 
     @pytest.mark.parametrize(
         "parameter,invalid_value",

--- a/pandapower/test/network_schema/elements/test_pandera_storage_elements.py
+++ b/pandapower/test/network_schema/elements/test_pandera_storage_elements.py
@@ -137,7 +137,7 @@ class TestStorageOptionalFields:
         create_storage(net, bus=b0, p_mw=0.1, q_mvar=0.0, scaling=1.0, in_service=True, max_e_mwh=10.0)
         net.storage["max_p_mw"] = 1.0
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "opf")
 
         # Case 2: only controllable
         net = pandapowerNet(name="test_opf_group_partial_missing_invalid1")
@@ -145,7 +145,7 @@ class TestStorageOptionalFields:
         create_storage(net, bus=b0, p_mw=0.2, q_mvar=0.1, scaling=1.0, in_service=True, max_e_mwh=10.0)
         net.storage["controllable"] = pd.Series([True], dtype="boolean")
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "opf")
 
         # Case 3: only min_q_mvar
         net = pandapowerNet(name="test_opf_group_partial_missing_invalid2")
@@ -153,7 +153,7 @@ class TestStorageOptionalFields:
         create_storage(net, bus=b0, p_mw=-0.2, q_mvar=0.0, scaling=1.0, in_service=True, max_e_mwh=10.0)
         net.storage["min_q_mvar"] = -0.5
         with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
+            validate_network(net, "opf")
 
     @pytest.mark.parametrize(
         "parameter,valid_value",


### PR DESCRIPTION
- removed tag group checks from the pandera schema because they will require each other to be set.
- added tag group to validate network. When passing this will set them as required to all schema instead of being per schema.
- added a test for the `add_tag_group_to_df` function
- minor fixes to various helper functions.
- `add_column_to_df` will now correctly set the default value if the df is not empty

closes #3091 