### PR TITLE
Fix FACTS and converter bus references in toolbox registry

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Change Log
 
 [upcoming release] - 2026-..-..
 -------------------------------
+- [FIXED] Include svc, vsc, vsc_stacked, vsc_bipolar and tcsc AC bus references in the shared toolbox registry, so bus reindexing and related operations update them consistently while preserving DC references.
 - [FIXED] OPF cleaned up in case of non convergence
 - [FIXED] ``create_continuous_bus_index`` (and other toolbox functions relying on ``element_bus_tuples``) now also update the ``bus`` column of the ``ssc`` element table; it was previously missing from the list of bus-referencing elements
 - [FIXED] speedup dump_to_geojson_node_branch

--- a/pandapower/test/toolbox/test_data_modification.py
+++ b/pandapower/test/toolbox/test_data_modification.py
@@ -241,3 +241,35 @@ def test_scaling_by_type():
 
 if __name__ == '__main__':
     pytest.main([__file__, "-xs"])
+
+
+@pytest.mark.parametrize("continuous", [False, True])
+def test_reindex_facts_and_converter_bus_references(continuous):
+    from pandapower.create import create_bus_dc, create_svc, create_vsc, create_vsc_stacked, create_vsc_bipolar, create_tcsc
+
+    net = create_empty_network()
+    b1 = create_bus(net, vn_kv=20., index=4)
+    b2 = create_bus(net, vn_kv=20., index=9)
+    d0 = create_bus_dc(net, vn_kv=20., index=4)
+    d1 = create_bus_dc(net, vn_kv=20., index=9)
+    create_svc(net, b1, x_l_ohm=1, x_cvar_ohm=-10, set_vm_pu=1., thyristor_firing_angle_degree=90)
+    create_vsc(net, b1, d0, r_ohm=1, x_ohm=1, r_dc_ohm=1)
+    create_vsc_stacked(net, b1, d0, d1, r_ohm=1, x_ohm=1, r_dc_ohm=1)
+    create_vsc_bipolar(net, b1, d0, d1, r_ohm=1, x_ohm=1, r_dc_ohm=1)
+    create_tcsc(net, b1, b2, x_l_ohm=1, x_cvar_ohm=-10, set_p_to_mw=10, thyristor_firing_angle_degree=90)
+    original = copy.deepcopy(net)
+
+    if continuous:
+        lookup = create_continuous_bus_index(net, start=2)
+    else:
+        lookup = reindex_buses(net, {4: 12, 9: 7})
+
+    for element in ("svc", "vsc", "vsc_stacked", "vsc_bipolar", "tcsc"):
+        for column in ("bus", "from_bus", "to_bus"):
+            if column in net[element]:
+                expected = original[element][column].map(lookup)
+                pd.testing.assert_series_equal(net[element][column], expected, check_dtype=False)
+        for column in ("bus_dc", "bus_dc_plus", "bus_dc_minus"):
+            if column in net[element]:
+                pd.testing.assert_series_equal(net[element][column], original[element][column])
+    pd.testing.assert_frame_equal(net.bus_dc, original.bus_dc)

--- a/pandapower/test/toolbox/test_element_selection.py
+++ b/pandapower/test/toolbox/test_element_selection.py
@@ -259,3 +259,30 @@ def test_get_all_elements():
 
 if __name__ == '__main__':
     pytest.main([__file__, "-xs"])
+
+
+def test_element_bus_tuples_cover_ac_bus_columns():
+    net = create_empty_network()
+    ac_bus_columns = {"bus", "from_bus", "to_bus", "hv_bus", "mv_bus", "lv_bus"}
+    expected = {
+        (element, column)
+        for element, table in net.items()
+        if isinstance(table, pd.DataFrame) and not element.startswith("res_")
+        for column in ac_bus_columns.intersection(table.columns)
+    }
+    assert set(element_bus_tuples()) == expected
+
+
+@pytest.mark.parametrize("in_service", [True, False])
+def test_get_connected_tcsc(in_service):
+    from pandapower.create import create_tcsc
+    from pandapower.toolbox.element_selection import get_connected_elements
+
+    net = create_empty_network()
+    buses = create_buses(net, 3, vn_kv=20.)
+    tcsc = create_tcsc(net, buses[0], buses[1], x_l_ohm=1, x_cvar_ohm=-10,
+                       set_p_to_mw=10, thyristor_firing_angle_degree=90, in_service=in_service)
+    for bus in buses[:2]:
+        assert get_connected_elements(net, "tcsc", bus) == {tcsc}
+        assert get_connected_elements(net, "tcsc", bus, respect_in_service=True) == ({tcsc} if in_service else set())
+    assert not get_connected_elements(net, "tcsc", buses[2])

