### PR TITLE
added element_type, side combination validation to measurement

### DIFF
--- a/pandapower/create/measurement_create.py
+++ b/pandapower/create/measurement_create.py
@@ -28,6 +28,7 @@ def create_measurement(
     name: str | None = None,
     **kwargs,
 ) -> Int:
+    # TODO: create should raise Attribute error if side does not match element_type (et=line, side=hv)
     """
     Creates a measurement, which is used by the estimation module. Possible types of measurements \
     are: v, p, q, i, va, ia

--- a/pandapower/network_schema/measurement.py
+++ b/pandapower/network_schema/measurement.py
@@ -4,6 +4,13 @@ import pandera.pandas as pa
 # TODO: to discuss whole concept
 # TODO: whats required and whats not ?
 
+_side_allowed = {"line": ["from", "to"], "trafo": ["hv", "lv"], "trafo3w": ["hv", "mv", "lv"]}
+
+def _check_elment_type_side_combination(row: pd.Series) -> bool:
+    return row.element_type not in _side_allowed or row.side in _side_allowed[row.element_type]
+
+# TODO: add cross reference (foreign_key) check for element column
+
 measurement_schema = pa.DataFrameSchema(
     {
         "name": pa.Column(pd.StringDtype, nullable=True, description="Name of measurement"),
@@ -25,8 +32,9 @@ measurement_schema = pa.DataFrameSchema(
         ),
         "side": pa.Column(
             pd.StringDtype,
+            pa.Check.isin(["from", "to", "hv", "mv", "lv"]),
             nullable=True,
-            description="Only used for measured lines or transformers. Side defines at which end of the branch the measurement is gathered. For lines this may be “from“, “to“ to denote the side with the from_bus or to_bus. It can also be the index of the from_bus or to_bus. For transformers, it can be “hv“, “mv“ or “lv“ or the corresponding bus index, respectively.",
+            description="Used for element_type line, trafo or trafo3w. Defines where the measurement is gathered.",
         ),  # TODO: check nur wenn element_type trafo(3w) oder line
         "origin_id": pa.Column(
             pd.StringDtype,
@@ -71,6 +79,10 @@ measurement_schema = pa.DataFrameSchema(
             metadata={"cim": True, "doc": False},
         ),
     },
+    pa.Check(
+        _check_elment_type_side_combination,
+        element_wise=True
+    ),
     name="measurement",
     strict=False,
 )

--- a/pandapower/network_schema/tools/validation/bus_index_validation.py
+++ b/pandapower/network_schema/tools/validation/bus_index_validation.py
@@ -136,8 +136,10 @@ def _bus_index_validation(element: str, schema: pa.DataFrameSchema, net: pandapo
         >>> _bus_index_validation('load', net)  # Validates bus column
     """
     if element not in ["bus", "bus_dc"]:
+        # TODO: bus columns should not be looked up by name but by metadata (foreign_key)
         bus_columns = [col for col in schema.columns if "bus" in col.lower() and col in net[element]]
         if element == "switch":
+            # TODO: check if this approach works for et column not "b" in switch table.
             bus_columns.append("element")
         dc_items = [item for item in bus_columns if "dc" in item]
         non_dc_items = [item for item in bus_columns if "dc" not in item]

--- a/pandapower/test/network_schema/elements/test_pandera_measurment_elements.py
+++ b/pandapower/test/network_schema/elements/test_pandera_measurment_elements.py
@@ -5,24 +5,36 @@ import pandera as pa
 import pytest
 
 from pandapower import create_measurement
-from pandapower.create import create_bus
+from pandapower.create import create_bus, create_line, create_transformer, create_transformer3w
 from pandapower.network import pandapowerNet
 from pandapower.network_schema.tools.validation.network_validation import validate_network
 from pandapower.test.network_schema.elements.helper import (
     all_allowed_floats,
     all_allowed_ints,
-    negativ_ints,
     not_floats_list,
     not_ints_list,
     not_strings_list,
-    positiv_ints_plus_zero,
     strings,
 )
 
 valid_measurement_types = ["p", "q", "i", "v"]
 valid_element_types = ["bus", "line", "trafo", "trafo3w", "load", "gen", "sgen", "shunt", "ward", "xward", "ext_grid"]
+valid_sides = ["from", "to", "hv", "mv", "lv"]
 invalid_measurement_types = ["power", "voltage", "current", "", " "]
 invalid_element_types = ["branch", "generator", "line3w", "", " "]
+
+measurement_sides_element_type_lookup = {
+    "from": "line",
+    "to": "line",
+    "hv": "trafo3w",
+    "mv": "trafo3w",
+    "lv": "trafo3w",
+}
+measurement_element_type_side_lookup = {
+    "line": "from",
+    "trafo": "hv",
+    "trafo3w": "hv",
+}
 
 
 class TestMeasurementRequiredFields:
@@ -38,7 +50,7 @@ class TestMeasurementRequiredFields:
                 itertools.product(["value"], all_allowed_floats),
                 itertools.product(["std_dev"], all_allowed_floats),
                 itertools.product(["element"], all_allowed_ints),
