### PR TITLE
removed unused element from measurement table.

### DIFF
--- a/pandapower/network_schema/measurement.py
+++ b/pandapower/network_schema/measurement.py
@@ -6,11 +6,7 @@ import pandera.pandas as pa
 
 measurement_schema = pa.DataFrameSchema(
     {
-        "name": pa.Column(
-            pd.StringDtype,
-            nullable=True,
-            description="Name of measurement"
-        ),
+        "name": pa.Column(pd.StringDtype, nullable=True, description="Name of measurement"),
         "measurement_type": pa.Column(
             str, pa.Check.isin(["p", "q", "i", "v"]), description="Defines what physical quantity is measured"
         ),
@@ -23,16 +19,9 @@ measurement_schema = pa.DataFrameSchema(
         ),
         "value": pa.Column(float, description="Measurement value"),
         "std_dev": pa.Column(float, description="Standard deviation (same unit as measurement)"),
-        "bus": pa.Column(
-            int,
-            pa.Check.ge(0),
-            required=False,
-            description="Defines the bus at which the measurement is placed. For line or transformer measurement, it defines the side at which the measurement is placed (from_bus or to_bus). must be in net.bus.index",
-            metadata={"foreign_key": "bus.index"},
-        ),
         "element": pa.Column(
             int,
-            description="If the element_type is “line”, “trafo”, “trafo3w”, “load”, “gen”, “sgen”, “shunt”, “ward”, “xward” or “ext_grid”, element is the index of the relevant element. For “bus” measurements, it is None (default)",
+            description="Element is the index of the element in `net[element_type]`.",
         ),
         "side": pa.Column(
             pd.StringDtype,
@@ -40,7 +29,11 @@ measurement_schema = pa.DataFrameSchema(
             description="Only used for measured lines or transformers. Side defines at which end of the branch the measurement is gathered. For lines this may be “from“, “to“ to denote the side with the from_bus or to_bus. It can also be the index of the from_bus or to_bus. For transformers, it can be “hv“, “mv“ or “lv“ or the corresponding bus index, respectively.",
         ),  # TODO: check nur wenn element_type trafo(3w) oder line
         "origin_id": pa.Column(
-            pd.StringDtype, nullable=True, required=False, description="element rdfId from CIM", metadata={"cim": True, "doc": False}
+            pd.StringDtype,
+            nullable=True,
+            required=False,
+            description="element rdfId from CIM",
+            metadata={"cim": True, "doc": False},
         ),
         "origin_class": pa.Column(
             pd.StringDtype,

--- a/pandapower/test/network_schema/elements/test_pandera_measurment_elements.py
+++ b/pandapower/test/network_schema/elements/test_pandera_measurment_elements.py
@@ -1,4 +1,5 @@
 import itertools
+
 import pandas as pd
 import pandera as pa
 import pytest
@@ -7,18 +8,15 @@ from pandapower import create_measurement
 from pandapower.create import create_bus
 from pandapower.network import pandapowerNet
 from pandapower.network_schema.tools.validation.network_validation import validate_network
-
 from pandapower.test.network_schema.elements.helper import (
-    strings,
-    bools,
-    not_strings_list,
-    not_floats_list,
-    not_boolean_list,
-    positiv_ints_plus_zero,
-    negativ_ints,
-    not_ints_list,
     all_allowed_floats,
     all_allowed_ints,
+    negativ_ints,
+    not_floats_list,
+    not_ints_list,
+    not_strings_list,
+    positiv_ints_plus_zero,
+    strings,
 )
 
 valid_measurement_types = ["p", "q", "i", "v"]
@@ -58,7 +56,6 @@ class TestMeasurementRequiredFields:
                 "element_type": ["bus"],
                 "value": [10.0],
                 "std_dev": [0.1],
-                "bus": [b0],
                 "element": [b0],
                 "side": pd.Series(["hv"], dtype=pd.StringDtype()),
             }
@@ -127,85 +124,6 @@ class TestMeasurementOptionalFields:
         )
         validate_network(net)
 
-    @pytest.mark.parametrize(
-        "valid_bus",
-        positiv_ints_plus_zero,
-    )
-    def test_optional_bus_valid_values(self, valid_bus):
-        """Test: optional 'bus' column accepts valid values and FK passes if index exists"""
-        net = pandapowerNet(name="test_optional_bus_valid_values")
-        create_bus(net, 0.4)  # 0
-        create_bus(net, 0.4)  # 1
-        create_bus(net, 0.4, index=42)
-
-        net.measurement = pd.DataFrame(
-            {
-                "name": pd.Series(["m2"], dtype="string"),
-                "measurement_type": ["i"],
-                "element_type": ["line"],
-                "value": [3.3],
-                "std_dev": [0.05],
-                "bus": [0],
-                "element": [0],
-                "side": pd.Series(["to"], dtype="string"),
-            }
-        )
-        net.measurement["bus"] = valid_bus
-        validate_network(net)
-
-    @pytest.mark.parametrize(
-        "invalid_bus",
-        [*negativ_ints, *not_ints_list],
-    )
-    def test_optional_bus_invalid_values(self, invalid_bus):
-        """Test: optional 'bus' column rejects invalid values"""
-        net = pandapowerNet(name="test_optional_bus_invalid_values")
-        create_bus(net, 0.4)
-
-        net.measurement = pd.DataFrame(
-            {
-                "name": pd.Series(["m3"], dtype="string"),
-                "measurement_type": ["v"],
-                "element_type": ["trafo"],
-                "value": [1.01],
-                "std_dev": [0.01],
-                "bus": [0],
-                "element": [0],
-                "check_existing": [True],
-                "side": ["hv"],
-            }
-        )
-        net.measurement["bus"] = invalid_bus
-        with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
-
-
-class TestMeasurementForeignKey:
-    """Tests for foreign key constraints (bus FK)"""
-
-    def test_invalid_bus_index(self):
-        """Test: bus must reference an existing bus index if present"""
-        net = pandapowerNet(name="test_invalid_bus_index")
-        b0 = create_bus(net, 0.4)
-
-        net.measurement = pd.DataFrame(
-            {
-                "name": pd.Series(["m4"], dtype="string"),
-                "measurement_type": ["p"],
-                "element_type": ["bus"],
-                "value": [2.0],
-                "std_dev": [0.1],
-                "bus": [b0],
-                "element": [b0],
-                "check_existing": [True],
-                "side": ["hv"],
-            }
-        )
-
-        net.measurement["bus"] = 9999
-        with pytest.raises(pa.errors.SchemaError):
-            validate_network(net)
-
 
 class TestMeasurementResults:
     """Tests for measurement results after calculations"""
@@ -213,4 +131,4 @@ class TestMeasurementResults:
     @pytest.mark.skip(reason="Not yet implemented")
     def test_measurement_usage(self):
         """Test: measurement values are consumed correctly by state estimation"""
-        pass
+        raise NotImplementedError("Test not yet implemented")


### PR DESCRIPTION
As described in issue #3124 there was a unused column defined in the schema for measurement. I removed the column and the test for this column because I could not find any code that used the column.

closes #3124 