--- a/pandapower/toolbox/element_selection.py
+++ b/pandapower/toolbox/element_selection.py
@@ -178,10 +178,10 @@ def get_connected_elements(net, element_type, buses, respect_switches=True, resp
         connected_elements = set(net["trafo3w"].index[(net.trafo3w.hv_bus.isin(buses)) |
                                                       (net.trafo3w.mv_bus.isin(buses)) |
                                                       (net.trafo3w.lv_bus.isin(buses))])
-    elif element_type == "impedance":
-        element_table = net.impedance
-        connected_elements = set(net["impedance"].index[(net.impedance.from_bus.isin(buses)) |
-                                                        (net.impedance.to_bus.isin(buses))])
+    elif element_type in ("impedance", "tcsc"):
+        element_table = net[element_type]
+        connected_elements = set(element_table.index[element_table.from_bus.isin(buses) |
+                                                      element_table.to_bus.isin(buses)])
     elif element_type == "measurement":
         element_table = net[element_type]
         connected_elements = set(net.measurement.index[(net.measurement.element.isin(buses)) |
@@ -650,7 +650,9 @@ def branch_element_bus_dict(include_switch=False, sort=None):
 def element_bus_tuples(bus_elements=True, branch_elements=True, res_elements=False):
     """
     Utility function
-    Provides the tuples of elements and corresponding columns for buses they are connected to
+    Provides the tuples of elements and corresponding columns referencing AC buses.
+    Includes FACTS devices and the AC terminals of converters. DC bus columns
+    refer to the separate bus_dc table and must not be remapped as AC buses.
     :param bus_elements: whether tuples for bus elements e.g. load, sgen, ... are included
     :param branch_elements: whether branch elements e.g. line, trafo, ... are included
     :param res_elements: whether result table names e.g. res_sgen, res_line, ... are included
@@ -665,12 +667,14 @@ def element_bus_tuples(bus_elements=True, branch_elements=True, res_elements=Fal
         ebts += [("sgen", "bus"), ("load", "bus"), ("ext_grid", "bus"), ("gen", "bus"),
                  ("ward", "bus"), ("xward", "bus"), ("shunt", "bus"),
                  ("storage", "bus"), ("asymmetric_load", "bus"), ("asymmetric_sgen", "bus"),
-                 ("motor", "bus"), ("ssc", "bus")]
+                 ("motor", "bus"), ("ssc", "bus"), ("svc", "bus"), ("vsc", "bus"),
+                 ("vsc_stacked", "bus"), ("vsc_bipolar", "bus")]
     if branch_elements:
         ebts += [("line", "from_bus"), ("line", "to_bus"), ("impedance", "from_bus"),
                  ("impedance", "to_bus"), ("switch", "bus"), ("trafo", "hv_bus"),
                  ("trafo", "lv_bus"), ("trafo3w", "hv_bus"), ("trafo3w", "mv_bus"),
-                 ("trafo3w", "lv_bus"), ("dcline", "from_bus"), ("dcline", "to_bus")]
+                 ("trafo3w", "lv_bus"), ("dcline", "from_bus"), ("dcline", "to_bus"),
+                 ("tcsc", "from_bus"), ("tcsc", "to_bus")]
     if res_elements:
         elements_without_res = ["switch", "measurement", "asymmetric_load", "asymmetric_sgen"]
         ebts += [("res_" + ebt[0], ebt[1]) for ebt in ebts if ebt[0] not in elements_without_res]


### PR DESCRIPTION
Fixes #3112.

Bus reindexing currently leaves AC bus references unchanged in `svc`, `vsc`, `vsc_stacked`, `vsc_bipolar`, and `tcsc`. Add their AC columns to the shared `element_bus_tuples()` registry while leaving the separate DC bus references untouched.

The registry also drives connectivity and removal operations, so this change teaches `get_connected_elements()` to handle TCSC endpoints. Without that companion change, the toolbox's existing inactive-element tests fail when they encounter the newly registered type.

Regression coverage checks direct and continuous reindexing, preserves overlapping AC/DC index domains, compares the registry against the network's AC-reference columns, and verifies TCSC endpoint/service-state queries. The docstring and changelog document the reference-domain contract.

Validation (Python 3.12):
- Before the fix: all three new reindexing/registry checks failed.
- Toolbox suite: 101 passed.
- Main CI scope, `pytest --ignore=pandapower/test/opf`: 1,575 passed, 97 skipped, 19 xfailed, 11 xpassed; exit 0 (4,171 warnings).
- `mypy`: success across 534 source files.
- `git diff --check`: passed.

The separate Julia/OPF suite and downstream-project suites were not run locally. Dependencies used the `dev` extra, with `juliacall` removed as in the main CI job.

AI assistance was used for implementation and validation.