-                itertools.product(["side"], [pd.NA, *strings]),
+                itertools.product(["side"], valid_sides),
             )
         ),
     )
@@ -49,17 +61,26 @@ class TestMeasurementRequiredFields:
         create_bus(net, 0.4)  # index 1
         create_bus(net, 0.4, index=42)
 
+        # TODO: add line/trafo/trafo3w to net for enabling foreign_key check.
+
+        type = "bus"
+        side = pd.NA
+        if parameter == "side":
+            type = measurement_sides_element_type_lookup[valid_value]
+        if parameter == "element_type" and valid_value in ["line", "trafo", "trafo3w"]:
+            side = measurement_element_type_side_lookup[valid_value]
         net.measurement = pd.DataFrame(
             {
                 "name": pd.Series(["m1"], dtype=pd.StringDtype()),
                 "measurement_type": ["p"],
-                "element_type": ["bus"],
+                "element_type": [type],
                 "value": [10.0],
                 "std_dev": [0.1],
                 "element": [b0],
-                "side": pd.Series(["hv"], dtype=pd.StringDtype()),
+                "side": pd.Series([side], dtype=pd.StringDtype()),
             }
         )
+
         if parameter in {"name", "side"}:
             net.measurement[parameter] = pd.Series([valid_value], dtype=pd.StringDtype())
         else:
@@ -88,17 +109,93 @@ class TestMeasurementRequiredFields:
         create_bus(net, 0.4)  # index 1
 
         create_measurement(
+            net=net, meas_type="p", element_type="bus", value=10.0, std_dev=0.1, element=0, check_existing=True
+        )
+        net.measurement[parameter] = invalid_value
+        with pytest.raises(pa.errors.SchemaError):
+            validate_network(net)
+
+    @pytest.mark.parametrize(
+        "element_type, side",
+        itertools.chain(
+            itertools.product(["line"], ["from", "to"]),
+            itertools.product(["trafo"], ["hv", "lv"]),
+            itertools.product(["trafo3w"], ["hv", "mv", "lv"]),
+        ),
+    )
+    def test_valid_et_side_combinations(self, element_type, side):
+        net = pandapowerNet("test_valid_et_side_combinations")
+        b0 = create_bus(net, 0.4)  # index 0
+        b1 = create_bus(net, 0.4)  # index 1
+        b2 = create_bus(net, 0.8)  # index 2
+        b3 = create_bus(net, 1.2)  # index 3
+
+        l0 = create_line(net, b0, b1, 1, "NAYY 4x50 SE")
+        t0 = create_transformer(net, b2, b1, "160 MVA 380/110 kV")
+        t3w0 = create_transformer3w(net, b3, b2, b1, "63/25/38 MVA 110/20/10 kV")
+
+        match element_type:
+            case "line":
+                element = l0
+            case "trafo":
+                element = t0
+            case "trafo3w":
+                element = t3w0
+            case _:
+                raise AttributeError("element not in net")
+
+        create_measurement(
             net=net,
             meas_type="p",
-            element_type="bus",
+            element_type=element_type,
             value=10.0,
             std_dev=0.1,
-            element=0,
+            element=element,
+            side=side,
             check_existing=True,
-            side="hv",
         )
+        validate_network(net)
 
-        net.measurement[parameter] = invalid_value
+    @pytest.mark.parametrize(
+        "element_type, side",
+        itertools.chain(
+            itertools.product(["line"], ["hv", "mv", "lv"]),
+            itertools.product(["trafo"], ["from", "to", "mv"]),
+            itertools.product(["trafo3w"], ["from", "to"]),
+        ),
+    )
+    def test_invalid_et_side_combiantions(self, element_type, side):
+        net = pandapowerNet("test_valid_et_side_combinations")
+        b0 = create_bus(net, 0.4)  # index 0
+        b1 = create_bus(net, 0.4)  # index 1
+        b2 = create_bus(net, 0.8)  # index 2
+        b3 = create_bus(net, 1.2)  # index 3
+
+        l0 = create_line(net, b0, b1, 1, "NAYY 4x50 SE")
+        t0 = create_transformer(net, b2, b1, "160 MVA 380/110 kV")
+        t3w0 = create_transformer3w(net, b3, b2, b1, "63/25/38 MVA 110/20/10 kV")
+
+        match element_type:
+            case "line":
+                element = l0
+            case "trafo":
+                element = t0
+            case "trafo3w":
+                element = t3w0
+            case _:
+                raise AttributeError("element not in net")
+
+        m0 = create_measurement(
+            net=net,
+            meas_type="p",
+            element_type=element_type,
+            value=10.0,
+            std_dev=0.1,
+            element=element,
+            side=measurement_element_type_side_lookup[element_type],
+            check_existing=True,
+        )
+        net.measurement.at[m0, "side"] = side
         with pytest.raises(pa.errors.SchemaError):
             validate_network(net)
 


### PR DESCRIPTION
Some minor changes to the measurement pandera schema.

added valid values for side field to schema.

as discussed I removed the ability to store index directly in the measurement column, since the create_measurement is missing validation for element_type and side combinations at the moment, I have not yet updated the create_measurement function to set the side correctly when an index is given as side. I will do this change in a separate PR.