### PR TITLE
docs: add LV Schutterwald network

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Change Log
 
 [upcoming release] - 2026-..-..
 -------------------------------
+- [FIXED] added the LV Schutterwald network to the network documentation.
 - [FIXED] restored ``OpenDSSDirect.py`` to the ``all``/``dev`` extras so the OpenDSS converter is exercised (and its coverage reported) in CI again; it was dropped in #3062 because installing it alongside ``pytest~=9.1`` crashed the pytest process on Windows. Root cause (see `dss-extensions/OpenDSSDirect.py#148 <https://github.com/dss-extensions/OpenDSSDirect.py/issues/148>`_): pytest enables Python's ``faulthandler`` by default, which intercepts a first-chance Windows structured exception that OpenDSSDirect.py's native backend raises -- and normally handles itself -- during import, and misreports it as fatal. Bracketing the import with ``faulthandler.disable()``/``.enable()`` avoids the false crash while leaving ``faulthandler`` protecting the rest of the test run; the converter now runs on Windows instead of merely skipping there.
 - [ADDED] OpenDSS converter: series (bus-to-bus) ``Reactor`` elements are now imported as a fixed-impedance ``line``, the pattern some feeder libraries (e.g. EPRI's Ckt5/Ckt7) use to model the substation's Thevenin-equivalent source impedance instead of a ``Transformer``.
 - [FIXED] impedance element docs: the ``z_tf`` equation used ``rft_pu`` instead of ``rtf_pu``, and the ``gt_pu``/``bt_pu``/``gt0_pu``/``bt0_pu`` shunt parameters were described as being at the ``from_bus`` instead of the ``to_bus``.

--- a/doc/networks.rst
+++ b/doc/networks.rst
@@ -8,10 +8,11 @@ Besides creating your own grids using pandapower functions, pandapower provides 
 benchmark grids through the networks module.
 
 The pandapower networks module contains example grids, simple test grids, randomly generated grids, CIGRE test grids,
-IEEE case files (including 3-phase grids) and synthetic low voltage grids from Georg Kerber, Lindner et. al. and Dickert
-et. al. If you want to evaluate your algorithms on benchmark grids with corresponding full-year load, generation, and
-storage profiles or want to publish your results in a reproducible manner, we recommend the SimBench repository
-(`SimBench Homepage <https://simbench.de/en/>`__, `SimBench GitHub Repository <https://github.com/e2nIEE/simbench>`__).
+IEEE case files (including 3-phase grids), the LV Schutterwald network and synthetic low voltage grids from Georg
+Kerber, Lindner et. al. and Dickert et. al. If you want to evaluate your algorithms on benchmark grids with
+corresponding full-year load, generation, and storage profiles or want to publish your results in a reproducible
+manner, we recommend the SimBench repository (`SimBench Homepage <https://simbench.de/en/>`__, `SimBench GitHub
+Repository <https://github.com/e2nIEE/simbench>`__).
 
 You can find documentation for the individual network modules of pandapower here:
 
@@ -22,6 +23,7 @@ You can find documentation for the individual network modules of pandapower here
     networks/test
     networks/cigre
     networks/mv_oberrhein
+    networks/lv_schutterwald
     networks/power_system_test_cases
     networks/kerber
     networks/synthetic_voltage_control_lv_networks

--- a/doc/networks/lv_schutterwald.rst
+++ b/doc/networks/lv_schutterwald.rst
@@ -1,0 +1,10 @@
+=======================
+LV Schutterwald Network
+=======================
+
+The LV Schutterwald network is a generic 0.4 kV network supplied by 14 MV/LV transformer stations of the
+Oberrhein network. It represents 1,506 customers and can optionally include 1,251 heat pumps from the
+`underlying study <https://doi.org/10.3390/en13164052>`_. The network also contains geographical information for
+its buses and lines and can be returned as 14 separate subnetworks.
+
+.. autofunction:: pandapower.networks.lv_schutterwald

--- a/pandapower/networks/lv_schutterwald.py
+++ b/pandapower/networks/lv_schutterwald.py
@@ -24,19 +24,16 @@ def lv_schutterwald(separation_by_sub=False, include_heat_pumps=False, **kwargs)
 
     Source: https://doi.org/10.3390/en13164052
 
-    OPTIONAL:
-        **separation_by_sub** - (bool, False): if True, the network gets separated into 14
-        sections, referring to their substations
+    Parameters:
+        separation_by_sub (bool, False): if True, returns the network as 14 separate sections,
+            one for each substation
+        include_heat_pumps (bool, False): if True, includes the heat pumps from the study
 
-        **include_heat_pumps** - (bool, False): if True, the heat pumps from the study are
-        included in the network
+    Returns:
+        pandapowerNet or list: the complete network, or its 14 sections if ``separation_by_sub``
+        is True
 
-    OUTPUT:
-         **net** - pandapower network
-
-         **subnets** (list) - all sections of the pandapower network
-
-    EXAMPLE:
+    Example:
 
         >>> from pandapower.networks import lv_schutterwald
         >>> net = lv_schutterwald()


### PR DESCRIPTION
## Summary

Document [lv_schutterwald](https://github.com/e2nIEE/pandapower/blob/7b972fcf6e99e9a8871dee4a0dade57362d5ab21/pandapower/networks/lv_schutterwald.py#L17), which is available in [pandapower.networks](https://github.com/e2nIEE/pandapower/tree/7b972fcf6e99e9a8871dee4a0dade57362d5ab21/pandapower/networks) but missing in the [published Networks documentation](https://pandapower.readthedocs.io/en/latest/networks.html).

## Changes

- add a dedicated page and include it in the Networks toctree
- describe the network and link its [underlying study](https://doi.org/10.3390/en13164052)
- update the docstring so its options and return value render correctly in Sphinx
- add an upcoming-release changelog entry


## Validation

- The Sphinx HTML documentation build completed successfully with no warnings.