### PR TITLE
Fix PPJSONEncoder compatibility with simplejson

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Change Log
 
 [upcoming release] - 2026-..-..
 -------------------------------
+- [FIXED] ``PPJSONEncoder`` accepts the legacy ``encoding`` keyword supplied by ``simplejson``.
 - [FIXED] OPF cleaned up in case of non convergence
 - [FIXED] ``create_continuous_bus_index`` (and other toolbox functions relying on ``element_bus_tuples``) now also update the ``bus`` column of the ``ssc`` element table; it was previously missing from the list of bus-referencing elements
 - [FIXED] speedup dump_to_geojson_node_branch

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -882,6 +882,9 @@ class FromSerializableRegistry():
 
 class PPJSONDecoder(json.JSONDecoder):
     def __init__(self, **kwargs):
+        # simplejson passes its legacy encoding option to custom decoders, but
+        # the stdlib JSONDecoder used here does not accept it.
+        kwargs.pop("encoding", None)
         # net = pandapowerNet.__new__(pandapowerNet)
         #        net = create_empty_network()
         deserialize_pandas = kwargs.pop('deserialize_pandas', True)

--- a/pandapower/io_utils.py
+++ b/pandapower/io_utils.py
@@ -426,6 +426,23 @@ def _is_safe_to_deserialize(module_name, class_name, class_):
 
 class PPJSONEncoder(json.JSONEncoder):
     def __init__(self, isinstance_func=isinstance_partial, **kwargs):
+        # simplejson always supplies its backend-specific options to custom
+        # encoder classes. PPJSONEncoder uses the stdlib implementation, which
+        # does not accept these options.
+        simplejson_options = {
+            "encoding",
+            "use_decimal",
+            "namedtuple_as_object",
+            "tuple_as_array",
+            "iterable_as_array",
+            "bigint_as_string",
+            "item_sort_key",
+            "for_json",
+            "ignore_nan",
+            "int_as_string_bitcount",
+        }
+        for option in simplejson_options:
+            kwargs.pop(option, None)
         super().__init__(**kwargs)
         self.isinstance_func = isinstance_func
 

--- a/pandapower/test/api/test_file_io.py
+++ b/pandapower/test/api/test_file_io.py
@@ -143,8 +143,16 @@ def test_json_basic(net_in, tmp_path):
     assert_net_equal(net_in, net_out)
 
 
-def test_json_encoder_accepts_simplejson_encoding_keyword():
-    assert simplejson.dumps({"value": "✓"}, cls=PPJSONEncoder) == '{"value": "\\u2713"}'
+@pytest.mark.parametrize(
+    ("dumps", "loads"),
+    [(json.dumps, simplejson.loads), (simplejson.dumps, json.loads)],
+)
+def test_json_simplejson_interoperability(net_in, dumps, loads):
+    serialized_net = dumps(net_in, cls=PPJSONEncoder)
+    net_out = loads(serialized_net, cls=PPJSONDecoder)
+    convert_format(net_out)
+
+    assert_net_equal(net_in, net_out)
 
 
 def test_json_controller_none():

--- a/pandapower/test/api/test_file_io.py
+++ b/pandapower/test/api/test_file_io.py
@@ -11,7 +11,7 @@ import geojson
 import numpy as np
 import pandas as pd
 import pytest
-import simplejson
+import simplejson  # type: ignore[import-untyped]
 from pandas.testing import assert_frame_equal, assert_series_equal
 
 from pandapower import pp_dir

--- a/pandapower/test/api/test_file_io.py
+++ b/pandapower/test/api/test_file_io.py
@@ -11,6 +11,7 @@ import geojson
 import numpy as np
 import pandas as pd
 import pytest
+import simplejson
 from pandas.testing import assert_frame_equal, assert_series_equal
 
 from pandapower import pp_dir
@@ -140,6 +141,10 @@ def test_json_basic(net_in, tmp_path):
         convert_format(net_out)
 
     assert_net_equal(net_in, net_out)
+
+
+def test_json_encoder_accepts_simplejson_encoding_keyword():
+    assert simplejson.dumps({"value": "✓"}, cls=PPJSONEncoder) == '{"value": "\\u2713"}'
 
 
 def test_json_controller_none():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ docs = [
 ]
 plotting = ["plotly~=6.8", "matplotlib~=3.11; python_version >= '3.11'", "matplotlib~=3.10; python_version == '3.10'",
             "igraph", "geopandas~=1.1"]
-test = ["pytest~=9.1", "nbmake~=1.5", "pytest-timeout~=2.4", "pytest-split~=0.11"]
+test = ["pytest~=9.1", "nbmake~=1.5", "pytest-timeout~=2.4", "pytest-split~=0.11", "simplejson~=3.20"]
 performance = ["ortools~=9.15", "numba~=0.66", "lightsim2grid~=0.13.0"]
 fileio = ["xlsxwriter~=3.2", "openpyxl~=3.1", "cryptography~=49.0", "geopandas~=1.1", "psycopg~=3.2", "lxml~=6.1"]
 converter = ["matpowercaseframes~=2.1", "lxml~=6.1", "pypowsybl~=1.15"]


### PR DESCRIPTION
Fixes #2945.

`simplejson` passes backend-specific options to custom encoders. Filter those options before initializing the stdlib-based `PPJSONEncoder`, and exercise the real integration in the file-I/O tests.

Tests: `pytest pandapower/test --ignore=pandapower/test/opf -q` (1571 passed)
